### PR TITLE
Add 4.0 tests, remove hardcoded cluster names from tests [K8SSAND-890] [K8SSAND-862] 

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -55,8 +55,11 @@ jobs:
           - CreateStargateAndDatacenter
           - CreateSingleReaper
           - CreateReaperAndDatacenter
+        cassandra_version:
+          - "3.11.11"
+          - "4.0.1"
       fail-fast: false
-    name: ${{ matrix.e2e_test }}
+    name: SingleCluster-${{ matrix.e2e_test }}-${{ matrix.cassandra_version }}
     env:
       GOPATH: /home/runner/go
       GOROOT: /usr/local/go1.16
@@ -107,8 +110,8 @@ jobs:
           docker load --input /tmp/k8ssandra-operator.tar
       - name: Setup kind cluster
         run: make e2e-setup-single
-      - name: Run e2e test ( ${{ matrix.e2e_test }} )
-        run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} e2e-test
+      - name: Run e2e test ( ${{ matrix.e2e_test }}-${{ matrix.cassandra_version }} ) )
+        run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} TEST_ARGS="--cassandraVersion=${{ matrix.cassandra_version }}" e2e-test
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -56,8 +56,11 @@ jobs:
           - CreateMultiStargateAndDatacenter
           - CreateMultiReaper
           - ClusterScoped/MultiDcMultiCluster
+        cassandra_version:
+          - "3.11.11"
+          - "4.0.1"
       fail-fast: false
-    name: ${{ matrix.e2e_test }}
+    name: MultiCluster-${{ matrix.e2e_test }}-${{ matrix.cassandra_version }}
     env:
       GOPATH: /home/runner/go
       GOROOT: /usr/local/go1.16
@@ -108,8 +111,8 @@ jobs:
           docker load --input /tmp/k8ssandra-operator.tar
       - name: Setup kind clusters
         run: make e2e-setup-multi
-      - name: Run e2e test ( ${{ matrix.e2e_test }} )
-        run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} NODETOOL_STATUS_TIMEOUT=2m e2e-test
+      - name: Run e2e test ( ${{ matrix.e2e_test }}-${{ matrix.cassandra_version }} )
+        run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} TEST_ARGS="--cassandraVersion=${{ matrix.cassandra_version }}" NODETOOL_STATUS_TIMEOUT=2m e2e-test
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ifdef E2E_TEST
 	go test -v -timeout 3600s ./test/e2e/... -run="$(E2E_TEST)" -args $(TEST_ARGS)
 else
 	@echo Running e2e tests
