### PR TITLE
bump default version for stargate

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -31,5 +31,5 @@ const (
 	// controller. The label value is the Deployment name.
 	StargateDeploymentLabel = "k8ssandra.io/stargate-deployment"
 
-	DefaultStargateVersion = "1.0.31"
+	DefaultStargateVersion = "1.0.36"
 )

--- a/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
@@ -56,13 +56,6 @@ spec:
         size: 2
   stargate:
     size: 1
-    stargateContainerImage:
-      registry: docker.io
-      # Temporarily use a custom image that includes
-      # https://github.com/stargate/stargate/pull/1300 until there is an updated, official
-      # Stargate image with these changes.
-      repository: jsanda/stargate-3_11
-      tag: bc73a29a
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/testdata/fixtures/multi-stargate/stargate.yaml
+++ b/test/testdata/fixtures/multi-stargate/stargate.yaml
@@ -3,13 +3,6 @@ kind: Stargate
 metadata:
   name: s1
 spec:
-  stargateContainerImage:
-    registry: docker.io
-    # Temporarily use a custom image that includes
-    # https://github.com/stargate/stargate/pull/1300 until there is an updated, official
-    # Stargate image with these changes.
-    repository: jsanda/stargate-3_11
-    tag: bc73a29a
   datacenterRef:
     name: dc1
   size: 3

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -23,13 +23,6 @@ spec:
           jvmOptions:
             heapSize: 384Mi
         stargate:
-          stargateContainerImage:
-            # Temporarily use a custom image that includes
-            # https://github.com/stargate/stargate/pull/1300 until there is an updated, official
-            # Stargate image with these changes.
-            registry: docker.io
-            repository: jsanda/stargate-3_11
-            tag: bc73a29a
           size: 1
           heapSize: 384Mi
           livenessProbe:


### PR DESCRIPTION
The 1.0.36 images include https://github.com/stargate/stargate/pull/1300 which
is needed for e2e tests.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates default version of Stargate to 1.0.36 and removes the custom images that were being used in tests.

**Which issue(s) this PR fixes**:
Fixes #192

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
