### PR TITLE
Create multiple envTests for the multicluster testing purposes

### DIFF
--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -119,7 +119,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 				endpoints, err := r.resolveSeedEndpoints(ctx, actual, remoteClient)
 				if err != nil {
-					logger.Error(err,"Failed to resolve seed endpoints", "CassandraDatacenter", dcKey)
+					logger.Error(err, "Failed to resolve seed endpoints", "CassandraDatacenter", dcKey)
 					return ctrl.Result{}, err
 				}
 
@@ -155,19 +155,19 @@ func newDatacenter(k8ssandraNamespace, cluster string, template api.CassandraDat
 
 	return cassdcapi.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
+			Namespace:   namespace,
 			Name:        template.Meta.Name,
 			Annotations: map[string]string{},
 		},
 		Spec: cassdcapi.CassandraDatacenterSpec{
-			ClusterName:   cluster,
-			Size:          template.Size,
-			ServerType:    "cassandra",
-			ServerVersion: template.ServerVersion,
-			Resources:     template.Resources,
-			Config:        template.Config,
-			Racks:         template.Racks,
-			StorageConfig: template.StorageConfig,
+			ClusterName:     cluster,
+			Size:            template.Size,
+			ServerType:      "cassandra",
+			ServerVersion:   template.ServerVersion,
+			Resources:       template.Resources,
+			Config:          template.Config,
+			Racks:           template.Racks,
+			StorageConfig:   template.StorageConfig,
 			AdditionalSeeds: additionalSeeds,
 			Networking: &cassdcapi.NetworkingConfig{
 				HostNetwork: true,
@@ -276,4 +276,3 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&api.K8ssandraCluster{}).
 		Complete(r)
 }
-

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -93,7 +93,7 @@ func beforeTest(t *testing.T, namespace, fixtureDir string, f *framework.E2eFram
 
 	if err := f.DeployCassOperator(namespace); err != nil {
 		t.Log("failed to deploy cass-operator")
-		return  err
+		return err
 	}
 
 	if err := f.DeployK8sContextsSecret(namespace); err != nil {

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -178,7 +178,6 @@ func generateKustomizationFile(name string, k Kustomization, tmpl string) error 
 	return parsed.Execute(file, k)
 }
 
-
 func (f *E2eFramework) kustomizeAndApply(dir, namespace string, contexts ...string) error {
 	kdir, err := filepath.Abs(dir)
 	if err != nil {
@@ -295,7 +294,7 @@ func (f *E2eFramework) WaitForCrdsToBecomeActive() error {
 // ready in the control plane cluster.
 func (f *E2eFramework) WaitForK8ssandraOperatorToBeReady(namespace string, timeout, interval time.Duration) error {
 	key := ClusterKey{
-		K8sContext: f.ControlPlaneContext,
+		K8sContext:     f.ControlPlaneContext,
 		NamespacedName: types.NamespacedName{Namespace: namespace, Name: "k8ssandra-operator"},
 	}
 	return f.WaitForDeploymentToBeReady(key, timeout, interval)

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -17,7 +17,7 @@ func Apply(opts Options, arg interface{}) error {
 	cmd := exec.Command("kubectl")
 
 	if len(opts.Context) > 0 {
-		cmd.Args = append(cmd.Args,"--context", opts.Context)
+		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
 
 	if len(opts.Namespace) > 0 {
@@ -53,7 +53,7 @@ func Delete(opts Options, arg interface{}) error {
 	cmd := exec.Command("kubectl")
 
 	if len(opts.Context) > 0 {
-		cmd.Args = append(cmd.Args,"--context", opts.Context)
+		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
 
 	if len(opts.Namespace) > 0 {
@@ -113,7 +113,7 @@ func DumpClusterInfo(opts ClusterInfoOptions) error {
 	cmd := exec.Command("kubectl", "cluster-info", "dump")
 
 	if len(opts.Context) > 0 {
-		cmd.Args = append(cmd.Args,"--context", opts.Context)
+		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
 
 	if len(opts.Namespace) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Creates ``clustersToCreate`` amount of envTest environments, but starts only one Reconciler (for the envTest[0]).

**Which issue(s) this PR fixes**:
Fixes #35

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
