### PR TITLE
Use the correct kubeconfigs in e2e tests

### DIFF
--- a/scripts/create-clientconfig.sh
+++ b/scripts/create-clientconfig.sh
@@ -14,7 +14,7 @@
 # TODO Accept multiple values for the src-context option and generate a kubeconfig with
 #      entries for each
 
-set -ex
+set -e
 
 getopt_version=$(getopt -V)
 if [[ "$getopt_version" == " --" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes the `DeployK8sClientConfigs` function in `e2e_framework.go` to call the `create-clientconfig.sh` script for each cluster. By doing this the operator will create remote clients with correctly configured RBAC.

**Which issue(s) this PR fixes**:
Fixes #127

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
