### PR TITLE
set superuser secret name in CassandraDatacenters

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -14,7 +14,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## Unreleased
 
-[CHANGE] Update cass-operator to v1.8.0
+* [CHANGE] [#182](https://github.com/k8ssandra/k8ssandra-operator/pull/182) Update cass-operator to v1.8.0
+* [BUGFIX] [#203](https://github.com/k8ssandra/k8ssandra-operator/issues/203) Superuser secret name not set on CassandraDatacenters
 
 ## v1.0.0-alpha.1 - 2021-09-30
 

--- a/api/v1alpha1/k8ssandracluster_types.go
+++ b/api/v1alpha1/k8ssandracluster_types.go
@@ -102,7 +102,7 @@ type CassandraClusterTemplate struct {
 	Cluster string `json:"cluster,omitempty"`
 
 	// SuperuserSecretName allows to override the default super user secret
-	SuperuserSecretName string `json:"superUserSecret,omitempty"`
+	SuperuserSecretName string `json:"superuserSecret,omitempty"`
 
 	// ServerImage is the image for the cassandra container. Note that this should be a
 	// management-api image. If left empty the operator will choose a default image based

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -4188,7 +4188,7 @@ spec:
                             type: string
                         type: object
                     type: object
-                  superUserSecret:
+                  superuserSecret:
                     description: SuperuserSecretName allows to override the default
                       super user secret
                     type: string

--- a/controllers/k8ssandracluster_controller.go
+++ b/controllers/k8ssandracluster_controller.go
@@ -107,7 +107,11 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 	}
 
 	if kc.Spec.Cassandra.SuperuserSecretName == "" {
+		// Note that we do not persist this change because doing so would prevent us from
+		// differentiating between a default secret by the operator vs one provided by the
+		// client that happens to have the same name as the default name.
 		kc.Spec.Cassandra.SuperuserSecretName = secret.DefaultSuperuserSecretName(kc.Spec.Cassandra.Cluster)
+		kcLogger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretName)
 	}
 
 	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, kc.Spec.Cassandra.Cluster, kc.Namespace, replicationTargets); err != nil {

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -26,18 +26,19 @@ type SystemReplication struct {
 // to be specified at the DC-level. Using a DatacenterConfig allows to keep the api types
 // clean such that cluster-level settings won't leak into the dc-level settings.
 type DatacenterConfig struct {
-	Meta              api.EmbeddedObjectMeta
-	Cluster           string
-	ServerImage       string
-	ServerVersion     string
-	Size              int32
-	Resources         *corev1.ResourceRequirements
-	SystemReplication SystemReplication
-	StorageConfig     *cassdcapi.StorageConfig
-	Racks             []cassdcapi.Rack
-	CassandraConfig   *api.CassandraConfig
-	AdditionalSeeds   []string
-	Networking        *cassdcapi.NetworkingConfig
+	Meta                api.EmbeddedObjectMeta
+	Cluster             string
+	SuperUserSecretName string
+	ServerImage         string
+	ServerVersion       string
+	Size                int32
+	Resources           *corev1.ResourceRequirements
+	SystemReplication   SystemReplication
+	StorageConfig       *cassdcapi.StorageConfig
+	Racks               []cassdcapi.Rack
+	CassandraConfig     *api.CassandraConfig
+	AdditionalSeeds     []string
+	Networking          *cassdcapi.NetworkingConfig
 }
 
 func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) (*cassdcapi.CassandraDatacenter, error) {
@@ -65,16 +66,17 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 			},
 		},
 		Spec: cassdcapi.CassandraDatacenterSpec{
-			ClusterName:     template.Cluster,
-			ServerImage:     template.ServerImage,
-			Size:            template.Size,
-			ServerType:      "cassandra",
-			ServerVersion:   template.ServerVersion,
-			Config:          rawConfig,
-			Racks:           template.Racks,
-			StorageConfig:   *template.StorageConfig,
-			AdditionalSeeds: template.AdditionalSeeds,
-			Networking:      template.Networking,
+			ClusterName:         template.Cluster,
+			ServerImage:         template.ServerImage,
+			SuperuserSecretName: template.SuperUserSecretName,
+			Size:                template.Size,
+			ServerType:          "cassandra",
+			ServerVersion:       template.ServerVersion,
+			Config:              rawConfig,
+			Racks:               template.Racks,
+			StorageConfig:       *template.StorageConfig,
+			AdditionalSeeds:     template.AdditionalSeeds,
+			Networking:          template.Networking,
 		},
 	}
 
@@ -92,6 +94,7 @@ func Coalesce(clusterTemplate *api.CassandraClusterTemplate, dcTemplate *api.Cas
 
 	// Handler cluster-wide settings first
 	dcConfig.Cluster = clusterTemplate.Cluster
+	dcConfig.SuperUserSecretName = clusterTemplate.SuperuserSecretName
 
 	// DC-level settings
 	dcConfig.Meta = dcTemplate.Meta

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -28,10 +28,11 @@ func TestCoalesce(t *testing.T) {
 	tests := []test{
 		{
 			// There are some properties that should only be set at the cluster-level
-			// and should not differ among DCs. Cluster name is a good example.
+			// and should not differ among DCs.
 			name: "Set non-override configs",
 			clusterTemplate: &api.CassandraClusterTemplate{
-				Cluster: "k8ssandra",
+				Cluster:             "k8ssandra",
+				SuperuserSecretName: "test-superuser",
 			},
 			dcTemplate: &api.CassandraDatacenterTemplate{
 				Meta: api.EmbeddedObjectMeta{
@@ -52,7 +53,8 @@ func TestCoalesce(t *testing.T) {
 						"env": "dev",
 					},
 				},
-				Size: 3,
+				SuperUserSecretName: "test-superuser",
+				Size:                3,
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Propagate the `SuperuserSecretName` to CassandraDatacenters
* Update unit tests
* Update integration tests to verify the default secret is created
* Change json property name from superUserSecret to superuserSecret

**Which issue(s) this PR fixes**:
Fixes #203

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
