### PR TITLE
Ignore the docs and CHANGELOG directories for our workflows

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
 jobs:
   build_image:
     name: Build Image

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
 jobs:
   build_image:
     name: Build Image

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
 jobs:
   scan-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG/**'
 jobs:
   unit_integration_tests:
     name: Run unit/integration tests


### PR DESCRIPTION
**What this PR does**:

Configure the workflows so that we don't run tests when making changes to in-tree docs and changelogs.

I tested the settings here with a series of PRs in my fork to make sure it was behaving as expected -- I wasn't totally sure of the syntax to start.

I was able to confirm:

* A PR and/or merge to main with changes only in /docs does not trigger any workflows
* A PR and/or merge to main with changes only in /CHANGELOG does not trigger any workflows
* A PR and/or merge to main with changes only in /CHANGELOG does not trigger any workflows
* A PR and/or merge to main with changes only outside of /docs and /CHANGELOG triggers all expected workflows
* A PR and/or merge to main with changes both inside and outside of /docs and /CHANGELOG triggers all expected workflows

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
