### PR TITLE
Use cass-config-builder for Stargate deployments

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -14,6 +14,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## Unreleased
 
+[CHANGE] [#189](https://github.com/k8ssandra/k8ssandra-operator/issues/189) Use cass-config-builder with Stargate deployment
+
 ## v1.0.0-alpha.1 - 2021-09-30
 
 [FEATURE] [#98](https://github.com/k8ssandra/k8ssandra-operator/issues/98) Create Helm chart for the operator

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -44,11 +44,6 @@ func (c config) MarshalJSON() ([]byte, error) {
 	config := make(map[string]interface{}, 0)
 
 	if c.CassandraYaml != nil {
-		if isCassandra4(c.cassandraVersion) {
-			c.StartRpc = nil
-			c.ThriftPreparedStatementCacheSizeMb = nil
-		}
-
 		// Even though we default to Cassandra's stock defaults for num_tokens, we need to
 		// explicitly set it because the config builder defaults to num_tokens: 1
 		if c.NumTokens == nil {

--- a/pkg/cassandra/config_test.go
+++ b/pkg/cassandra/config_test.go
@@ -1,12 +1,13 @@
 package cassandra
 
 import (
+	"testing"
+
 	"github.com/Jeffail/gabs"
 	api "github.com/k8ssandra/k8ssandra-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"testing"
 )
 
 func TestApplySystemReplication(t *testing.T) {
@@ -300,21 +301,6 @@ func TestCreateJsonConfig(t *testing.T) {
 				"num_tokens": 256,
                 "start_rpc": false,
                 "thrift_prepared_statements_cache_size_mb": 1
-              }
-            }`,
-		},
-		{
-			name:             "[4.0.0] start_rpc, thrift_prepared_statements_cache_size_mb",
-			cassandraVersion: "4.0.0",
-			config: &api.CassandraConfig{
-				CassandraYaml: &api.CassandraYaml{
-					StartRpc:                           boolPtr(false),
-					ThriftPreparedStatementCacheSizeMb: intPtr(1),
-				},
-			},
-			want: `{
-              "cassandra-yaml": {
-				"num_tokens": 16
               }
             }`,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
When Stargate deployment sets the CassandraConfigRefMap, the configuration should be ran through cass-config-builder to ensure it is correctly parsed and invalid fields are removed.

**Which issue(s) this PR fixes**:
Fixes #189 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
