### PR TITLE
Script to generate kubeconfig secret and ClientConfig

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	REQUEUE_DEFAULT_DELAY_ENV_VAR = "REQUEUE_DEFAULT_DELAY"
-	REQUEUE_LONG_DELAY_ENV_VAR    = "REQUEUE_LONG_DELAY"
+	RequeueDefaultDelayEnvVar = "REQUEUE_DEFAULT_DELAY"
+	RequeueLongDelayEnvVar    = "REQUEUE_LONG_DELAY"
 )
 
 var (
@@ -16,27 +16,27 @@ var (
 	longDelay    time.Duration
 )
 
-// InitConfig is primarily a hook for integration tests. It provides a way use shorter
+// InitConfig is primarily a hook for integration tests. It provides a way to use shorter
 // requeue delays which allows the tests to run much faster. Note that this code will
 // likely be changed when we tackle
 // https://github.com/k8ssandra/k8ssandra-operator/issues/63.
 func InitConfig() {
 	var err error
-	val, found := os.LookupEnv(REQUEUE_DEFAULT_DELAY_ENV_VAR)
+	val, found := os.LookupEnv(RequeueDefaultDelayEnvVar)
 	if found {
 		defaultDelay, err = time.ParseDuration(val)
 		if err != nil {
-			log.Fatalf("failed to parse value for %s %s: %s", REQUEUE_DEFAULT_DELAY_ENV_VAR, val, err)
+			log.Fatalf("failed to parse value for %s %s: %s", RequeueDefaultDelayEnvVar, val, err)
 		}
 	} else {
 		defaultDelay = 15 * time.Second
 	}
 
-	val, found = os.LookupEnv(REQUEUE_LONG_DELAY_ENV_VAR)
+	val, found = os.LookupEnv(RequeueLongDelayEnvVar)
 	if found {
 		longDelay, err = time.ParseDuration(val)
 		if err != nil {
-			log.Fatalf("failed to parse value for %s %s: %s", REQUEUE_LONG_DELAY_ENV_VAR, val, err)
+			log.Fatalf("failed to parse value for %s %s: %s", RequeueLongDelayEnvVar, val, err)
 		}
 	} else {
 		longDelay = 1 * time.Minute

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,0 +1,44 @@
+package controllers
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+const (
+	REQUEUE_DEFAULT_DELAY_ENV_VAR = "REQUEUE_DEFAULT_DELAY"
+	REQUEUE_LONG_DELAY_ENV_VAR    = "REQUEUE_LONG_DELAY"
+)
+
+var (
+	defaultDelay time.Duration
+	longDelay    time.Duration
+)
+
+// InitConfig is primarily a hook for integration tests. It provides a way use shorter
+// requeue delays which allows the tests to run much faster. Note that this code will
+// likely be changed when we tackle
+// https://github.com/k8ssandra/k8ssandra-operator/issues/63.
+func InitConfig() {
+	var err error
+	val, found := os.LookupEnv(REQUEUE_DEFAULT_DELAY_ENV_VAR)
+	if found {
+		defaultDelay, err = time.ParseDuration(val)
+		if err != nil {
+			log.Fatalf("failed to parse value for %s %s: %s", REQUEUE_DEFAULT_DELAY_ENV_VAR, val, err)
+		}
+	} else {
+		defaultDelay = 15 * time.Second
+	}
+
+	val, found = os.LookupEnv(REQUEUE_LONG_DELAY_ENV_VAR)
+	if found {
+		longDelay, err = time.ParseDuration(val)
+		if err != nil {
+			log.Fatalf("failed to parse value for %s %s: %s", REQUEUE_LONG_DELAY_ENV_VAR, val, err)
+		}
+	} else {
+		longDelay = 1 * time.Minute
+	}
+}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+	"os"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 	"time"
 
@@ -13,8 +15,6 @@ import (
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -28,99 +28,40 @@ import (
 
 const (
 	clustersToCreate = 2
-	timeout          = time.Second * 30
-	interval         = time.Second * 1
+	timeout          = time.Second * 5
+	interval         = time.Millisecond * 500
 	clusterProtoName = "cluster-%d"
 )
 
 var (
-	testClients   = make(map[string]client.Client, clustersToCreate)
-	testEnvs      = make([]*envtest.Environment, clustersToCreate)
 	seedsResolver = &fakeSeedsResolver{}
 )
 
 func TestControllers(t *testing.T) {
-	defer afterSuite(t)
-	beforeSuite(t)
-
-	ctx := context.Background()
-
-	t.Run("CreateSingleDcCluster", controllerTest(ctx, createSingleDcCluster))
-	t.Run("CreateMultiDcCluster", controllerTest(ctx, createMultiDcCluster))
-	t.Run("TestStargate", testStargate)
-}
-
-func beforeSuite(t *testing.T) {
-	require := require.New(t)
+	ctx := ctrl.SetupSignalHandler()
 
 	log := logrusr.NewLogger(logrus.New())
 	logf.SetLogger(log)
 
-	// Prevent the metrics listener being created (it binds to 8080 for all testEnvs)
-	metrics.DefaultBindAddress = "0"
-
-	require.NoError(registerApis(), "failed to register apis with scheme")
-
-	cfgs := make([]*rest.Config, clustersToCreate)
-
-	for i := 0; i < clustersToCreate; i++ {
-		clusterName := fmt.Sprintf(clusterProtoName, i)
-		testEnv := &envtest.Environment{
-			CRDDirectoryPaths: []string{
-				filepath.Join("..", "config", "crd", "bases"),
-				filepath.Join("..", "config", "cass-operator", "crd", "bases")},
-			ErrorIfCRDPathMissing:    true,
-		}
-
-		testEnvs[i] = testEnv
-
-		cfg, err := testEnv.Start()
-		require.NoError(err, "failed to start test environment")
-		testClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		require.NoError(err, "failed to create controller-runtime client")
-
-		testClients[clusterName] = testClient
-		cfgs[i] = cfg
+	if err := os.Setenv(REQUEUE_DEFAULT_DELAY_ENV_VAR, "500ms"); err != nil {
+		t.Fatalf("failed to set value for %s env var: %s", REQUEUE_DEFAULT_DELAY_ENV_VAR, err)
 	}
+	if err := os.Setenv(REQUEUE_LONG_DELAY_ENV_VAR, "1s"); err != nil {
+		t.Fatalf("failed to set value for %s env var: %s", REQUEUE_LONG_DELAY_ENV_VAR, err)
+	}
+	InitConfig()
 
-	k8sManager, err := ctrl.NewManager(cfgs[0], ctrl.Options{
-		Scheme: scheme.Scheme,
+	t.Run("K8ssandraCluster", func(t *testing.T) {
+		kcCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		testK8ssandraCluster(kcCtx, t)
 	})
-	require.NoError(err, "failed to create controller-runtime manager")
 
-	clientCache := clientcache.New(k8sManager.GetClient(), testClients["cluster-0"], scheme.Scheme)
-	for ctxName, cli := range testClients {
-		clientCache.AddClient(ctxName, cli)
-	}
-
-	additionalClusters := make([]cluster.Cluster, 0, clustersToCreate-1)
-
-	// We start only one reconciler, for the clusters number 0
-	err = (&K8ssandraClusterReconciler{
-		Client:        k8sManager.GetClient(),
-		Scheme:        scheme.Scheme,
-		ClientCache:   clientCache,
-		SeedsResolver: seedsResolver,
-	}).SetupWithManager(k8sManager, additionalClusters)
-	require.NoError(err, "Failed to set up K8ssandraClusterReconciler with multicluster test")
-
-	err = (&StargateReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: scheme.Scheme,
-	}).SetupWithManager(k8sManager)
-	require.NoError(err, "Failed to set up StargateReconciler")
-
-	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
-		assert.NoError(t, err, "failed to start manager")
-	}()
-}
-
-func afterSuite(t *testing.T) {
-	for _, testEnv := range testEnvs {
-		err := testEnv.Stop()
-		assert.NoError(t, err, "failed to stop test environment")
-	}
+	t.Run("Stargate", func(t *testing.T) {
+		stargateCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		testStargate(stargateCtx, t)
+	})
 }
 
 func registerApis() error {
@@ -135,14 +76,175 @@ func registerApis() error {
 	return nil
 }
 
+type TestEnv struct {
+	*envtest.Environment
+
+	TestClient client.Client
+}
+
+func (e *TestEnv) Start(ctx context.Context, t *testing.T, initReconcilers func(mgr manager.Manager) error) error {
+	// Prevent the metrics listener being created (it binds to 8080 for all testEnvs)
+	metrics.DefaultBindAddress = "0"
+
+	if err := registerApis(); err != nil {
+		return err
+	}
+
+	e.Environment = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join("..", "config", "cass-operator", "crd", "bases")},
+	}
+
+	cfg, err := e.Environment.Start()
+	if err != nil {
+		return err
+	}
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = initReconcilers(k8sManager)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		err = k8sManager.Start(ctx)
+		if err != nil {
+			t.Errorf("failed to start manager: %s", err)
+		}
+	}()
+
+	e.TestClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	return err
+}
+
+func (e *TestEnv) Stop(t *testing.T) {
+	if e.Environment != nil {
+		err := e.Environment.Stop()
+		if err != nil {
+			t.Errorf("failed to stop test environment: %s", err)
+		}
+	}
+}
+
+type MultiClusterTestEnv struct {
+	// Clients is a mapping of cluster (or k8s context) names to Client objects. This map
+	// is used to create the ClientCache as well as to initialize the Framework object
+	// for each test.
+	Clients map[string]client.Client
+
+	// testEnvs is a list of the test environments that are created
+	testEnvs []*envtest.Environment
+}
+
+func NewMultiClusterTestEnv() *MultiClusterTestEnv {
+	return &MultiClusterTestEnv{
+		Clients:  make(map[string]client.Client, 0),
+		testEnvs: make([]*envtest.Environment, 0),
+	}
+}
+
+func (e *MultiClusterTestEnv) Start(ctx context.Context, t *testing.T, initReconcilers func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error) error {
+	// Prevent the metrics listener being created (it binds to 8080 for all testEnvs)
+	metrics.DefaultBindAddress = "0"
+
+	if err := registerApis(); err != nil {
+		return err
+	}
+
+	e.Clients = make(map[string]client.Client, 0)
+	e.testEnvs = make([]*envtest.Environment, 0)
+	cfgs := make([]*rest.Config, clustersToCreate)
+	clusters := make([]cluster.Cluster, 0, clustersToCreate)
+
+	for i := 0; i < clustersToCreate; i++ {
+		clusterName := fmt.Sprintf(clusterProtoName, i)
+		testEnv := &envtest.Environment{
+			CRDDirectoryPaths: []string{
+				filepath.Join("..", "config", "crd", "bases"),
+				filepath.Join("..", "config", "cass-operator", "crd", "bases")},
+			ErrorIfCRDPathMissing:    true,
+		}
+
+		e.testEnvs = append(e.testEnvs, testEnv)
+
+		cfg, err := testEnv.Start()
+		if err != nil {
+			return err
+		}
+
+		testClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		if err != nil {
+			return err
+		}
+
+		e.Clients[clusterName] = testClient
+		cfgs[i] = cfg
+
+		c, err := cluster.New(cfg, func(o *cluster.Options) {
+			o.Scheme = scheme.Scheme
+		})
+		if err != nil {
+			return err
+		}
+		clusters = append(clusters, c)
+	}
+
+	k8sManager, err := ctrl.NewManager(cfgs[0], ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, c := range clusters {
+		if err = k8sManager.Add(c); err != nil {
+			return err
+		}
+	}
+
+	clientCache := clientcache.New(k8sManager.GetClient(), e.Clients["cluster-0"], scheme.Scheme)
+	for ctxName, cli := range e.Clients {
+		clientCache.AddClient(ctxName, cli)
+	}
+
+	if err = initReconcilers(k8sManager, clientCache, clusters); err != nil {
+		return err
+	}
+
+	go func() {
+		err = k8sManager.Start(ctx)
+		if err != nil {
+			t.Errorf("failed to start manager: %s", err)
+		}
+	}()
+
+	return nil
+}
+
+func (e *MultiClusterTestEnv) Stop(t *testing.T) {
+	for _, testEnv := range e.testEnvs {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("failed to stop test environment: %s", err)
+		}
+	}
+}
+
 type ControllerTest func(*testing.T, context.Context, *framework.Framework, string)
 
-func controllerTest(ctx context.Context, test ControllerTest) func(*testing.T) {
+func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test ControllerTest) func(*testing.T) {
 	namespace := rand.String(9)
 	return func(t *testing.T) {
 		primaryCluster := fmt.Sprintf(clusterProtoName, 0)
-		controlPlaneCluster := testClients[primaryCluster]
-		f := framework.NewFramework(controlPlaneCluster, primaryCluster, testClients)
+		controlPlaneCluster := e.Clients[primaryCluster]
+		f := framework.NewFramework(controlPlaneCluster, primaryCluster, e.Clients)
 
 		if err := f.CreateNamespace(namespace); err != nil {
 			t.Fatalf("failed to create namespace %s: %v", namespace, err)

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -186,23 +186,23 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 				Name:      kc.Name + "-" + actualDc.Name + "-stargate",
 			}
 
-				desiredStargate := &api.Stargate{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   stargateKey.Namespace,
-						Name:        stargateKey.Name,
-						Annotations: map[string]string{},
-						Labels: map[string]string{
-							api.PartOfLabel:           api.PartOfLabelValue,
-							api.K8ssandraClusterLabel: kcKey.Name,
-						},
+			desiredStargate := &api.Stargate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   stargateKey.Namespace,
+					Name:        stargateKey.Name,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						api.PartOfLabel:           api.PartOfLabelValue,
+						api.K8ssandraClusterLabel: kcKey.Name,
 					},
-					Spec: api.StargateSpec{
-						StargateTemplate: *dcTemplate.Stargate,
-						DatacenterRef:    corev1.LocalObjectReference{Name: actualDc.Name},
-					},
-				}
-				desiredStargateHash := utils.DeepHashString(desiredStargate)
-				desiredStargate.Annotations[api.ResourceHashAnnotation] = desiredStargateHash
+				},
+				Spec: api.StargateSpec{
+					StargateTemplate: *dcTemplate.Stargate,
+					DatacenterRef:    corev1.LocalObjectReference{Name: actualDc.Name},
+				},
+			}
+			desiredStargateHash := utils.DeepHashString(desiredStargate)
+			desiredStargate.Annotations[api.ResourceHashAnnotation] = desiredStargateHash
 
 			actualStargate := &api.Stargate{}
 

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -224,7 +224,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 						}
 					}
 
-					if !stargateutil.IsReady(actualStargate) {
+					if !stargateutil.IsReady(actualStargate.Status) {
 						logger.Info("Waiting for Stargate to become ready", "Stargate", stargateKey)
 						return ctrl.Result{RequeueAfter: defaultDelay}, nil
 					}

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 	stargateutil "github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"math"
@@ -71,104 +72,119 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	kc = kc.DeepCopy()
+	patch := client.MergeFromWithOptions(kc.DeepCopy())
+	result, err := r.reconcile(ctx, kc, logger)
+	if patchErr := r.Status().Patch(ctx, kc, patch); patchErr != nil {
+		logger.Error(patchErr, "failed to update k8ssandracluster status", "K8ssandraCluster", req.NamespacedName)
+	} else {
+		logger.Info("updated k8ssandracluster status", "K8ssandraCluster", req.NamespacedName)
+	}
+	return result, err
+}
 
-	if kc.Spec.Cassandra != nil {
-		var seeds []string
-		systemDistributedRF := getSystemDistributedRF(kc)
-		dcNames := make([]string, 0, len(kc.Spec.Cassandra.Datacenters))
+func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) (ctrl.Result, error) {
+	if kc.Spec.Cassandra == nil {
+		// TODO handle the scenario of Cassandra being set to nil after having a non-nil value
+		return ctrl.Result{}, nil
+	}
 
-		for _, dc := range kc.Spec.Cassandra.Datacenters {
-			dcNames = append(dcNames, dc.Meta.Name)
+	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
+	var seeds []string
+	systemDistributedRF := getSystemDistributedRF(kc)
+	dcNames := make([]string, 0, len(kc.Spec.Cassandra.Datacenters))
+
+	for _, dc := range kc.Spec.Cassandra.Datacenters {
+		dcNames = append(dcNames, dc.Meta.Name)
+	}
+
+	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+		desiredDc, err := newDatacenter(kcKey, kc.Spec.Cassandra.Cluster, dcNames, dcTemplate, seeds, systemDistributedRF)
+		if err != nil {
+			logger.Error(err, "Failed to create new CassandraDatacenter")
+			return ctrl.Result{}, err
+		}
+		dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
+
+		desiredDcHash := utils.DeepHashString(desiredDc)
+		desiredDc.Annotations[api.ResourceHashAnnotation] = desiredDcHash
+
+		remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+		if err != nil {
+			logger.Error(err, "Failed to get remote client for datacenter", "CassandraDatacenter", dcKey)
+			return ctrl.Result{}, err
 		}
 
-		for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
-			desiredDc, err := newDatacenter(req.NamespacedName, kc.Spec.Cassandra.Cluster, dcNames, dcTemplate, seeds, systemDistributedRF)
-			if err != nil {
-				logger.Error(err, "Failed to create new CassandraDatacenter")
-				return ctrl.Result{}, err
-			}
-			dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
+		if remoteClient == nil {
+			logger.Info("remoteClient cannot be nil")
+			return ctrl.Result{}, fmt.Errorf("remoteClient cannot be nil")
+		}
 
-			desiredDcHash := utils.DeepHashString(desiredDc)
-			desiredDc.Annotations[api.ResourceHashAnnotation] = desiredDcHash
+		actualDc := &cassdcapi.CassandraDatacenter{}
 
-			remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
-			if err != nil {
-				logger.Error(err, "Failed to get remote client for datacenter", "CassandraDatacenter", dcKey)
+		if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
+			if err = r.setStatusForDatacenter(kc, actualDc); err != nil {
+				logger.Error(err, "Failed to update status for datacenter", "CassandraDatacenter", dcKey)
 				return ctrl.Result{}, err
 			}
 
-			if remoteClient == nil {
-				logger.Info("remoteClient cannot be nil")
-				return ctrl.Result{}, fmt.Errorf("remoteClient cannot be nil")
+			if actualHash, found := actualDc.Annotations[api.ResourceHashAnnotation]; !(found && actualHash == desiredDcHash) {
+				logger.Info("Updating datacenter", "CassandraDatacenter", dcKey)
+				actualDc = actualDc.DeepCopy()
+				resourceVersion := actualDc.GetResourceVersion()
+				desiredDc.DeepCopyInto(actualDc)
+				actualDc.SetResourceVersion(resourceVersion)
+				if err = remoteClient.Update(ctx, actualDc); err != nil {
+					logger.Error(err, "Failed to update datacenter", "CassandraDatacenter", dcKey)
+					return ctrl.Result{}, err
+				}
 			}
 
-			actualDc := &cassdcapi.CassandraDatacenter{}
+			if !cassandra.DatacenterReady(actualDc) {
+				logger.Info("Waiting for datacenter to become ready", "CassandraDatacenter", dcKey)
+				return ctrl.Result{RequeueAfter: defaultDelay}, nil
+			}
 
-			if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
-				if err = r.setStatusForDatacenter(ctx, kc, actualDc); err != nil {
-					logger.Error(err, "Failed to update status for datacenter", "CassandraDatacenter", dcKey)
+			logger.Info("The datacenter is ready", "CassandraDatacenter", dcKey)
+
+			endpoints, err := r.SeedsResolver.ResolveSeedEndpoints(ctx, actualDc, remoteClient)
+			if err != nil {
+				logger.Error(err, "Failed to resolve seed endpoints", "CassandraDatacenter", dcKey)
+				return ctrl.Result{}, err
+			}
+
+			// The following code will update the AdditionalSeeds property for the
+			// datacenters. We will wind up having endpoints from every DC listed in
+			// the AdditionalSeeds property. We really want to exclude the seeds from
+			// the current DC. It is not a major concern right now as this is a short-term
+			// solution for handling seed addresses.
+			seeds = addSeedEndpoints(seeds, endpoints...)
+
+			// Temporarily do not update seeds on existing dcs. SEE
+			// https://github.com/k8ssandra/k8ssandra-operator/issues/67.
+			//logger.Info("Updating seeds", "Seeds", seeds)
+			//if err = r.updateAdditionalSeeds(ctx, kc, seeds, 0, i); err != nil {
+			//	logger.Error(err, "Failed to update seeds")
+			//	return ctrl.Result{}, err
+			//}
+		} else {
+			if errors.IsNotFound(err) {
+				if err = remoteClient.Create(ctx, desiredDc); err != nil {
+					logger.Error(err, "Failed to create datacenter", "CassandraDatacenter", dcKey)
 					return ctrl.Result{}, err
 				}
-
-				if actualHash, found := actualDc.Annotations[api.ResourceHashAnnotation]; !(found && actualHash == desiredDcHash) {
-					logger.Info("Updating datacenter", "CassandraDatacenter", dcKey)
-					actualDc = actualDc.DeepCopy()
-					resourceVersion := actualDc.GetResourceVersion()
-					desiredDc.DeepCopyInto(actualDc)
-					actualDc.SetResourceVersion(resourceVersion)
-					if err = remoteClient.Update(ctx, actualDc); err != nil {
-						logger.Error(err, "Failed to update datacenter", "CassandraDatacenter", dcKey)
-						return ctrl.Result{}, err
-					}
-				}
-
-				if !cassandra.DatacenterReady(actualDc) {
-					logger.Info("Waiting for datacenter to become ready", "CassandraDatacenter", dcKey)
-					return ctrl.Result{RequeueAfter: defaultDelay}, nil
-				}
-
-				logger.Info("The datacenter is ready", "CassandraDatacenter", dcKey)
-
-				endpoints, err := r.SeedsResolver.ResolveSeedEndpoints(ctx, actualDc, remoteClient)
-				if err != nil {
-					logger.Error(err, "Failed to resolve seed endpoints", "CassandraDatacenter", dcKey)
-					return ctrl.Result{}, err
-				}
-
-				// The following code will update the AdditionalSeeds property for the
-				// datacenters. We will wind up having endpoints from every DC listed in
-				// the AdditionalSeeds property. We really want to exclude the seeds from
-				// the current DC. It is not a major concern right now as this is a short-term
-				// solution for handling seed addresses.
-				seeds = addSeedEndpoints(seeds, endpoints...)
-
-				// Temporarily do not update seeds on existing dcs. SEE
-				// https://github.com/k8ssandra/k8ssandra-operator/issues/67.
-				//logger.Info("Updating seeds", "Seeds", seeds)
-				//if err = r.updateAdditionalSeeds(ctx, kc, seeds, 0, i); err != nil {
-				//	logger.Error(err, "Failed to update seeds")
-				//	return ctrl.Result{}, err
-				//}
+				return ctrl.Result{RequeueAfter: defaultDelay}, nil
 			} else {
-				if errors.IsNotFound(err) {
-					if err = remoteClient.Create(ctx, desiredDc); err != nil {
-						logger.Error(err, "Failed to create datacenter", "CassandraDatacenter", dcKey)
-						return ctrl.Result{}, err
-					}
-					return ctrl.Result{RequeueAfter: defaultDelay}, nil
-				} else {
-					logger.Error(err, "Failed to get datacenter", "CassandraDatacenter", dcKey)
-					return ctrl.Result{}, err
-				}
+				logger.Error(err, "Failed to get datacenter", "CassandraDatacenter", dcKey)
+				return ctrl.Result{}, err
 			}
+		}
 
-			if dcTemplate.Stargate != nil {
+		if dcTemplate.Stargate != nil {
 
-				stargateKey := types.NamespacedName{
-					Namespace: actualDc.Namespace,
-					Name:      kc.Name + "-" + actualDc.Name + "-stargate",
-				}
+			stargateKey := types.NamespacedName{
+				Namespace: actualDc.Namespace,
+				Name:      kc.Name + "-" + actualDc.Name + "-stargate",
+			}
 
 				desiredStargate := &api.Stargate{
 					ObjectMeta: metav1.ObjectMeta{
@@ -177,7 +193,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 						Annotations: map[string]string{},
 						Labels: map[string]string{
 							api.PartOfLabel:           api.PartOfLabelValue,
-							api.K8ssandraClusterLabel: req.Name,
+							api.K8ssandraClusterLabel: kcKey.Name,
 						},
 					},
 					Spec: api.StargateSpec{
@@ -188,52 +204,51 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				desiredStargateHash := utils.DeepHashString(desiredStargate)
 				desiredStargate.Annotations[api.ResourceHashAnnotation] = desiredStargateHash
 
-				actualStargate := &api.Stargate{}
+			actualStargate := &api.Stargate{}
 
-				if err := remoteClient.Get(ctx, stargateKey, actualStargate); err != nil {
-					if errors.IsNotFound(err) {
-						logger.Info("Creating Stargate resource", "Stargate", stargateKey)
+			if err := remoteClient.Get(ctx, stargateKey, actualStargate); err != nil {
+				if errors.IsNotFound(err) {
+					logger.Info("Creating Stargate resource", "Stargate", stargateKey)
 
-						if err := remoteClient.Create(ctx, desiredStargate); err != nil {
-							logger.Error(err, "Failed to create Stargate resource", "Stargate", stargateKey)
-							return ctrl.Result{}, err
-						} else {
-							return ctrl.Result{RequeueAfter: defaultDelay}, nil
-						}
+					if err := remoteClient.Create(ctx, desiredStargate); err != nil {
+						logger.Error(err, "Failed to create Stargate resource", "Stargate", stargateKey)
+						return ctrl.Result{}, err
 					} else {
-						logger.Error(err, "Failed to get Stargate resource", "Stargate", stargateKey)
-						return ctrl.Result{}, err
-					}
-				} else {
-					if err = r.setStatusForStargate(ctx, kc, actualStargate, dcTemplate.Meta.Name); err != nil {
-						logger.Error(err, "Failed to update status for stargate", "Stargate", stargateKey)
-						return ctrl.Result{}, err
-					}
-
-					if actualStargateHash, found := actualStargate.Annotations[api.ResourceHashAnnotation]; !found || actualStargateHash != desiredStargateHash {
-						logger.Info("Updating Stargate resource", "Stargate", stargateKey)
-						resourceVersion := actualStargate.GetResourceVersion()
-						desiredStargate.DeepCopyInto(actualStargate)
-						actualStargate.SetResourceVersion(resourceVersion)
-
-						if err = remoteClient.Update(ctx, actualStargate); err == nil {
-							return ctrl.Result{RequeueAfter: defaultDelay}, nil
-						} else {
-							logger.Error(err, "Failed to update Stargate resource", "Stargate", stargateKey)
-							return ctrl.Result{}, err
-						}
-					}
-
-					if !stargateutil.IsReady(actualStargate.Status) {
-						logger.Info("Waiting for Stargate to become ready", "Stargate", stargateKey)
 						return ctrl.Result{RequeueAfter: defaultDelay}, nil
 					}
-					logger.Info("Stargate is ready", "Stargate", stargateKey)
+				} else {
+					logger.Error(err, "Failed to get Stargate resource", "Stargate", stargateKey)
+					return ctrl.Result{}, err
 				}
+			} else {
+				if err = r.setStatusForStargate(kc, actualStargate, dcTemplate.Meta.Name); err != nil {
+					logger.Error(err, "Failed to update status for stargate", "Stargate", stargateKey)
+					return ctrl.Result{}, err
+				}
+
+				if actualStargateHash, found := actualStargate.Annotations[api.ResourceHashAnnotation]; !found || actualStargateHash != desiredStargateHash {
+					logger.Info("Updating Stargate resource", "Stargate", stargateKey)
+					resourceVersion := actualStargate.GetResourceVersion()
+					desiredStargate.DeepCopyInto(actualStargate)
+					actualStargate.SetResourceVersion(resourceVersion)
+
+					if err = remoteClient.Update(ctx, actualStargate); err == nil {
+						return ctrl.Result{RequeueAfter: defaultDelay}, nil
+					} else {
+						logger.Error(err, "Failed to update Stargate resource", "Stargate", stargateKey)
+						return ctrl.Result{}, err
+					}
+				}
+
+				if !stargateutil.IsReady(actualStargate.Status) {
+					logger.Info("Waiting for Stargate to become ready", "Stargate", stargateKey)
+					return ctrl.Result{RequeueAfter: defaultDelay}, nil
+				}
+				logger.Info("Stargate is ready", "Stargate", stargateKey)
 			}
 		}
 	}
-	logger.Info("Finished reconciling the k8ssandracluster")
+	logger.Info("Finished reconciling the k8ssandracluster", "K8ssandraCluster", kcKey)
 	return ctrl.Result{}, nil
 }
 
@@ -378,8 +393,7 @@ func getDatacenterKey(dcTemplate api.CassandraDatacenterTemplateSpec, kcKey type
 	return types.NamespacedName{Namespace: dcTemplate.Meta.Namespace, Name: dcTemplate.Meta.Name}
 }
 
-func (r *K8ssandraClusterReconciler) setStatusForDatacenter(ctx context.Context, kc *api.K8ssandraCluster, dc *cassdcapi.CassandraDatacenter) error {
-	patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+func (r *K8ssandraClusterReconciler) setStatusForDatacenter(kc *api.K8ssandraCluster, dc *cassdcapi.CassandraDatacenter) error {
 	if len(kc.Status.Datacenters) == 0 {
 		kc.Status.Datacenters = make(map[string]api.K8ssandraStatus, 0)
 	}
@@ -394,11 +408,10 @@ func (r *K8ssandraClusterReconciler) setStatusForDatacenter(ctx context.Context,
 		}
 	}
 
-	return r.Status().Patch(ctx, kc, patch)
+	return nil
 }
 
-func (r *K8ssandraClusterReconciler) setStatusForStargate(ctx context.Context, kc *api.K8ssandraCluster, stargate *api.Stargate, dcName string) error {
-	patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+func (r *K8ssandraClusterReconciler) setStatusForStargate(kc *api.K8ssandraCluster, stargate *api.Stargate, dcName string) error {
 	if len(kc.Status.Datacenters) == 0 {
 		kc.Status.Datacenters = make(map[string]api.K8ssandraStatus, 0)
 	}
@@ -418,7 +431,7 @@ func (r *K8ssandraClusterReconciler) setStatusForStargate(ctx context.Context, k
 		}
 	}
 
-	return r.Status().Patch(ctx, kc, patch)
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -22,10 +22,8 @@ import (
 	stargateutil "github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"math"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
-
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
@@ -69,7 +67,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
+		return ctrl.Result{RequeueAfter: defaultDelay}, err
 	}
 
 	kc = kc.DeepCopy()
@@ -127,7 +125,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 				if !cassandra.DatacenterReady(actualDc) {
 					logger.Info("Waiting for datacenter to become ready", "CassandraDatacenter", dcKey)
-					return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+					return ctrl.Result{RequeueAfter: defaultDelay}, nil
 				}
 
 				logger.Info("The datacenter is ready", "CassandraDatacenter", dcKey)
@@ -158,7 +156,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 						logger.Error(err, "Failed to create datacenter", "CassandraDatacenter", dcKey)
 						return ctrl.Result{}, err
 					}
-					return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+					return ctrl.Result{RequeueAfter: defaultDelay}, nil
 				} else {
 					logger.Error(err, "Failed to get datacenter", "CassandraDatacenter", dcKey)
 					return ctrl.Result{}, err
@@ -200,7 +198,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 							logger.Error(err, "Failed to create Stargate resource", "Stargate", stargateKey)
 							return ctrl.Result{}, err
 						} else {
-							return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+							return ctrl.Result{RequeueAfter: defaultDelay}, nil
 						}
 					} else {
 						logger.Error(err, "Failed to get Stargate resource", "Stargate", stargateKey)
@@ -219,7 +217,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 						actualStargate.SetResourceVersion(resourceVersion)
 
 						if err = remoteClient.Update(ctx, actualStargate); err == nil {
-							return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+							return ctrl.Result{RequeueAfter: defaultDelay}, nil
 						} else {
 							logger.Error(err, "Failed to update Stargate resource", "Stargate", stargateKey)
 							return ctrl.Result{}, err
@@ -228,7 +226,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 					if !stargateutil.IsReady(actualStargate) {
 						logger.Info("Waiting for Stargate to become ready", "Stargate", stargateKey)
-						return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+						return ctrl.Result{RequeueAfter: defaultDelay}, nil
 					}
 					logger.Info("Stargate is ready", "Stargate", stargateKey)
 				}

--- a/controllers/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandracluster_controller_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func testK8ssandraCluster(ctx context.Context, t *testing.T) {
-	testEnv := NewMultiClusterTestEnv()
+	ctx, cancel := context.WithCancel(ctx)
+	testEnv := &MultiClusterTestEnv{}
 	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
 		err := (&K8ssandraClusterReconciler{
 			Client:        mgr.GetClient(),
@@ -36,6 +37,7 @@ func testK8ssandraCluster(ctx context.Context, t *testing.T) {
 	}
 
 	defer testEnv.Stop(t)
+	defer cancel()
 
 	t.Run("CreateSingleDcCluster", testEnv.ControllerTest(ctx, createSingleDcCluster))
 	t.Run("CreateMultiDcCluster", testEnv.ControllerTest(ctx, createMultiDcCluster))

--- a/controllers/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandracluster_controller_test.go
@@ -5,15 +5,42 @@ import (
 	"fmt"
 	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+	stargateutil "github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
-	"time"
 )
+
+func testK8ssandraCluster(ctx context.Context, t *testing.T) {
+	testEnv := NewMultiClusterTestEnv()
+	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
+		err := (&K8ssandraClusterReconciler{
+			Client:        mgr.GetClient(),
+			Scheme:        scheme.Scheme,
+			ClientCache:   clientCache,
+			SeedsResolver: seedsResolver,
+		}).SetupWithManager(mgr, clusters)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("failed to start test environment: %s", err)
+	}
+
+	defer testEnv.Stop(t)
+
+	t.Run("CreateSingleDcCluster", testEnv.ControllerTest(ctx, createSingleDcCluster))
+	t.Run("CreateMultiDcCluster", testEnv.ControllerTest(ctx, createMultiDcCluster))
+	t.Run("CreateMultiDcClusterWithStargate", testEnv.ControllerTest(ctx, createMultiDcClusterWithStargate))
+}
 
 func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
@@ -21,7 +48,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 
 	k8sCtx := "cluster-1"
 
-	cluster := &api.K8ssandraCluster{
+	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      "test",
@@ -43,7 +70,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 		},
 	}
 
-	err := f.Client.Create(ctx, cluster)
+	err := f.Client.Create(ctx, kc)
 	require.NoError(err, "failed to create K8ssandraCluster")
 
 	t.Log("check that the datacenter was created")
@@ -62,28 +89,28 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 	})
 	require.NoError(err, "failed to patch datacenter status")
 
-	k8ssandraKey := framework.ClusterKey{K8sContext: "cluster-0", NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+	kcKey := framework.ClusterKey{K8sContext: "cluster-0", NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
 	require.Eventually(func() bool {
-		k8ssandra := &api.K8ssandraCluster{}
-		err = f.Get(ctx, k8ssandraKey, k8ssandra)
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
 		if err != nil {
 			t.Logf("failed to get K8ssandraCluster: %v", err)
 			return false
 		}
 
-		if len(k8ssandra.Status.Datacenters) == 0 {
+		if len(kc.Status.Datacenters) == 0 {
 			return false
 		}
 
-		kdcStatus, found := k8ssandra.Status.Datacenters[dcKey.Name]
+		k8ssandraStatus, found := kc.Status.Datacenters[dcKey.Name]
 		if !found {
 			t.Logf("status for datacenter %s not found", dcKey)
 			return false
 		}
 
-		condition := findDatacenterCondition(kdcStatus.Cassandra, cassdcapi.DatacenterScalingUp)
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
 		return condition != nil
-	}, 20*time.Second, 1*time.Second, "timed out waiting for K8ssandraCluster status update")
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
 
 	t.Log("update datacenter status to ready")
 	err = f.PatchDatacenterStatus(ctx, dcKey, func(dc *cassdcapi.CassandraDatacenter) {
@@ -101,36 +128,37 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 	})
 	require.NoError(err, "failed to patch datacenter status")
 
+	t.Log("check that the K8ssandraCluster status is updated")
 	require.Eventually(func() bool {
-		k8ssandra := &api.K8ssandraCluster{}
-		err = f.Get(ctx, k8ssandraKey, k8ssandra)
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
 		if err != nil {
 			t.Logf("failed to get K8ssandraCluster: %v", err)
 			return false
 		}
 
-		if len(k8ssandra.Status.Datacenters) == 0 {
+		if len(kc.Status.Datacenters) == 0 {
 			return false
 		}
 
-		kdcStatus, found := k8ssandra.Status.Datacenters[dcKey.Name]
+		k8ssandraStatus, found := kc.Status.Datacenters[dcKey.Name]
 		if !found {
 			t.Logf("status for datacenter %s not found", dcKey)
 			return false
 		}
 
-		condition := findDatacenterCondition(kdcStatus.Cassandra, cassdcapi.DatacenterScalingUp)
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
 		if condition == nil || condition.Status == corev1.ConditionTrue {
 			return false
 		}
 
-		condition = findDatacenterCondition(kdcStatus.Cassandra, cassdcapi.DatacenterReady)
+		condition = findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
 		if condition == nil || condition.Status == corev1.ConditionFalse {
 			return false
 		}
 
 		return true
-	}, 20*time.Second, 1*time.Second, "timed out waiting for K8ssandraCluster status update")
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
 }
 
 func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
@@ -184,6 +212,47 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
 
+	t.Log("update datacenter status to scaling up")
+	err = f.PatchDatacenterStatus(ctx, dc1Key, func(dc *cassdcapi.CassandraDatacenter) {
+		dc.SetCondition(cassdcapi.DatacenterCondition{
+			Type:               cassdcapi.DatacenterScalingUp,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+	require.NoError(err, "failed to patch datacenter status")
+
+	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+
+	t.Log("check that the K8ssandraCluster status is updated")
+	require.Eventually(func() bool {
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
+		if err != nil {
+			t.Logf("failed to get K8ssandraCluster: %v", err)
+			return false
+		}
+
+		if len(kc.Status.Datacenters) == 0 {
+			return false
+		}
+
+		k8ssandraStatus, found := kc.Status.Datacenters[dc1Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc1Key)
+			return false
+		}
+
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
+		return !(condition == nil && condition.Status == corev1.ConditionFalse)
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+
+	t.Log("check that dc2 has not been created yet")
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: k8sCtx1}
+	dc2 := &cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dc2Key, dc2)
+	require.True(err != nil && errors.IsNotFound(err), "dc2 should not be created until dc1 is ready")
+
 	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
 		if dc.Name == "dc1" {
 			return dc1PodIps, nil
@@ -206,11 +275,10 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	require.NoError(err, "failed to update dc1 status to ready")
 
 	t.Log("check that dc2 was created")
-	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: k8sCtx1}
 	require.Eventually(f.DatacenterExists(ctx, dc2Key), timeout, interval)
 
 	t.Log("check that remote seeds are set on dc2")
-	dc2 := &cassdcapi.CassandraDatacenter{}
+	dc2 = &cassdcapi.CassandraDatacenter{}
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
@@ -241,6 +309,261 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	//	return equalsNoOrder(allPodIps, dc.Spec.AdditionalSeeds), nil
 	//})
 	//require.NoError(err, "timed out waiting for remote seeds to be updated on dc1")
+
+	t.Log("check that the K8ssandraCluster status is updated")
+	require.Eventually(func() bool {
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
+		if err != nil {
+			t.Logf("failed to get K8ssandraCluster: %v", err)
+			return false
+		}
+
+		if len(kc.Status.Datacenters) != 2 {
+			return false
+		}
+
+		k8ssandraStatus, found := kc.Status.Datacenters[dc1Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc1Key)
+			return false
+		}
+
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
+		if condition == nil || condition.Status == corev1.ConditionFalse {
+			return false
+		}
+
+		k8ssandraStatus, found = kc.Status.Datacenters[dc2Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc2Key)
+			return false
+		}
+
+		condition = findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
+		return condition != nil && condition.Status == corev1.ConditionTrue
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+}
+
+func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	k8sCtx0 := "cluster-0"
+	k8sCtx1 := "cluster-1"
+
+	kc := &api.K8ssandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test",
+		},
+		Spec: api.K8ssandraClusterSpec{
+			Cassandra: &api.Cassandra{
+				Cluster: "test",
+				Datacenters: []api.CassandraDatacenterTemplateSpec{
+					{
+						Meta: api.EmbeddedObjectMeta{
+							Name: "dc1",
+						},
+						K8sContext:    k8sCtx0,
+						Size:          3,
+						ServerVersion: "3.11.10",
+						Stargate: &api.StargateTemplate{
+							Size: 1,
+						},
+					},
+					{
+						Meta: api.EmbeddedObjectMeta{
+							Name: "dc2",
+						},
+						K8sContext:    k8sCtx1,
+						Size:          3,
+						ServerVersion: "3.11.10",
+						Stargate: &api.StargateTemplate{
+							Size: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := f.Client.Create(ctx, kc)
+	require.NoError(err, "failed to create K8ssandraCluster")
+
+	dc1PodIps := []string{"10.10.100.1", "10.10.100.2", "10.10.100.3"}
+	dc2PodIps := []string{"10.11.100.1", "10.11.100.2", "10.11.100.3"}
+
+	allPodIps := make([]string, 0, 6)
+	allPodIps = append(allPodIps, dc1PodIps...)
+	allPodIps = append(allPodIps, dc2PodIps...)
+
+	t.Log("check that dc1 was created")
+	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
+	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
+
+	t.Log("update datacenter status to scaling up")
+	err = f.PatchDatacenterStatus(ctx, dc1Key, func(dc *cassdcapi.CassandraDatacenter) {
+		dc.SetCondition(cassdcapi.DatacenterCondition{
+			Type:               cassdcapi.DatacenterScalingUp,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+	require.NoError(err, "failed to patch datacenter status")
+
+	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+
+	t.Log("check that the K8ssandraCluster status is updated")
+	require.Eventually(func() bool {
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
+		if err != nil {
+			t.Logf("failed to get K8ssandraCluster: %v", err)
+			return false
+		}
+
+		if len(kc.Status.Datacenters) == 0 {
+			return false
+		}
+
+		k8ssandraStatus, found := kc.Status.Datacenters[dc1Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc1Key)
+			return false
+		}
+
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
+		return !(condition == nil && condition.Status == corev1.ConditionFalse)
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+
+	sg1Key := framework.ClusterKey{
+		K8sContext: k8sCtx0,
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      kc.Name + "-" + dc1Key.Name + "-stargate"},
+	}
+
+	t.Logf("check that stargate %s has not been created", sg1Key)
+	sg1 := &api.Stargate{}
+	err = f.Get(ctx, sg1Key, sg1)
+	require.True(err != nil && errors.IsNotFound(err), fmt.Sprintf("stargate %s should not be created until dc1 is ready", sg1Key))
+
+	t.Log("check that dc2 has not been created yet")
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: k8sCtx1}
+	dc2 := &cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dc2Key, dc2)
+	require.True(err != nil && errors.IsNotFound(err), "dc2 should not be created until dc1 is ready")
+
+	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
+		if dc.Name == "dc1" {
+			return dc1PodIps, nil
+		}
+		if dc.Name == "dc2" {
+			return dc2PodIps, nil
+		}
+		return nil, fmt.Errorf("unknown datacenter: %s", dc.Name)
+	}
+
+	t.Log("update dc1 status to ready")
+	err = f.PatchDatacenterStatus(ctx, dc1Key, func(dc *cassdcapi.CassandraDatacenter) {
+		dc.Status.CassandraOperatorProgress = cassdcapi.ProgressReady
+		dc.SetCondition(cassdcapi.DatacenterCondition{
+			Type:               cassdcapi.DatacenterReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+	require.NoError(err, "failed to update dc1 status to ready")
+
+	t.Log("check that stargate sg1 is created")
+	require.Eventually(f.StargateExists(ctx, sg1Key), timeout, interval)
+
+	t.Logf("update stargate sg1 status to ready")
+	err = f.PatchStagateStatus(ctx, sg1Key, func(sg *api.Stargate) {
+		now := metav1.Now()
+		sg.Status.Progress = api.StargateProgressRunning
+		sg.Status.AvailableReplicas = 1
+		sg.Status.Replicas = 1
+		sg.Status.ReadyReplicas = 1
+		sg.Status.UpdatedReplicas = 1
+		stargateutil.SetCondition(sg, api.StargateCondition{
+			Type:               api.StargateReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: &now,
+		})
+	})
+	require.NoError(err, "failed to patch stargate status")
+
+	t.Log("check that dc2 was created")
+	require.Eventually(f.DatacenterExists(ctx, dc2Key), timeout, interval)
+
+	t.Log("check that remote seeds are set on dc2")
+	dc2 = &cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dc2Key, dc2)
+	require.NoError(err, "failed to get dc2")
+
+	assert.Equal(dc1PodIps, dc2.Spec.AdditionalSeeds, "The AdditionalSeeds property for dc2 is wrong")
+
+	t.Log("update dc2 status to ready")
+	err = f.PatchDatacenterStatus(ctx, dc2Key, func(dc *cassdcapi.CassandraDatacenter) {
+		dc.Status.CassandraOperatorProgress = cassdcapi.ProgressReady
+		dc.SetCondition(cassdcapi.DatacenterCondition{
+			Type:               cassdcapi.DatacenterReady,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+	require.NoError(err, "failed to update dc2 status to ready")
+
+	// Commenting out the following check for now to due to
+	// https://github.com/k8ssandra/k8ssandra-operator/issues/67
+	//
+	//t.Log("check that remote seeds are set on dc1")
+	//err = wait.Poll(interval, timeout, func() (bool, error) {
+	//	dc := &cassdcapi.CassandraDatacenter{}
+	//	if err = f.Get(ctx, dc1Key, dc); err != nil {
+	//		t.Logf("failed to get dc1: %s", err)
+	//		return false, err
+	//	}
+	//	t.Logf("additional seeds for dc1: %v", dc.Spec.AdditionalSeeds)
+	//	return equalsNoOrder(allPodIps, dc.Spec.AdditionalSeeds), nil
+	//})
+	//require.NoError(err, "timed out waiting for remote seeds to be updated on dc1")
+
+	t.Log("check that the K8ssandraCluster status is updated")
+	require.Eventually(func() bool {
+		kc := &api.K8ssandraCluster{}
+		err = f.Get(ctx, kcKey, kc)
+		if err != nil {
+			t.Logf("failed to get K8ssandraCluster: %v", err)
+			return false
+		}
+
+		if len(kc.Status.Datacenters) != 2 {
+			return false
+		}
+
+		k8ssandraStatus, found := kc.Status.Datacenters[dc1Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc1Key)
+			return false
+		}
+
+		condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
+		if condition == nil || condition.Status == corev1.ConditionFalse {
+			return false
+		}
+
+		k8ssandraStatus, found = kc.Status.Datacenters[dc2Key.Name]
+		if !found {
+			t.Logf("status for datacenter %s not found", dc2Key)
+			return false
+		}
+
+		condition = findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
+		return condition != nil && condition.Status == corev1.ConditionTrue
+	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
 }
 
 func equalsNoOrder(s1, s2 []string) bool {

--- a/controllers/stargate_controller.go
+++ b/controllers/stargate_controller.go
@@ -26,14 +26,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
 )
@@ -101,7 +99,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					return ctrl.Result{}, err
 				}
 			}
-			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: defaultDelay}, nil
 		} else {
 			logger.Error(err, "Failed to fetch CassandraDatacenter", "CassandraDatacenter", dcKey)
 			return ctrl.Result{}, err
@@ -119,7 +117,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 		}
 		logger.Info("Waiting for datacenter to become ready", "CassandraDatacenter", dcKey)
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: defaultDelay}, nil
 	}
 
 	// Compute the desired deployment
@@ -157,7 +155,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				}
 			} else {
 				logger.Info("Stargate Deployment created successfully", "Deployment", deploymentKey)
-				return ctrl.Result{RequeueAfter: time.Minute}, nil
+				return ctrl.Result{RequeueAfter: longDelay}, nil
 			}
 		} else {
 			logger.Error(err, "Failed to fetch Stargate Deployment", "Deployment", deploymentKey)
@@ -181,7 +179,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		} else {
 			logger.Info("Stargate Deployment updated successfully", "Deployment", deploymentKey)
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
+			return ctrl.Result{RequeueAfter: longDelay}, nil
 		}
 	}
 
@@ -213,7 +211,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 		}
 		logger.Info("Waiting for deployment to be rolled out", "Deployment", deploymentKey)
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: defaultDelay}, nil
 	}
 
 	// Compute the desired service
@@ -241,7 +239,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				}
 			} else {
 				logger.Info("Stargate Service created successfully", "Service", serviceKey)
-				return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+				return ctrl.Result{RequeueAfter: defaultDelay}, nil
 			}
 		} else {
 			logger.Error(err, "Failed to fetch Stargate Service", "Service", serviceKey)
@@ -265,7 +263,7 @@ func (r *StargateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		} else {
 			logger.Info("Stargate Service updated successfully", "Service", serviceKey)
-			return ctrl.Result{RequeueAfter: time.Minute}, nil
+			return ctrl.Result{RequeueAfter: longDelay}, nil
 		}
 	}
 

--- a/controllers/stargate_controller_test.go
+++ b/controllers/stargate_controller_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func testStargate(ctx context.Context, t *testing.T) {
+	ctx, cancel := context.WithCancel(ctx)
 	testEnv := &TestEnv{}
 	err := testEnv.Start(ctx, t, func(mgr manager.Manager) error {
 		err := (&StargateReconciler{
@@ -30,6 +31,7 @@ func testStargate(ctx context.Context, t *testing.T) {
 	}
 
 	defer testEnv.Stop(t)
+	defer cancel()
 
 	t.Run("CreateStargate", func(t *testing.T) {
 		testCreate(t, testEnv.TestClient)

--- a/controllers/stargate_controller_test.go
+++ b/controllers/stargate_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	cassdcapi "github.com/k8ssandra/cass-operator/operator/pkg/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
 	"github.com/stretchr/testify/require"
@@ -11,12 +10,34 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 )
 
-func testStargate(t *testing.T) {
+func testStargate(ctx context.Context, t *testing.T) {
+	testEnv := &TestEnv{}
+	err := testEnv.Start(ctx, t, func(mgr manager.Manager) error {
+		err := (&StargateReconciler{
+			Client: mgr.GetClient(),
+			Scheme: scheme.Scheme,
+		}).SetupWithManager(mgr)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("failed to start test environment: %s", err)
+	}
+
+	defer testEnv.Stop(t)
+
+	t.Run("CreateStargate", func(t *testing.T) {
+		testCreate(t, testEnv.TestClient)
+	})
+}
+
+func testCreate(t *testing.T, testClient client.Client) {
 	req := require.New(t)
-	testClient := testClients[fmt.Sprintf(clusterProtoName, 0)]
 
 	namespace := "default"
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	controllers.InitConfig()
+
 	if isControlPlane() {
 		// Fetch ClientConfigs and create the clientCache
 		clientCache := clientcache.New(mgr.GetClient(), uncachedClient, scheme)

--- a/main.go
+++ b/main.go
@@ -126,12 +126,6 @@ func main() {
 				os.Exit(1)
 			}
 
-			_, err = clientCache.CreateClient(cCfg.GetContextName(), cfg)
-			if err != nil {
-				setupLog.Error(err, "unable to create cluster connection")
-				os.Exit(1)
-			}
-
 			// Add cluster to the manager
 			c, err := cluster.New(cfg, func(o *cluster.Options) {
 				o.Scheme = scheme
@@ -141,6 +135,8 @@ func main() {
 				setupLog.Error(err, "unable to create manager cluster connection")
 				os.Exit(1)
 			}
+
+			clientCache.AddClient(cCfg.GetContextName(), c.GetClient())
 
 			err = mgr.Add(c)
 			if err != nil {

--- a/pkg/clientcache/cache.go
+++ b/pkg/clientcache/cache.go
@@ -51,23 +51,22 @@ func (c *ClientCache) GetRemoteClient(k8sContextName string) (client.Client, err
 }
 
 // GetLocalClient returns the current cluster's client used for operator's local communication
-func (c *ClientCache) GetLocalClient() (client.Client, error) {
-	return c.localClient, nil
+func (c *ClientCache) GetLocalClient() client.Client {
+	return c.localClient
 }
 
 // GetRemoteClients returns all the remote clients
-func (c *ClientCache) GetRemoteClients() (map[string]client.Client, error) {
-	return c.remoteClients, nil
+func (c *ClientCache) GetRemoteClients() map[string]client.Client {
+	return c.remoteClients
 }
 
 // AddClient adds a new remoteClient with the name k8sContextName
-func (c *ClientCache) AddClient(k8sContextName string, cli client.Client) error {
+func (c *ClientCache) AddClient(k8sContextName string, cli client.Client) {
 	c.remoteClients[k8sContextName] = cli
-	return nil
 }
 
-// CreateClient creates a remoteClient and stores it in the cache. If already stored, returns the existing client
-func (c *ClientCache) CreateClient(contextName string, restConfig *rest.Config) (client.Client, error) {
+// createClient creates a remoteClient and stores it in the cache. If already stored, returns the existing client
+func (c *ClientCache) createClient(contextName string, restConfig *rest.Config) (client.Client, error) {
 	if cli, found := c.remoteClients[contextName]; found {
 		// We already have created that client
 		return cli, nil
@@ -102,7 +101,7 @@ func (c *ClientCache) CreateRemoteClientsFromSecret(secretKey types.NamespacedNa
 			return err
 		}
 
-		if _, err := c.CreateClient(ctx, restConfig); err != nil {
+		if _, err := c.createClient(ctx, restConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -260,12 +260,12 @@ func getStargateContainerName(dc *cassdcapi.CassandraDatacenter) string {
 	return dc.Spec.ClusterName + "-" + dc.Name + "-stargate-deployment"
 }
 
-func IsReady(sg *api.Stargate) bool {
-	if sg.Status.Progress != api.StargateProgressRunning {
+func IsReady(status api.StargateStatus) bool {
+	if status.Progress != api.StargateProgressRunning {
 		return false
 	}
 
-	for _, condition := range sg.Status.Conditions {
+	for _, condition := range status.Conditions {
 		if condition.Type == api.StargateReady && condition.Status == corev1.ConditionTrue {
 			return true
 		}

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -273,3 +273,27 @@ func IsReady(sg *api.Stargate) bool {
 
 	return false
 }
+
+func SetCondition(sg *api.Stargate, condition api.StargateCondition) {
+	var conditions []api.StargateCondition
+	if sg.Status.Conditions == nil {
+		conditions = make([]api.StargateCondition, 0)
+	} else {
+		conditions = sg.Status.Conditions
+	}
+	updated := false
+
+	for i, c := range conditions {
+		if c.Type == condition.Type {
+			conditions[i] = condition
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		conditions = append(conditions, condition)
+	}
+
+	sg.Status.Conditions = conditions
+}

--- a/scripts/create-client-config.sh
+++ b/scripts/create-client-config.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -e
+
+set -o xtrace
+
+OPTS=$(getopt -o h --long src-context:,src-kubeconfig:,dest-context:,dest-kubeconfig:,namespace:,serviceaccount,output-dir:,help -n 'create-client-config' -- "$@")
+
+eval set -- "$OPTS"
+
+function help() {
+    echo
+    echo "Syntax: create-client-config.sh [options]"
+    echo "Options:"
+    echo "src-context     The context for the source cluster that contains the service account."
+    echo "src-kubeconfig   The kubeconfig for the source cluster that contains the service account."
+    echo "dest-context    The context for the cluster where the ClientConfig will be created."
+    echo "dest-kubeconfig  The kubeconfig for the cluster where the ClientConfig will be created."
+    echo "namespace       The namespace in which the service account exists and where the ClientConfig will be created."
+    echo "serviceaccount  The name of the service account from which the ClientConfig will be created. Defaults to k8ssandra-operator."
+    echo "output-dir      The directory where generated artifacts are written. If not specified a temp directory is created."
+}
+
+src_context=""
+src_kubeconfig=""
+dest_context=""
+dest_kubeconfig=""
+service_account="k8ssandra-operator"
+namespace=""
+output_dir=""
+
+while true; do
+  case "$1" in
+    --src-context ) src_context="$2"; shift 2 ;;
+    --src_kubeconfig ) src_kubeconfig="$2"; shift 2 ;;
+    --dest-context ) dest_context="$2"; shift 2 ;;
+    --dest-kubeconfig ) dest_kubeconfig="$2"; shift 2 ;;
+    --namespace ) namespace="$2"; shift 2 ;;
+    --serviceaccount ) service_account="$2"; shift 2 ;;
+    --output-dir ) output_dir="$2"; shift 2 ;;
+    -h | --help ) help; exit;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ -z "$src_context" ] && [ -z "$src_kubeconfig" ]; then
+  echo "At least one of the --src-context or --src-kubeconfig options must be specified"
+  exit 1
+fi
+
+src_context_opt=""
+src_kubeconfig_opt=""
+namespace_opt=""
+
+if [ -z "$src_context" ]; then
+  src_context=$(kubectl $src_kubeconfig config current-context)
+else
+  src_kubeconfig=""
+  src_context_opt="--context $src_context"
+fi
+
+if [ ! -z "$src_kubeconfig" ]; then
+  src_kubeconfig_opt="--kubeconfig $src_kubeconfig"
+fi
+
+if [ -z "$output_dir" ]; then
+  output_dir=$(mktemp -d)
+fi
+
+if [ ! -z "$namespace"]; then
+  namespace_opt="-n $namespace"
+fi
+
+sa_secret=$(kubectl $src_kubeconfig_opt $src_context_opt $namespace_opt get serviceaccount $service_account -o jsonpath='{.secrets[0].name}')
+sa_token=$(kubectl $src_kubeconfig_opt $src_context_opt $namespace_opt get secret $sa_secret -o jsonpath='{.data.token}' | base64 -d)
+ca_cert=$(kubectl $src_kubeconfig_opt $src_context_opt $namespace_opt get secret $sa_secret -o jsonpath="{.data['ca\.crt']}")
+
+cluster=$(kubectl $src_kubeconfig_opt config view -o jsonpath="{.contexts[?(@.name == \"$src_context\"})].context.cluster}")
+cluster_addr=$(kubectl $src_kubeconfig_opt config view -o jsonpath="{.clusters[?(@.name == \"$cluster\"})].cluster.server}")
+
+output_kubeconfig="$output_dir/kubeconfig"
+echo "Creating $output_kubeconfig"
+cat > $output_kubeconfig <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${ca_cert}
+    server: $cluster_addr
+  name: ${cluster}
+contexts:
+- context:
+    cluster: $cluster
+    user: $cluster-$service_account
+  name: $src_context
+current-context: $src_context
+kind: Config
+preferences: {}
+users:
+- name: $cluster-$service_account
+  user:
+    token: $sa_token
+EOF
+
+output_secret="$src_context-config"
+echo "Creating secret $output_secret"
+
+kubectl $namespace_opt create secret generic $output_secret --from-file="$output_kubeconfig"
+
+clientconfig_name="$src_context"
+clientconfig_path="${output_dir}/${clientconfig_name}.yaml"
+echo "Creating ClientConfig $clientconfig_path"
+cat > "$clientconfig_path" <<EOF
+apiVersion: k8ssandra.io/v1alpha1
+kind: ClientConfig
+metadata:
+  name: $clientconfig_name
+spec:
+  contextName: $src_context
+  kubeConfigSecret:
+    name: $output_secret
+EOF
+
+kubectl $namespace_opt apply -f $clientconfig_path

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -130,8 +130,22 @@ func (f *Framework) PatchDatacenterStatus(ctx context.Context, key ClusterKey, u
 	updateFn(dc)
 
 	remoteClient := f.remoteClients[key.K8sContext]
-
 	return remoteClient.Status().Patch(ctx, dc, patch)
+}
+
+func (f *Framework) PatchStagateStatus(ctx context.Context, key ClusterKey, updateFn func(sg *api.Stargate)) error {
+	sg := &api.Stargate{}
+	err := f.Get(ctx, key, sg)
+
+	if err != nil {
+		return err
+	}
+
+	patch := client.MergeFromWithOptions(sg.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	updateFn(sg)
+
+	remoteClient := f.remoteClients[key.K8sContext]
+	return remoteClient.Status().Patch(ctx, sg, patch)
 }
 
 // WaitForDeploymentToBeReady Blocks until the Deployment is ready. If


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Gets the service account token from the remote cluster
* Gets the CA cert from the remote cluster
* Creates a kubeconfig file using the token and CA cert
* Create a secret that contains the kubeconfig
* Create a ClientConfig that references the secret

**TODO**:
- [ ] Accept multiple values for the `src-context` option and generate a kubeconfig entry for each one

**Which issue(s) this PR fixes**:
Fixes #83

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
