### PR TITLE
Add support for disabling the control plane

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,7 +9,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8ssandra-operator
-#  namespace: system
   labels:
     control-plane: k8ssandra-operator
 spec:
@@ -37,6 +36,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: K8SSANDRA_CONTROL_PLANE
+            value: "true"
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -261,6 +261,16 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 	}
 }
 
+func getSystemDistributedRF(k8ssandra *api.K8ssandraCluster) int {
+	size := 1.0
+	for _, dc := range k8ssandra.Spec.Cassandra.Datacenters {
+		size := math.Min(size, float64(dc.Size))
+	}
+	replicationFactor := math.Min(size, float64(3.0))
+
+	return int(replicationFactor)
+}
+
 func deepHashString(obj interface{}) string {
 	hasher := sha256.New()
 	hash.DeepHashObject(hasher, obj)

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -35,9 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/util/hash"
 	"math"
-	"time"
-
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -258,7 +255,7 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 				HostNetwork: true,
 			},
 		},
-	}
+	}, nil
 }
 
 func getSystemDistributedRF(k8ssandra *api.K8ssandraCluster) int {

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -258,17 +258,7 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 				HostNetwork: true,
 			},
 		},
-	}, nil
-}
-
-func getSystemDistributedRF(k8ssandra *api.K8ssandraCluster) int {
-	size := 1.0
-	for _, dc := range k8ssandra.Spec.Cassandra.Datacenters {
-		size = math.Min(size, float64(dc.Size))
 	}
-	replicationFactor := math.Min(size, 3.0)
-
-	return int(replicationFactor)
 }
 
 func deepHashString(obj interface{}) string {

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -264,9 +264,9 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 func getSystemDistributedRF(k8ssandra *api.K8ssandraCluster) int {
 	size := 1.0
 	for _, dc := range k8ssandra.Spec.Cassandra.Datacenters {
-		size := math.Min(size, float64(dc.Size))
+		size = math.Min(size, float64(dc.Size))
 	}
-	replicationFactor := math.Min(size, float64(3.0))
+	replicationFactor := math.Min(size, 3.0)
 
 	return int(replicationFactor)
 }

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -240,14 +240,14 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 			Annotations: map[string]string{},
 		},
 		Spec: cassdcapi.CassandraDatacenterSpec{
-			ClusterName:   cluster,
-			Size:          template.Size,
-			ServerType:    "cassandra",
-			ServerVersion: template.ServerVersion,
-			Resources:     template.Resources,
-			Config:        config,
-			Racks:         template.Racks,
-			StorageConfig: template.StorageConfig,
+			ClusterName:     cluster,
+			Size:            template.Size,
+			ServerType:      "cassandra",
+			ServerVersion:   template.ServerVersion,
+			Resources:       template.Resources,
+			Config:          config,
+			Racks:           template.Racks,
+			StorageConfig:   template.StorageConfig,
 			AdditionalSeeds: additionalSeeds,
 			Networking: &cassdcapi.NetworkingConfig{
 				HostNetwork: true,
@@ -259,9 +259,9 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 func getSystemDistributedRF(k8ssandra *api.K8ssandraCluster) int {
 	size := 1.0
 	for _, dc := range k8ssandra.Spec.Cassandra.Datacenters {
-		size := math.Min(size, float64(dc.Size))
+		size = math.Min(size, float64(dc.Size))
 	}
-	replicationFactor := math.Min(size, float64(3.0))
+	replicationFactor := math.Min(size, 3.0)
 
 	return int(replicationFactor)
 }

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -233,7 +233,7 @@ func newDatacenter(k8ssandraNamespace, cluster string, dcNames []string, templat
 		namespace = k8ssandraNamespace
 	}
 
-	config, err := cassandra.GetMergedConfig(template.Config, dcNames, systemDistributedRF)
+	config, err := cassandra.GetMergedConfig(template.Config, dcNames, systemDistributedRF, template.ServerVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/k8ssandra/k8ssandra-operator
 go 1.16
 
 require (
+	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/bombsimon/logrusr v1.1.0
 	github.com/go-logr/logr v0.3.0
 	github.com/google/go-cmp v0.5.4 // indirect

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 		}
 	}
 
-        if err = (&controllers.StargateReconciler{
+    if err = (&controllers.StargateReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -93,23 +93,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	clientCache := clientcache.New(mgr.GetClient(), scheme)
+	if isControlPlane() {
+		clientCache := clientcache.New(mgr.GetClient(), scheme)
 
-	if err = (&controllers.K8ssandraClusterReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ClientCache: clientCache,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "K8ssandraCluster")
-		os.Exit(1)
+		if err = (&controllers.K8ssandraClusterReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClientCache: clientCache,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "K8ssandraCluster")
+			os.Exit(1)
+		}
 	}
-	if err = (&controllers.StargateReconciler{
+
+        if err = (&controllers.StargateReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Stargate")
 		os.Exit(1)
 	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -140,4 +144,14 @@ func getWatchNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+func isControlPlane() bool {
+	controlPlaneEnvVar := "K8SSANDRA_CONTROL_PLANE"
+	val, found := os.LookupEnv(controlPlaneEnvVar)
+	if !found {
+		return false
+	}
+
+	return val == "true"
 }

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -3,6 +3,7 @@ package cassandra
 import (
 	"encoding/json"
 	"github.com/Jeffail/gabs"
+	"strconv"
 	"strings"
 )
 
@@ -11,9 +12,9 @@ type NodeConfig map[string]interface{}
 func getOperatorSuppliedConfig(dcs []string, replicationFactor int) NodeConfig {
 	return NodeConfig{
 		"jvm-options": NodeConfig{
-			"additional-jvm-options": NodeConfig{
-				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
-				"-Dcassandra.system_distributed_replication_per_dc": replicationFactor,
+			"additional-jvm-opts": []string{
+				"-Dcassandra.system_distributed_replication_dc_names=" + strings.Join(dcs, ","),
+				"-Dcassandra.system_distributed_replication_per_dc=" + strconv.Itoa(replicationFactor),
 			},
 		},
 	}

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -24,8 +24,8 @@ func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVer
 	}
 }
 
-func GetMergedConfig(config []byte, dcs []string, replicationFactor int) ([]byte, error) {
-	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor)
+func GetMergedConfig(config []byte, dcs []string, replicationFactor int, cassandraVersion string) ([]byte, error) {
+	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor, cassandraVersion)
 	operatorBytes, err := json.Marshal(operatorValues)
 	if err != nil {
 		return nil, err

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -1,0 +1,43 @@
+package cassandra
+
+import (
+	"encoding/json"
+	"github.com/Jeffail/gabs"
+	"strings"
+)
+
+type NodeConfig map[string]interface{}
+
+func getOperatorSuppliedConfig(dcs []string) NodeConfig {
+	return NodeConfig{
+		"jvm-options": NodeConfig{
+			"additional-jvm-options": NodeConfig{
+				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
+			},
+		},
+	}
+}
+
+func GetMergedConfig(config []byte, dcs []string) ([]byte, error) {
+	operatorValues := getOperatorSuppliedConfig(dcs)
+	operatorBytes, err := json.Marshal(operatorValues)
+	if err != nil {
+		return nil, err
+	}
+
+	operatorParsedConfig, err := gabs.ParseJSON(operatorBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedConfig, err := gabs.ParseJSON(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = operatorParsedConfig.Merge(parsedConfig); err != nil {
+		return nil, err
+	}
+
+	return operatorParsedConfig.Bytes(), nil
+}

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -8,18 +8,19 @@ import (
 
 type NodeConfig map[string]interface{}
 
-func getOperatorSuppliedConfig(dcs []string) NodeConfig {
+func getOperatorSuppliedConfig(dcs []string, replicationFactor int) NodeConfig {
 	return NodeConfig{
 		"jvm-options": NodeConfig{
 			"additional-jvm-options": NodeConfig{
 				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
+				"-Dcassandra.system_distributed_replication_per_dc": replicationFactor,
 			},
 		},
 	}
 }
 
-func GetMergedConfig(config []byte, dcs []string) ([]byte, error) {
-	operatorValues := getOperatorSuppliedConfig(dcs)
+func GetMergedConfig(config []byte, dcs []string, replicationFactor int) ([]byte, error) {
+	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor)
 	operatorBytes, err := json.Marshal(operatorValues)
 	if err != nil {
 		return nil, err

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -9,9 +9,13 @@ import (
 
 type NodeConfig map[string]interface{}
 
-func getOperatorSuppliedConfig(dcs []string, replicationFactor int) NodeConfig {
+func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVersion string) NodeConfig {
+	jvmOpts := "jvm-server-options"
+	if strings.HasPrefix(cassandraVersion, "3.") {
+		jvmOpts = "jvm-options"
+	}
 	return NodeConfig{
-		"jvm-options": NodeConfig{
+		jvmOpts: NodeConfig{
 			"additional-jvm-opts": []string{
 				"-Dcassandra.system_distributed_replication_dc_names=" + strings.Join(dcs, ","),
 				"-Dcassandra.system_distributed_replication_per_dc=" + strconv.Itoa(replicationFactor),

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -12,7 +12,6 @@ import (
 
 type NodeConfig map[string]interface{}
 
-<<<<<<< HEAD
 func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVersion string) NodeConfig {
 	jvmOpts := "jvm-server-options"
 	if strings.HasPrefix(cassandraVersion, "3.") {
@@ -23,25 +22,19 @@ func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVer
 			"additional-jvm-opts": []string{
 				"-Dcassandra.system_distributed_replication_dc_names=" + strings.Join(dcs, ","),
 				"-Dcassandra.system_distributed_replication_per_dc=" + strconv.Itoa(replicationFactor),
-=======
 func getOperatorSuppliedConfig(dcs []string) NodeConfig {
 	return NodeConfig{
 		"jvm-options": NodeConfig{
 			"additional-jvm-options": NodeConfig{
 				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
->>>>>>> 1c51550 (first pass at configuring replication)
+				"-Dcassandra.system_distributed_replication_per_dc": replicationFactor,
 			},
 		},
 	}
 }
 
-<<<<<<< HEAD
-func GetMergedConfig(config []byte, dcs []string, replicationFactor int, cassandraVersion string) ([]byte, error) {
-	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor, cassandraVersion)
-=======
 func GetMergedConfig(config []byte, dcs []string) ([]byte, error) {
 	operatorValues := getOperatorSuppliedConfig(dcs)
->>>>>>> 1c51550 (first pass at configuring replication)
 	operatorBytes, err := json.Marshal(operatorValues)
 	if err != nil {
 		return nil, err

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -3,12 +3,16 @@ package cassandra
 import (
 	"encoding/json"
 	"github.com/Jeffail/gabs"
+<<<<<<< HEAD
 	"strconv"
+=======
+>>>>>>> 1c51550 (first pass at configuring replication)
 	"strings"
 )
 
 type NodeConfig map[string]interface{}
 
+<<<<<<< HEAD
 func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVersion string) NodeConfig {
 	jvmOpts := "jvm-server-options"
 	if strings.HasPrefix(cassandraVersion, "3.") {
@@ -19,13 +23,25 @@ func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVer
 			"additional-jvm-opts": []string{
 				"-Dcassandra.system_distributed_replication_dc_names=" + strings.Join(dcs, ","),
 				"-Dcassandra.system_distributed_replication_per_dc=" + strconv.Itoa(replicationFactor),
+=======
+func getOperatorSuppliedConfig(dcs []string) NodeConfig {
+	return NodeConfig{
+		"jvm-options": NodeConfig{
+			"additional-jvm-options": NodeConfig{
+				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
+>>>>>>> 1c51550 (first pass at configuring replication)
 			},
 		},
 	}
 }
 
+<<<<<<< HEAD
 func GetMergedConfig(config []byte, dcs []string, replicationFactor int, cassandraVersion string) ([]byte, error) {
 	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor, cassandraVersion)
+=======
+func GetMergedConfig(config []byte, dcs []string) ([]byte, error) {
+	operatorValues := getOperatorSuppliedConfig(dcs)
+>>>>>>> 1c51550 (first pass at configuring replication)
 	operatorBytes, err := json.Marshal(operatorValues)
 	if err != nil {
 		return nil, err

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -3,10 +3,7 @@ package cassandra
 import (
 	"encoding/json"
 	"github.com/Jeffail/gabs"
-<<<<<<< HEAD
 	"strconv"
-=======
->>>>>>> 1c51550 (first pass at configuring replication)
 	"strings"
 )
 
@@ -22,19 +19,13 @@ func getOperatorSuppliedConfig(dcs []string, replicationFactor int, cassandraVer
 			"additional-jvm-opts": []string{
 				"-Dcassandra.system_distributed_replication_dc_names=" + strings.Join(dcs, ","),
 				"-Dcassandra.system_distributed_replication_per_dc=" + strconv.Itoa(replicationFactor),
-func getOperatorSuppliedConfig(dcs []string) NodeConfig {
-	return NodeConfig{
-		"jvm-options": NodeConfig{
-			"additional-jvm-options": NodeConfig{
-				"-Dcassandra.system_distributed_replication_dc_names": strings.Join(dcs, ","),
-				"-Dcassandra.system_distributed_replication_per_dc": replicationFactor,
 			},
 		},
 	}
 }
 
-func GetMergedConfig(config []byte, dcs []string) ([]byte, error) {
-	operatorValues := getOperatorSuppliedConfig(dcs)
+func GetMergedConfig(config []byte, dcs []string, replicationFactor int, cassandraVersion string) ([]byte, error) {
+	operatorValues := getOperatorSuppliedConfig(dcs, replicationFactor, cassandraVersion)
 	operatorBytes, err := json.Marshal(operatorValues)
 	if err != nil {
 		return nil, err

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"text/template"
 	"time"
@@ -409,4 +410,18 @@ func (f *E2eFramework) UndeployK8ssandraOperator(namespace string) error {
 	options := kubectl.Options{Namespace: namespace}
 
 	return kubectl.Delete(options, buf)
+}
+
+// GetNodeToolStatusUN Executes nodetool status against the Cassandra pod and returns a
+// count of the matching lines reporting a status of Up/Normal.
+func (f *E2eFramework) GetNodeToolStatusUN(opts kubectl.Options, pod string) (int, error) {
+	output, err := kubectl.Exec(opts, pod, "nodetool", "status")
+	if err != nil {
+		return -1, err
+	}
+
+	re := regexp.MustCompile("UN\\s\\s")
+	matches := re.FindAllString(output, -1)
+
+	return len(matches), nil
 }

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -472,8 +472,6 @@ func (f *E2eFramework) GetNodeToolStatusUN(opts kubectl.Options, pod string) (in
 		return -1, err
 	}
 
-
-
 	matches := f.nodeToolStatusUN.FindAllString(output, -1)
 
 	return len(matches), nil

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -103,6 +103,34 @@ func WaitForCondition(condition string, args ...string) error {
 	return err
 }
 
+func Exec(opts Options, pod string, args ...string) (string, error) {
+	cmd := exec.Command("kubectl")
+
+	if len(opts.Context) > 0 {
+		cmd.Args = append(cmd.Args,"--context", opts.Context)
+	}
+
+	if len(opts.Namespace) > 0 {
+		cmd.Args = append(cmd.Args, "-n", opts.Namespace)
+	}
+
+	cmd.Args = append(cmd.Args, "exec", "-i", pod, "-c", "cassandra", "--")
+	cmd.Args = append(cmd.Args, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	fmt.Println(cmd)
+
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+
+	return stdout.String(), nil
+}
+
 type ClusterInfoOptions struct {
 	Options
 

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -103,11 +103,13 @@ func WaitForCondition(condition string, args ...string) error {
 	return err
 }
 
+// Exec executes a command against a Cassandra pod and the cassandra container in
+// particular. This does not currently handle pipes.
 func Exec(opts Options, pod string, args ...string) (string, error) {
 	cmd := exec.Command("kubectl")
 
 	if len(opts.Context) > 0 {
-		cmd.Args = append(cmd.Args,"--context", opts.Context)
+		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
 
 	if len(opts.Namespace) > 0 {

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -24,8 +24,6 @@ spec:
           jvm-options:
             initial_heap_size: "512m"
             max_heap_size: "512m"
-#            additional-jvm-opts:
-#              - "-Dcassandra.system_distributed_replication_dc_names=dc1,dc2"
       - metadata:
           name: dc2
         k8sContext: kind-k8ssandra-1

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -10,7 +10,7 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 1
+        size: 3
         serverVersion: "3.11.10"
         storageConfig:
           cassandraDataVolumeClaimSpec:
@@ -29,7 +29,7 @@ spec:
       - metadata:
           name: dc2
         k8sContext: kind-k8ssandra-1
-        size: 1
+        size: 3
         serverVersion: "3.11.10"
         storageConfig:
           cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -24,6 +24,8 @@ spec:
           jvm-options:
             initial_heap_size: "512m"
             max_heap_size: "512m"
+#            additional-jvm-opts:
+#              - "-Dcassandra.system_distributed_replication_dc_names=dc1,dc2"
       - metadata:
           name: dc2
         k8sContext: kind-k8ssandra-1

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -22,8 +22,8 @@ spec:
                 storage: 5Gi
         config:
           jvm-options:
-            initial_heap_size: "512m"
-            max_heap_size: "512m"
+            initial_heap_size: "384m"
+            max_heap_size: "384m"
       - metadata:
           name: dc2
         k8sContext: kind-k8ssandra-1
@@ -39,5 +39,5 @@ spec:
                 storage: 5Gi
         config:
           jvm-options:
-            initial_heap_size: "512m"
-            max_heap_size: "512m"
+            initial_heap_size: "384m"
+            max_heap_size: "384m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
1. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds the `K8SSANDRA_CONTROL_PLANE` environment variable to the operator deployment with a value of `true` In `main.go` we only create and start the K8ssandraCluster controller when the env var is set. 

I have updated test code to generate some new kustomization templates. The following now get created during test execution:

* build/test-config/k8ssandra-operator/control-plane
* build/test-config/k8ssandra-operator/data-plane

k8ssandra-operator is now deployed in each cluster during tests, but the K8ssandraCluster controller will only run in the control plane cluster.

**Which issue(s) this PR fixes**:
Fixes #49 

**Checklist**


* [x] Changes manually tested
* [x] Automated Tests added/updated
* [ ] Documentation added/updated
* [ ] CHANGELOG.md updated (not required for documentation PRs)
* [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)



┆Issue is synchronized with this [Jiraserver Task](https://k8ssandra.atlassian.net/browse/K8SSAND-754) by [Unito](https://www.unito.io)
┆Issue Number: K8SSAND-754
┆Priority: Medium
