### PR TITLE
Minor enhancements for Stargate

### DIFF
--- a/api/v1alpha1/k8ssandracluster_types.go
+++ b/api/v1alpha1/k8ssandracluster_types.go
@@ -55,8 +55,8 @@ type K8ssandraStatus struct {
 	Stargate  *StargateStatus                      `json:"stargate,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // K8ssandraCluster is the Schema for the k8ssandraclusters API
 type K8ssandraCluster struct {
@@ -67,7 +67,25 @@ type K8ssandraCluster struct {
 	Status K8ssandraClusterStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// HasStargates returns true if at least one Stargate resource will be created as part of the creation
+// of this K8ssandraCluster object.
+func (in *K8ssandraCluster) HasStargates() bool {
+	if in == nil {
+		return false
+	} else if in.Spec.Stargate != nil {
+		return true
+	} else if in.Spec.Cassandra == nil || len(in.Spec.Cassandra.Datacenters) == 0 {
+		return false
+	}
+	for _, dcTemplate := range in.Spec.Cassandra.Datacenters {
+		if dcTemplate.Stargate != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// +kubebuilder:object:root=true
 
 // K8ssandraClusterList contains a list of K8ssandraCluster
 type K8ssandraClusterList struct {

--- a/api/v1alpha1/k8ssandracluster_types_test.go
+++ b/api/v1alpha1/k8ssandracluster_types_test.go
@@ -1,0 +1,55 @@
+package v1alpha1
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestK8ssandraCluster(t *testing.T) {
+	t.Run("HasStargates", testK8ssandraClusterHasStargates)
+}
+
+func testK8ssandraClusterHasStargates(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var kc *K8ssandraCluster = nil
+		assert.False(t, kc.HasStargates())
+	})
+	t.Run("no stargates", func(t *testing.T) {
+		kc := K8ssandraCluster{}
+		assert.False(t, kc.HasStargates())
+	})
+	t.Run("cluster-level stargate", func(t *testing.T) {
+		kc := K8ssandraCluster{
+			Spec: K8ssandraClusterSpec{
+				Stargate: &StargateClusterTemplate{
+					Size: 3,
+				},
+			},
+		}
+		assert.True(t, kc.HasStargates())
+	})
+	t.Run("dc-level stargate", func(t *testing.T) {
+		kc := K8ssandraCluster{
+			Spec: K8ssandraClusterSpec{
+				Cassandra: &Cassandra{
+					Cluster: "cluster1",
+					Datacenters: []CassandraDatacenterTemplateSpec{
+						{
+							Size:     3,
+							Stargate: nil,
+						},
+						{
+							Size: 3,
+							Stargate: &StargateDatacenterTemplate{
+								StargateClusterTemplate: StargateClusterTemplate{
+									Size: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.True(t, kc.HasStargates())
+	})
+}

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ const (
 
 var (
 	seedsResolver  = &fakeSeedsResolver{}
-	managementApi  = &fakeManagementApi{}
+	managementApi  = &fakeManagementApiFactory{}
 	controlCluster = fmt.Sprintf(clusterProtoName, 0)
 )
 
@@ -258,9 +259,16 @@ func (r *fakeSeedsResolver) ResolveSeedEndpoints(ctx context.Context, dc *cassdc
 	return r.callback(dc)
 }
 
+type fakeManagementApiFactory struct {
+}
+
+func (f fakeManagementApiFactory) NewManagementApiFacade(ctx context.Context, dc *cassdcapi.CassandraDatacenter, k8sClient client.Client, logger logr.Logger) (cassandra.ManagementApiFacade, error) {
+	return &fakeManagementApi{}, nil
+}
+
 type fakeManagementApi struct {
 }
 
-func (r *fakeManagementApi) CreateKeyspaceIfNotExists(ctx context.Context, dc *cassdcapi.CassandraDatacenter, remoteClient client.Client, keyspaceName string, replicationConfig map[string]int, logger logr.Logger) error {
+func (r *fakeManagementApi) CreateKeyspaceIfNotExists(keyspaceName string, replication map[string]int) error {
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 			Scheme:        mgr.GetScheme(),
 			ClientCache:   clientCache,
 			SeedsResolver: cassandra.NewRemoteSeedsResolver(),
-			ManagementApi: cassandra.NewManagementApiFacade(),
+			ManagementApi: cassandra.NewManagementApiFactory(),
 		}).SetupWithManager(mgr, additionalClusters); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "K8ssandraCluster")
 			os.Exit(1)

--- a/test/framework/traefik.go
+++ b/test/framework/traefik.go
@@ -30,8 +30,8 @@ func (f *E2eFramework) DeployTraefik(t testing.TestingT, namespace string) error
 	valuesFile := filepath.Join("..", "testdata", "ingress", "traefik.values.yaml")
 	for k8sContext := range f.remoteClients {
 		// Delete potential leftovers that could make the release installation fail
-		_ = kubectl.DeleteByName(kubectl.Options{Context: k8sContext}, "ClusterRoleBinding", "traefik")
-		_ = kubectl.DeleteByName(kubectl.Options{Context: k8sContext}, "ClusterRole", "traefik")
+		_ = kubectl.DeleteByName(kubectl.Options{Context: k8sContext}, "ClusterRoleBinding", "traefik", true)
+		_ = kubectl.DeleteByName(kubectl.Options{Context: k8sContext}, "ClusterRole", "traefik", true)
 		options := &helm.Options{KubectlOptions: k8s.NewKubectlOptions(k8sContext, "", namespace)}
 		out, err := helm.RunHelmCommandAndGetOutputE(t, options, "install", "traefik", "traefik/traefik", "--version", "v10.3.2", "-f", valuesFile)
 		if err != nil {

--- a/test/framework/traefik.go
+++ b/test/framework/traefik.go
@@ -8,7 +8,7 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/k8ssandra/k8ssandra-operator/test/kubectl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,14 +17,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	testing2 "testing"
+	"testing"
 	"time"
 )
 
-func (f *E2eFramework) DeployTraefik(t testing.TestingT, namespace string) error {
-	if _, err := helm.RunHelmCommandAndGetOutputE(t, &helm.Options{}, "repo", "add", "traefik", "https://helm.traefik.io/traefik"); err != nil {
+func (f *E2eFramework) DeployTraefik(t *testing.T, namespace string) error {
+	if _, err := helm.RunHelmCommandAndGetOutputE(t, &helm.Options{Logger: logger.Discard}, "repo", "add", "traefik", "https://helm.traefik.io/traefik"); err != nil {
 		return err
-	} else if _, err = helm.RunHelmCommandAndGetOutputE(t, &helm.Options{}, "repo", "update"); err != nil {
+	} else if _, err = helm.RunHelmCommandAndGetOutputE(t, &helm.Options{Logger: logger.Discard}, "repo", "update"); err != nil {
 		return err
 	}
 	valuesFile := filepath.Join("..", "testdata", "ingress", "traefik.values.yaml")
@@ -43,9 +43,9 @@ func (f *E2eFramework) DeployTraefik(t testing.TestingT, namespace string) error
 	return nil
 }
 
-func (f *E2eFramework) UndeployTraefik(t testing.TestingT, namespace string) error {
+func (f *E2eFramework) UndeployTraefik(t *testing.T, namespace string) error {
 	for k8sContext := range f.remoteClients {
-		options := &helm.Options{KubectlOptions: k8s.NewKubectlOptions(k8sContext, "", namespace)}
+		options := &helm.Options{KubectlOptions: k8s.NewKubectlOptions(k8sContext, "", namespace), Logger: logger.Discard}
 		if _, err := helm.RunHelmCommandAndGetOutputE(t, options, "uninstall", "traefik"); err != nil {
 			return err
 		}
@@ -53,7 +53,7 @@ func (f *E2eFramework) UndeployTraefik(t testing.TestingT, namespace string) err
 	return nil
 }
 
-func (f *E2eFramework) DeployStargateIngresses(t *testing2.T, k8sContext string, k8sContextIdx int, namespace, stargateServiceName string) {
+func (f *E2eFramework) DeployStargateIngresses(t *testing.T, k8sContext string, k8sContextIdx int, namespace, stargateServiceName string) {
 	src := filepath.Join("..", "..", "test", "testdata", "ingress", "stargate-ingress.yaml")
 	dir := filepath.Join("..", "..", "build", "test-config", "ingress", k8sContext)
 	dest := filepath.Join(dir, "stargate-ingress.yaml")
@@ -94,7 +94,7 @@ func (f *E2eFramework) DeployStargateIngresses(t *testing2.T, k8sContext string,
 	}, timeout, interval, "Address is unreachable: %s", stargateCql)
 }
 
-func (f *E2eFramework) UndeployStargateIngresses(t *testing2.T, k8sContext, namespace string) {
+func (f *E2eFramework) UndeployStargateIngresses(t *testing.T, k8sContext, namespace string) {
 	options := kubectl.Options{Context: k8sContext, Namespace: namespace}
 	err := kubectl.DeleteAllOf(options, "IngressRoute")
 	assert.NoError(t, err)

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -85,7 +85,7 @@ func Delete(opts Options, arg interface{}) error {
 	return err
 }
 
-func DeleteByName(opts Options, kind, name string) error {
+func DeleteByName(opts Options, kind, name string, ignoreNotFound bool) error {
 	cmd := exec.Command("kubectl")
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
@@ -94,6 +94,9 @@ func DeleteByName(opts Options, kind, name string) error {
 		cmd.Args = append(cmd.Args, "-n", opts.Namespace)
 	}
 	cmd.Args = append(cmd.Args, "delete", kind, name)
+	if ignoreNotFound {
+		cmd.Args = append(cmd.Args, "--ignore-not-found")
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Minor enhancements :

* d6ff94e Only check for Stargate auth keyspace once per cluster
* 47ef2cf Make ManagementApiFacade a request-scoped component
* 91ec4ea Add ignoreNotFound option to kubectl.DeleteByName  (improves logging in e2e tests)
* 90cc984 Make terratest logger log through logr (improves logging in e2e tests)


**Which issue(s) this PR fixes**:
None

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