-	go test -v -timeout 3600s $(TEST_ARGS) ./test/e2e/...
+	go test -v -timeout 3600s ./test/e2e/... -args $(TEST_ARGS)
 endif
 
 # The e2e-setup-single and e2e-setup-multi targets load the operator image but do not

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -44,11 +44,6 @@ func (c config) MarshalJSON() ([]byte, error) {
 	config := make(map[string]interface{})
 
 	if c.CassandraYaml != nil {
-		if isCassandra4(c.cassandraVersion) {
-			c.StartRpc = nil
-			c.ThriftPreparedStatementCacheSizeMb = nil
-		}
-
 		// Even though we default to Cassandra's stock defaults for num_tokens, we need to
 		// explicitly set it because the config builder defaults to num_tokens: 1
 		if c.NumTokens == nil {

--- a/pkg/cassandra/config_test.go
+++ b/pkg/cassandra/config_test.go
@@ -305,21 +305,6 @@ func TestCreateJsonConfig(t *testing.T) {
             }`,
 		},
 		{
-			name:             "[4.0.0] start_rpc, thrift_prepared_statements_cache_size_mb",
-			cassandraVersion: "4.0.0",
-			config: &api.CassandraConfig{
-				CassandraYaml: &api.CassandraYaml{
-					StartRpc:                           boolPtr(false),
-					ThriftPreparedStatementCacheSizeMb: intPtr(1),
-				},
-			},
-			want: `{
-              "cassandra-yaml": {
-				"num_tokens": 16
-              }
-            }`,
-		},
-		{
 			name:             "[3.11.11] num_tokens",
 			cassandraVersion: "3.11.11",
 			config: &api.CassandraConfig{

--- a/test/e2e/stargate_apis_test.go
+++ b/test/e2e/stargate_apis_test.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/datastax/go-cassandra-native-protocol/client"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
@@ -12,11 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/resty.v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"net/http"
-	neturl "net/url"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func testStargateApis(t *testing.T, ctx context.Context, k8sContextName string, k8sContextIdx int, username string, password string, replication map[string]int) {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -91,13 +91,12 @@ func (k ClusterKey) String() string {
 	return k.K8sContext + string(types.Separator) + k.Namespace + string(types.Separator) + k.Name
 }
 
-func NewFramework(client client.Client, controlPlanContext string, remoteClients map[string]client.Client) *Framework {
-	var log logr.Logger
-	log = logrusr.NewLogger(logrus.New())
+func NewFramework(client client.Client, controlPlaneContext string, remoteClients map[string]client.Client) *Framework {
+	log := logrusr.NewLogger(logrus.New())
 	terratestlogger.Default = terratestlogger.New(&terratestLoggerBridge{logger: log})
 
 	// TODO ControlPlaneContext should default to the first context in the kubeconfig file. We should also provide a flag to override it.
-	return &Framework{Client: client, ControlPlaneContext: controlPlanContext, remoteClients: remoteClients, logger: log}
+	return &Framework{Client: client, ControlPlaneContext: controlPlaneContext, remoteClients: remoteClients, logger: log}
 }
 
 // Get fetches the object specified by key from the cluster specified by key. An error is
@@ -202,7 +201,7 @@ func (f *Framework) PatchReaperStatus(ctx context.Context, key ClusterKey, updat
 // remote clusters.
 func (f *Framework) WaitForDeploymentToBeReady(key ClusterKey, timeout, interval time.Duration) error {
 	return wait.Poll(interval, timeout, func() (bool, error) {
-		if len(key.K8sContext) == 0 {
+		if key.K8sContext == "" {
 			for _, remoteClient := range f.remoteClients {
 				deployment := &appsv1.Deployment{}
 				if err := remoteClient.Get(context.TODO(), key.NamespacedName, deployment); err != nil {

--- a/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   cassandra:
     cluster: test
-    serverVersion: "3.11.11"
+    serverVersion: ${CASSANDRA_VERSION}
     storageConfig:
       cassandraDataVolumeClaimSpec:
         storageClassName: standard
@@ -30,9 +30,7 @@ spec:
         compaction_throughput_mb_per_sec: 0
         sstable_preemptive_open_interval_in_mb: 0
         key_cache_size_in_mb: 0
-        thrift_prepared_statements_cache_size_mb: 1
         prepared_statements_cache_size_mb: 1
-        start_rpc: false
         slow_query_log_timeout_in_ms: 0
         counter_cache_size_in_mb: 0
         concurrent_reads: 2
@@ -48,11 +46,11 @@ spec:
     datacenters:
       - metadata:
           name: dc1
-        k8sContext: kind-k8ssandra-0
+        k8sContext: ${CONTROL_PLANE_CONTEXT}
         size: 2
       - metadata:
           name: dc2
-        k8sContext: kind-k8ssandra-1
+        k8sContext: ${DATA_PLANE_CONTEXT_0}
         size: 2
   stargate:
     size: 1

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   cassandra:
     cluster: test
-    serverVersion: "3.11.11"
+    serverVersion: ${CASSANDRA_VERSION}
     storageConfig:
       cassandraDataVolumeClaimSpec:
         storageClassName: standard
@@ -33,9 +33,7 @@ spec:
         compaction_throughput_mb_per_sec: 0
         sstable_preemptive_open_interval_in_mb: 0
         key_cache_size_in_mb: 0
-        thrift_prepared_statements_cache_size_mb: 1
         prepared_statements_cache_size_mb: 1
-        start_rpc: false
         slow_query_log_timeout_in_ms: 0
         counter_cache_size_in_mb: 0
         concurrent_reads: 2
@@ -51,9 +49,9 @@ spec:
     datacenters:
       - metadata:
           name: dc1
-        k8sContext: kind-k8ssandra-0
+        k8sContext: ${CONTROL_PLANE_CONTEXT}
         size: 3
       - metadata:
           name: dc2
-        k8sContext: kind-k8ssandra-1
+        k8sContext: ${DATA_PLANE_CONTEXT_0}
         size: 3

--- a/test/testdata/fixtures/multi-stargate/3.11.x/cassdc.yaml
+++ b/test/testdata/fixtures/multi-stargate/3.11.x/cassdc.yaml
@@ -19,8 +19,6 @@ spec:
       prepared_statements_cache_size_mb: 1
       slow_query_log_timeout_in_ms: 0
       sstable_preemptive_open_interval_in_mb: 0
-      start_rpc: false
-      thrift_prepared_statements_cache_size_mb: 1
     jvm-options:
       additional-jvm-opts:
         - -Dcassandra.system_distributed_replication_dc_names=dc1
@@ -31,7 +29,7 @@ spec:
     limits:
       memory: 800Mi
   serverType: cassandra
-  serverVersion: 3.11.11
+  serverVersion: ${CASSANDRA_VERSION}
   networking:
     hostNetwork: false
   size: 3

--- a/test/testdata/fixtures/multi-stargate/4.0.x/cassdc.yaml
+++ b/test/testdata/fixtures/multi-stargate/4.0.x/cassdc.yaml
@@ -19,9 +19,7 @@ spec:
       prepared_statements_cache_size_mb: 1
       slow_query_log_timeout_in_ms: 0
       sstable_preemptive_open_interval_in_mb: 0
-      start_rpc: false
-      thrift_prepared_statements_cache_size_mb: 1
-    jvm-options:
+    jvm-server-options:
       additional-jvm-opts:
         - -Dcassandra.system_distributed_replication_dc_names=dc1
         - -Dcassandra.system_distributed_replication_per_dc=1
@@ -31,7 +29,7 @@ spec:
     limits:
       memory: 800Mi
   serverType: cassandra
-  serverVersion: 3.11.11
+  serverVersion: ${CASSANDRA_VERSION}
   networking:
     hostNetwork: false
   size: 3

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -5,11 +5,10 @@ metadata:
 spec:
   cassandra:
     cluster: test
-    serverVersion: "3.11.11"
+    serverVersion: ${CASSANDRA_VERSION}
     datacenters:
       - metadata:
           name: dc1
-        k8sContext: kind-k8ssandra-0
         size: 1
         storageConfig:
           cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/stargate/3.11.x/cassdc.yaml
+++ b/test/testdata/fixtures/stargate/3.11.x/cassdc.yaml
@@ -1,0 +1,53 @@
+apiVersion: cassandra.datastax.com/v1beta1
+kind: CassandraDatacenter
+metadata:
+  name: dc1
+spec:
+  clusterName: test
+  config:
+    cassandra-yaml:
+      auto_snapshot: false
+      commitlog_segment_size_in_mb: 2
+      compaction_throughput_mb_per_sec: 0
+      concurrent_compactors: 1
+      concurrent_counter_writes: 2
+      concurrent_reads: 2
+      concurrent_writes: 2
+      counter_cache_size_in_mb: 0
+      key_cache_size_in_mb: 0
+      memtable_flush_writers: 1
+      prepared_statements_cache_size_mb: 1
+      slow_query_log_timeout_in_ms: 0
+      sstable_preemptive_open_interval_in_mb: 0
+    jvm-options:
+      additional-jvm-opts:
+        - -Dcassandra.system_distributed_replication_dc_names=dc1
+        - -Dcassandra.system_distributed_replication_per_dc=1
+      initial_heap_size: 512m
+      max_heap_size: 512m
+  resources:
+    limits:
+      memory: 800Mi
+  serverType: cassandra
+  serverVersion: ${CASSANDRA_VERSION}
+  networking:
+    hostNetwork: false
+  size: 3
+  racks:
+    - name: rack1
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack1
+    - name: rack2
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack2
+    - name: rack3
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack3
+  storageConfig:
+    cassandraDataVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: standard

--- a/test/testdata/fixtures/stargate/4.0.x/cassdc.yaml
+++ b/test/testdata/fixtures/stargate/4.0.x/cassdc.yaml
@@ -1,0 +1,53 @@
+apiVersion: cassandra.datastax.com/v1beta1
+kind: CassandraDatacenter
+metadata:
+  name: dc1
+spec:
+  clusterName: test
+  config:
+    cassandra-yaml:
+      auto_snapshot: false
+      commitlog_segment_size_in_mb: 2
+      compaction_throughput_mb_per_sec: 0
+      concurrent_compactors: 1
+      concurrent_counter_writes: 2
+      concurrent_reads: 2
+      concurrent_writes: 2
+      counter_cache_size_in_mb: 0
+      key_cache_size_in_mb: 0
+      memtable_flush_writers: 1
+      prepared_statements_cache_size_mb: 1
+      slow_query_log_timeout_in_ms: 0
+      sstable_preemptive_open_interval_in_mb: 0
+    jvm-options:
+      additional-jvm-opts:
+        - -Dcassandra.system_distributed_replication_dc_names=dc1
+        - -Dcassandra.system_distributed_replication_per_dc=1
+      initial_heap_size: 512m
+      max_heap_size: 512m
+  resources:
+    limits:
+      memory: 800Mi
+  serverType: cassandra
+  serverVersion: ${CASSANDRA_VERSION}
+  networking:
+    hostNetwork: false
+  size: 3
+  racks:
+    - name: rack1
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack1
+    - name: rack2
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack2
+    - name: rack3
+      nodeAffinityLabels:
+        "topology.kubernetes.io/zone": rack3
+  storageConfig:
+    cassandraDataVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: standard


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Substitutes certain parameters, such as cassandraVersion, controlPlane and dataPlane clusters to avoid hardcoded values. Adds tests against different versions of Cassandra also.

**Which issue(s) this PR fixes**:
Fixes #112
Fixes #130


**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
