### PR TITLE
Refactor seeds handling

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## Unreleased
 
 * [CHANGE] [#182](https://github.com/k8ssandra/k8ssandra-operator/pull/182) Update cass-operator to v1.8.0
+* [FEATURE] [#15](https://github.com/k8ssandra/k8ssandra-operator/pull/15) Add finalizer for K8ssandraCluster
 * [BUGFIX] [#203](https://github.com/k8ssandra/k8ssandra-operator/issues/203) Superuser secret name not set on CassandraDatacenters
 
 ## v1.0.0-alpha.1 - 2021-09-30

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - secrets
   verbs:

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -88,11 +88,12 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	kc = kc.DeepCopy()
 	patch := client.MergeFromWithOptions(kc.DeepCopy())
 	result, err := r.reconcile(ctx, kc, logger)
-	// TODO Don't patch the status if the K8ssandraCluster was deleted
-	if patchErr := r.Status().Patch(ctx, kc, patch); patchErr != nil {
-		logger.Error(patchErr, "failed to update k8ssandracluster status")
-	} else {
-		logger.Info("updated k8ssandracluster status")
+	if kc.GetDeletionTimestamp() == nil {
+		if patchErr := r.Status().Patch(ctx, kc, patch); patchErr != nil {
+			logger.Error(patchErr, "failed to update k8ssandracluster status")
+		} else {
+			logger.Info("updated k8ssandracluster status")
+		}
 	}
 	return result, err
 }

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -141,7 +141,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 				api.CreatedByLabel:        api.CreatedByLabelValueK8ssandraClusterController,
 				api.K8ssandraClusterLabel: kc.Name,
 			}
-			stargateList := &api.StargateList{}
+			stargateList := &stargateapi.StargateList{}
 			options := client.ListOptions{
 				Namespace:     namespace,
 				LabelSelector: labels.SelectorFromSet(selector),
@@ -167,7 +167,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 		}
 
 		if hasErrors {
-			return ctrl.Result{RequeueAfter: defaultDelay}, nil
+			return ctrl.Result{RequeueAfter: r.DefaultDelay}, nil
 		}
 
 		patch := client.MergeFrom(kc.DeepCopy())

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -19,7 +19,9 @@ package k8ssandra
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"math"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sort"
 
 	"github.com/go-logr/logr"
@@ -49,7 +51,8 @@ import (
 )
 
 const (
-	stargateAuthKeyspace = "data_endpoint_auth"
+	stargateAuthKeyspace      = "data_endpoint_auth"
+	k8ssandraClusterFinalizer = "k8ssandracluster.k8ssandra.io/finalizer"
 )
 
 // K8ssandraClusterReconciler reconciles a K8ssandraCluster object
@@ -85,6 +88,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	kc = kc.DeepCopy()
 	patch := client.MergeFromWithOptions(kc.DeepCopy())
 	result, err := r.reconcile(ctx, kc, logger)
+	// TODO Don't patch the status if the K8ssandraCluster was deleted
 	if patchErr := r.Status().Patch(ctx, kc, patch); patchErr != nil {
 		logger.Error(patchErr, "failed to update k8ssandracluster status")
 	} else {
@@ -94,22 +98,104 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ssandraCluster, kcLogger logr.Logger) (ctrl.Result, error) {
+	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
+
+	if kc.DeletionTimestamp != nil {
+		if !controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
+			return ctrl.Result{}, nil
+		}
+
+		kcLogger.Info("Starting deletion")
+
+		hasErrors := false
+
+		for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+			namespace := dcTemplate.Meta.Namespace
+			if namespace == "" {
+				namespace = kc.Namespace
+			}
+			dcKey := client.ObjectKey{Namespace: namespace, Name: dcTemplate.Meta.Name}
+
+			remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+			if err != nil {
+				kcLogger.Error(err, "Failed to get remote client", "Context", dcTemplate.K8sContext)
+				hasErrors = true
+				continue
+			}
+
+			dc := &cassdcapi.CassandraDatacenter{}
+			err = remoteClient.Get(ctx, dcKey, dc)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					kcLogger.Error(err, "Failed to get CassandraDatacenter for deletion",
+						"CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+					hasErrors = true
+				}
+			} else if err = remoteClient.Delete(ctx, dc); err != nil {
+				kcLogger.Error(err, "Failed to delete CassandraDatacenter", "CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+				hasErrors = true
+			}
+
+			selector := map[string]string{
+				api.CreatedByLabel:        api.CreatedByLabelValueK8ssandraClusterController,
+				api.K8ssandraClusterLabel: kc.Name,
+			}
+			stargateList := &api.StargateList{}
+			options := client.ListOptions{
+				Namespace:     namespace,
+				LabelSelector: labels.SelectorFromSet(selector),
+			}
+
+			err = remoteClient.List(ctx, stargateList, &options)
+			if err != nil {
+				kcLogger.Error(err, "Failed to list Stargate objects", "Context", dcTemplate.K8sContext)
+				hasErrors = true
+				continue
+			}
+
+			for _, sg := range stargateList.Items {
+				if err = remoteClient.Delete(ctx, &sg); err != nil {
+					key := client.ObjectKey{Namespace: namespace, Name: sg.Name}
+					if !errors.IsNotFound(err) {
+						kcLogger.Error(err, "Failed to delete Stargate", "Stargate", key,
+							"Context", dcTemplate.K8sContext)
+						hasErrors = true
+					}
+				}
+			}
+		}
+
+		if hasErrors {
+			return ctrl.Result{RequeueAfter: defaultDelay}, nil
+		}
+
+		patch := client.MergeFrom(kc.DeepCopy())
+		kc.SetFinalizers(nil)
+		if err := r.Client.Patch(ctx, kc, patch); err != nil {
+			kcLogger.Error(err, "Failed to remove finalizer")
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
+		patch := client.MergeFrom(kc.DeepCopy())
+		controllerutil.AddFinalizer(kc, k8ssandraClusterFinalizer)
+		if err := r.Client.Patch(ctx, kc, patch); err != nil {
+			kcLogger.Error(err, "Failed to add finalizer")
+			return ctrl.Result{}, err
+		}
+	}
+
 	if kc.Spec.Cassandra == nil {
 		// TODO handle the scenario of CassandraClusterTemplate being set to nil after having a non-nil value
 		return ctrl.Result{}, nil
 	}
 
-	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
 	var seeds []string
 
 	// Reconcile the ReplicatedSecret and superuserSecret first (otherwise CassandraDatacenter will not start)
-	replicationTargets := make([]string, 0, len(kc.Spec.Cassandra.Datacenters))
-	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
-		if dcTemplate.K8sContext != "" {
-			replicationTargets = append(replicationTargets, dcTemplate.K8sContext)
-		}
-	}
-
 	if kc.Spec.Cassandra.SuperuserSecretName == "" {
 		// Note that we do not persist this change because doing so would prevent us from
 		// differentiating between a default secret by the operator vs one provided by the
@@ -118,7 +204,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 		kcLogger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretName)
 	}
 
-	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, kc.Spec.Cassandra.Cluster, kc.Namespace, replicationTargets); err != nil {
+	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, r.Scheme, kc, kcLogger); err != nil {
 		kcLogger.Error(err, "Failed to reconcile ReplicatedSecret")
 		return ctrl.Result{}, err
 	}
@@ -254,6 +340,82 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 	kcLogger.Info("Finished reconciling the k8ssandracluster")
 	return ctrl.Result{}, nil
 }
+
+//func (r *K8ssandraClusterReconciler) reconcileDeletion(ctx context.Context, kluster *api.K8ssandraCluster, logger logr.Logger) (ctrl.Result, error) {
+//	if kluster.DeletionTimestamp != nil {
+//		if !controllerutil.ContainsFinalizer(kluster, k8ssandraClusterFinalizer) {
+//			return ctrl.Result{}, nil
+//		}
+//
+//		logger.Info("Starting deletion")
+//
+//		hasErrors := false
+//
+//		for _, dcTemplate := range kluster.Spec.Cassandra.Datacenters {
+//			namespace := dcTemplate.Meta.Namespace
+//			if namespace == "" {
+//				namespace = kluster.Namespace
+//			}
+//			dcKey := client.ObjectKey{Namespace: namespace, Name: dcTemplate.Meta.Name}
+//
+//			remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+//			if err != nil {
+//				logger.Error(err, "Failed to get remote client", "Context", dcTemplate.K8sContext)
+//				hasErrors = true
+//				continue
+//			}
+//
+//			dc := &cassdcapi.CassandraDatacenter{}
+//			err = remoteClient.Get(ctx, dcKey, dc)
+//			if err != nil {
+//				logger.Error(err, "Failed to get CassandraDatacenter for deletion", "CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+//				hasErrors = true
+//			}
+//
+//			if err = remoteClient.Delete(ctx, dc); err != nil {
+//				logger.Error(err, "Failed to delete CassandraDatacenter", "CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+//				hasErrors = true
+//			}
+//
+//			selector := map[string]string{
+//				api.CreatedByLabel:        api.CreatedByLabelValueK8ssandraClusterController,
+//				api.K8ssandraClusterLabel: kluster.Name,
+//			}
+//			stargateList := &api.StargateList{}
+//			options := client.ListOptions{
+//				Namespace:     namespace,
+//				LabelSelector: labels.SelectorFromSet(selector),
+//			}
+//
+//			err = remoteClient.List(ctx, stargateList, &options)
+//			if err != nil {
+//				logger.Error(err, "Failed to list Stargate objects", "Context", dcTemplate.K8sContext)
+//				hasErrors = true
+//				continue
+//			}
+//
+//			for _, sg := range stargateList.Items {
+//				if err = remoteClient.Delete(ctx, &sg); err != nil {
+//					key := client.ObjectKey{Namespace: namespace, Name: sg.Name}
+//					logger.Error(err, "Failed to delete Stargate", "Stargate", key, "Context", dcTemplate.K8sContext)
+//					hasErrors = true
+//				}
+//			}
+//		}
+//
+//		if hasErrors {
+//			return ctrl.Result{RequeueAfter: defaultDelay}, nil
+//		}
+//
+//		patch := client.MergeFrom(kluster.DeepCopy())
+//		kluster.SetFinalizers(nil)
+//		if err := r.Client.Patch(ctx, kluster, patch); err != nil {
+//			logger.Error(err, "Failed to remove finalizer")
+//			return ctrl.Result{}, err
+//		}
+//	}
+//	return ctrl.Result{}, nil
+//}
 
 func (r *K8ssandraClusterReconciler) reconcileStargate(
 	ctx context.Context,

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -72,6 +72,7 @@ type K8ssandraClusterReconciler struct {
 // +kubebuilder:rbac:groups=cassandra.datastax.com,namespace="k8ssandra",resources=cassandradatacenters,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=stargate.k8ssandra.io,namespace="k8ssandra",resources=stargates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=pods;secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=endpoints,verbs=get;list;watch;create;update;patch;delete
 
 func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("K8ssandraCluster", req.NamespacedName)
@@ -194,7 +195,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 		return ctrl.Result{}, nil
 	}
 
-	var seeds []string
+	//var seeds []string
 
 	// Reconcile the ReplicatedSecret and superuserSecret first (otherwise CassandraDatacenter will not start)
 	if kc.Spec.Cassandra.SuperuserSecretName == "" {
@@ -218,6 +219,13 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 	systemReplication := cassandra.ComputeSystemReplication(kc)
 
 	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
+
+	seeds, err := r.findSeeds(ctx, kc, kcLogger)
+	if err != nil {
+		kcLogger.Error(err, "Failed to find seed nodes")
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile CassandraDatacenter objects only
 	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
@@ -229,7 +237,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 			// if we're not running Cassandra 3.11 and have Stargate pods, we need to allow alter RF during range movements
 			cassandra.AllowAlterRfDuringRangeMovement(dcConfig)
 		}
-		dcConfig.AdditionalSeeds = seeds
+		//dcConfig.AdditionalSeeds = seeds
 		desiredDc, err := cassandra.NewDatacenter(kcKey, dcConfig)
 		dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
 		logger := kcLogger.WithValues("CassandraDatacenter", dcKey)
@@ -248,6 +256,49 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+
+		// reconcile seeds
+
+		if len(seeds) > 0 {
+			desiredEndpoints := newEndpoints(desiredDc, seeds)
+			actualEndpoints := &corev1.Endpoints{}
+			endpointsKey := client.ObjectKey{Namespace: desiredEndpoints.Namespace, Name: desiredEndpoints.Name}
+
+			if err = remoteClient.Get(ctx, endpointsKey, actualEndpoints); err == nil {
+				if actualHash, found := actualDc.Annotations[api.ResourceHashAnnotation]; !(found && actualHash == desiredDcHash) {
+					logger.Info("Updating Endpoints", "K8SContext", dcTemplate.K8sContext, "CassandraDatacenter", dcKey, "Endpoints", endpointsKey)
+					actualEndpoints := actualEndpoints.DeepCopy()
+					resourceVersion := actualEndpoints.GetResourceVersion()
+					desiredEndpoints.DeepCopyInto(actualEndpoints)
+					actualEndpoints.SetResourceVersion(resourceVersion)
+					if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
+						logger.Error(err, "Failed to update Endpoints",
+							"K8SContext", dcTemplate.K8sContext,
+							"CassandraDatacenter", dcKey,
+							"Endpoints", endpointsKey)
+						return ctrl.Result{}, err
+					}
+				}
+			} else {
+				if errors.IsNotFound(err) {
+					if err = remoteClient.Create(ctx, desiredEndpoints); err != nil {
+						logger.Error(err, "Failed to create Endpoints",
+							"K8SContext", dcTemplate.K8sContext,
+							"CassandraDatacenter", dcKey,
+							"Endpoints", endpointsKey)
+						return ctrl.Result{}, err
+					}
+				} else {
+					logger.Error(err, "Failed to get Endpoints",
+						"K8SContext", dcTemplate.K8sContext,
+						"CassandraDatacenter", dcKey,
+						"Endpoints", endpointsKey)
+					return ctrl.Result{}, err
+				}
+			}
+		}
+
+		// end reconcile seeds
 
 		if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
 			// cassdc already exists, we'll update it
@@ -283,26 +334,6 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 
 			logger.Info("The datacenter is ready")
 
-			endpoints, err := r.SeedsResolver.ResolveSeedEndpoints(ctx, actualDc, remoteClient)
-			if err != nil {
-				logger.Error(err, "Failed to resolve seed endpoints")
-				return ctrl.Result{}, err
-			}
-
-			// The following code will update the AdditionalSeeds property for the
-			// datacenters. We will wind up having endpoints from every DC listed in
-			// the AdditionalSeeds property. We really want to exclude the seeds from
-			// the current DC. It is not a major concern right now as this is a short-term
-			// solution for handling seed addresses.
-			seeds = addSeedEndpoints(seeds, endpoints...)
-
-			// Temporarily do not update seeds on existing dcs. SEE
-			// https://github.com/k8ssandra/k8ssandra-operator/issues/67.
-			// logger.Info("Updating seeds", "Seeds", seeds)
-			// if err = r.updateAdditionalSeeds(ctx, kc, seeds, 0, i); err != nil {
-			//	logger.Error(err, "Failed to update seeds")
-			//	return ctrl.Result{}, err
-			// }
 			actualDcs = append(actualDcs, actualDc)
 		} else {
 			if errors.IsNotFound(err) {
@@ -646,6 +677,73 @@ func (r *K8ssandraClusterReconciler) removeStargateStatus(kc *api.K8ssandraClust
 			Cassandra: kdcStatus.Cassandra.DeepCopy(),
 		}
 	}
+}
+
+func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) ([]corev1.Pod, error) {
+	pods := make([]corev1.Pod, 0)
+
+	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+		remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+		if err != nil {
+			logger.Error(err, "Failed to get remote client", "K8sContext", dcTemplate.K8sContext)
+			return nil, err
+		}
+
+		namespace := kc.Namespace
+		if dcTemplate.Meta.Namespace != "" {
+			namespace = dcTemplate.Meta.Namespace
+		}
+
+		list := &corev1.PodList{}
+		selector := map[string]string{
+			cassdcapi.ClusterLabel:    kc.Spec.Cassandra.Cluster,
+			cassdcapi.DatacenterLabel: dcTemplate.Meta.Name,
+			cassdcapi.SeedNodeLabel:   "true",
+		}
+
+		dcKey := client.ObjectKey{Namespace: namespace, Name: dcTemplate.Meta.Name}
+
+		if err := remoteClient.Get(ctx, dcKey, &cassdcapi.CassandraDatacenter{}); err != nil && errors.IsNotFound(err) {
+			continue
+		}
+
+		if err := remoteClient.List(ctx, list, client.InNamespace(namespace), client.MatchingLabels(selector)); err != nil {
+			logger.Error(err, "Failed to get seed pods", "K8sContext", dcTemplate.K8sContext, "DC", dcKey)
+			return nil, err
+		}
+
+		pods = append(pods, list.Items...)
+	}
+
+	return pods, nil
+}
+
+func newEndpoints(dc *cassdcapi.CassandraDatacenter, seeds []corev1.Pod) *corev1.Endpoints {
+	ep := corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   dc.Namespace,
+			Name:        dc.GetAdditionalSeedsServiceName(),
+			Labels:      dc.GetDatacenterLabels(),
+			Annotations: map[string]string{},
+		},
+	}
+
+	addresses := make([]corev1.EndpointAddress, 0, len(seeds))
+	for _, seed := range seeds {
+		addresses = append(addresses, corev1.EndpointAddress{
+			IP: seed.Status.PodIP,
+		})
+	}
+
+	ep.Subsets = []corev1.EndpointSubset{
+		{
+			Addresses: addresses,
+		},
+	}
+
+	ep.Annotations[api.ResourceHashAnnotation] = utils.DeepHashString(ep)
+
+	return &ep
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -1197,7 +1197,7 @@ func verifyDefaultSuperUserSecretCreated(ctx context.Context, t *testing.T, f *f
 func verifyReplicatedSecretReconciled(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
 	t.Log("check ReplicatedSecret reconciled")
 
-	replSecret := &api.ReplicatedSecret{}
+	replSecret := &replicationapi.ReplicatedSecret{}
 	replSecretKey := types.NamespacedName{Name: kc.Spec.Cassandra.Cluster, Namespace: kc.Namespace}
 
 	require.Eventually(t, func() bool {

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -221,6 +221,11 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 
 		return true
 	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dcKey, &cassdcapi.CassandraDatacenter{})
 }
 
 // applyClusterTemplateConfigs verifies that settings specified at the cluster-level, i.e.,
@@ -339,6 +344,12 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 	expectedConfig, err = parseCassandraConfig(kluster.Spec.Cassandra.CassandraConfig, serverVersion, 3, "dc1", "dc2")
 	require.NoError(err, "failed to parse CassandraConfig")
 	assert.Equal(expectedConfig, actualConfig)
+
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kluster.Namespace, Name: kluster.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
 }
 
 // applyDatacenterTemplateConfigs verifies that settings specified at the dc-level, i.e.,
@@ -487,6 +498,12 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 	expectedConfig, err = parseCassandraConfig(kluster.Spec.Cassandra.Datacenters[1].CassandraConfig, serverVersion, 3, "dc1", "dc2")
 	require.NoError(err, "failed to parse CassandraConfig")
 	assert.Equal(expectedConfig, actualConfig)
+
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kluster.Namespace, Name: kluster.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
 }
 
 // applyClusterTemplateAndDatacenterTemplateConfigs specifies settings in the cluster
@@ -632,6 +649,12 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	expectedConfig, err = parseCassandraConfig(kluster.Spec.Cassandra.Datacenters[1].CassandraConfig, serverVersion, 3, "dc1", "dc2")
 	require.NoError(err, "failed to parse CassandraConfig")
 	assert.Equal(expectedConfig, actualConfig)
+
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kluster.Namespace, Name: kluster.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
 }
 
 func parseCassandraConfig(config *api.CassandraConfig, serverVersion string, systemRF int, dcNames ...string) (*gabs.Container, error) {
@@ -874,6 +897,12 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 		condition = findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterReady)
 		return condition != nil && condition.Status == corev1.ConditionTrue
 	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
 }
 
 func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
@@ -1188,6 +1217,13 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 			kc.Status.Datacenters[dc2Key.Name].Stargate == nil
 	}, timeout, interval)
 
+	t.Log("deleting K8ssandraCluster")
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name})
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, sg1Key, &stargateapi.Stargate{})
+	verifyObjectDoesNotExist(ctx, t, f, sg2Key, &stargateapi.Stargate{})
 }
 
 func verifyDefaultSuperUserSecretCreated(ctx context.Context, t *testing.T, f *framework.Framework, kluster *api.K8ssandraCluster) {
@@ -1200,7 +1236,7 @@ func verifyDefaultSuperUserSecretCreated(ctx context.Context, t *testing.T, f *f
 			return false
 		}
 		return true
-	}, timeout, interval)
+	}, timeout, interval, "failed to verify that the default superuser secret was created")
 }
 
 func verifyFinalizerAdded(ctx context.Context, t *testing.T, f *framework.Framework, key client.ObjectKey) {
@@ -1213,7 +1249,14 @@ func verifyFinalizerAdded(ctx context.Context, t *testing.T, f *framework.Framew
 			return false
 		}
 		return controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer)
-	}, timeout, interval)
+	}, timeout, interval, "failed to verify that finalizer was added")
+}
+
+func verifyObjectDoesNotExist(ctx context.Context, t *testing.T, f *framework.Framework, key framework.ClusterKey, obj client.Object) {
+	assert.Eventually(t, func() bool {
+		err := f.Get(ctx, key, obj)
+		return err != nil && errors.IsNotFound(err)
+	}, timeout, interval, "failed to verify object does not exist", key)
 }
 
 func verifyReplicatedSecretReconciled(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
@@ -1222,10 +1265,14 @@ func verifyReplicatedSecretReconciled(ctx context.Context, t *testing.T, f *fram
 	replSecret := &replicationapi.ReplicatedSecret{}
 	replSecretKey := types.NamespacedName{Name: kc.Spec.Cassandra.Cluster, Namespace: kc.Namespace}
 
-	require.Eventually(t, func() bool {
+	assert.Eventually(t, func() bool {
 		err := f.Client.Get(ctx, replSecretKey, replSecret)
 		return err == nil
-	}, timeout, interval)
+	}, timeout, interval, "failed to get ReplicatedSecret")
+
+	if replSecret == nil {
+		return
+	}
 
 	val, exists := replSecret.Labels[api.ManagedByLabel]
 	assert.True(t, exists)

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -685,7 +685,7 @@ func parseCassandraConfig(config *api.CassandraConfig, serverVersion string, sys
 // k8s clusters. It also verifies that status updates are made to the K8ssandraCluster.
 func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
-	assert := assert.New(t)
+	//assert := assert.New(t)
 
 	k8sCtx0 := "cluster-0"
 	k8sCtx1 := "cluster-1"
@@ -821,15 +821,15 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	err = f.Get(ctx, dc2Key, dc2)
 	require.True(err != nil && errors.IsNotFound(err), "dc2 should not be created until dc1 is ready")
 
-	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
-		if dc.Name == "dc1" {
-			return dc1PodIps, nil
-		}
-		if dc.Name == "dc2" {
-			return dc2PodIps, nil
-		}
-		return nil, fmt.Errorf("unknown datacenter: %s", dc.Name)
-	}
+	//seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
+	//	if dc.Name == "dc1" {
+	//		return dc1PodIps, nil
+	//	}
+	//	if dc.Name == "dc2" {
+	//		return dc2PodIps, nil
+	//	}
+	//	return nil, fmt.Errorf("unknown datacenter: %s", dc.Name)
+	//}
 
 	t.Log("update dc1 status to ready")
 	err = f.SetDatacenterStatusReady(ctx, dc1Key)
@@ -843,7 +843,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
-	assert.Equal(dc1PodIps, dc2.Spec.AdditionalSeeds, "The AdditionalSeeds property for dc2 is wrong")
+	//assert.Equal(dc1PodIps, dc2.Spec.AdditionalSeeds, "The AdditionalSeeds property for dc2 is wrong")
 
 	t.Log("update dc2 status to ready")
 	err = f.SetDatacenterStatusReady(ctx, dc2Key)
@@ -907,7 +907,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 
 func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
-	assert := assert.New(t)
+	//assert := assert.New(t)
 
 	k8sCtx0 := "cluster-0"
 	k8sCtx1 := "cluster-1"
@@ -1033,15 +1033,15 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	err = f.Get(ctx, dc2Key, dc2)
 	require.True(err != nil && errors.IsNotFound(err), "dc2 should not be created until dc1 is ready")
 
-	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
-		if dc.Name == "dc1" {
-			return dc1PodIps, nil
-		}
-		if dc.Name == "dc2" {
-			return dc2PodIps, nil
-		}
-		return nil, fmt.Errorf("unknown datacenter: %s", dc.Name)
-	}
+	//seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
+	//	if dc.Name == "dc1" {
+	//		return dc1PodIps, nil
+	//	}
+	//	if dc.Name == "dc2" {
+	//		return dc2PodIps, nil
+	//	}
+	//	return nil, fmt.Errorf("unknown datacenter: %s", dc.Name)
+	//}
 
 	t.Log("update dc1 status to ready")
 	err = f.PatchDatacenterStatus(ctx, dc1Key, func(dc *cassdcapi.CassandraDatacenter) {
@@ -1062,7 +1062,7 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
-	assert.Equal(dc1PodIps, dc2.Spec.AdditionalSeeds, "The AdditionalSeeds property for dc2 is wrong")
+	//assert.Equal(dc1PodIps, dc2.Spec.AdditionalSeeds, "The AdditionalSeeds property for dc2 is wrong")
 
 	sg2Key := framework.ClusterKey{
 		K8sContext: k8sCtx1,

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -131,6 +131,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 	require.NoError(err, "failed to create K8ssandraCluster")
 
 	verifyDefaultSuperUserSecretCreated(ctx, t, f, kc)
+	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
 	t.Log("check that the datacenter was created")
 	dcKey := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx}
@@ -282,6 +283,8 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 	err := f.Client.Create(ctx, kluster)
 	require.NoError(err, "failed to create K8sandraCluster")
 
+	verifyReplicatedSecretReconciled(ctx, t, f, kluster)
+
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -430,6 +433,8 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 	err := f.Client.Create(ctx, kluster)
 	require.NoError(err, "failed to create K8sandraCluster")
 
+	verifyReplicatedSecretReconciled(ctx, t, f, kluster)
+
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -571,6 +576,8 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	err := f.Client.Create(ctx, kluster)
 	require.NoError(err, "failed to create K8sandraCluster")
 
+	verifyReplicatedSecretReconciled(ctx, t, f, kluster)
+
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -704,6 +711,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	allPodIps = append(allPodIps, dc2PodIps...)
 
 	verifyDefaultSuperUserSecretCreated(ctx, t, f, cluster)
+	verifyReplicatedSecretReconciled(ctx, t, f, cluster)
 
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
@@ -928,6 +936,7 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	allPodIps = append(allPodIps, dc2PodIps...)
 
 	verifyDefaultSuperUserSecretCreated(ctx, t, f, kc)
+	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: k8sCtx0}
@@ -1183,6 +1192,27 @@ func verifyDefaultSuperUserSecretCreated(ctx context.Context, t *testing.T, f *f
 		}
 		return true
 	}, timeout, interval)
+}
+
+func verifyReplicatedSecretReconciled(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
+	t.Log("check ReplicatedSecret reconciled")
+
+	replSecret := &api.ReplicatedSecret{}
+	replSecretKey := types.NamespacedName{Name: kc.Spec.Cassandra.Cluster, Namespace: kc.Namespace}
+
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, replSecretKey, replSecret)
+		return err == nil
+	}, timeout, interval)
+
+	val, exists := replSecret.Labels[api.ManagedByLabel]
+	assert.True(t, exists)
+	assert.Equal(t, api.NameLabelValue, val)
+	val, exists = replSecret.Labels[api.K8ssandraClusterLabel]
+	assert.True(t, exists)
+	assert.Equal(t, kc.Spec.Cassandra.Cluster, val)
+
+	assert.Equal(t, len(kc.Spec.Cassandra.Datacenters), len(replSecret.Spec.ReplicationTargets))
 }
 
 func findDatacenterCondition(status *cassdcapi.CassandraDatacenterStatus, condType cassdcapi.DatacenterConditionType) *cassdcapi.DatacenterCondition {

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -9,7 +9,6 @@ import (
 	api "github.com/k8ssandra/k8ssandra-operator/apis/replication/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/secret"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -57,8 +57,6 @@ func TestSecretController(t *testing.T) {
 	t.Run("SingleClusterDoNothingToSecretsTest", testEnv.ControllerTest(ctx, wrongClusterIgnoreCopy))
 	t.Run("MultiClusterSyncSecretsTest", testEnv.ControllerTest(ctx, copySecretsFromClusterToCluster))
 	t.Run("VerifyFinalizerInMultiCluster", testEnv.ControllerTest(ctx, verifySecretIsDeleted))
-
-	t.Run("ManagedReplicatedSecret", testEnv.ControllerTest(ctx, managedReplicatedSecret))
 }
 
 // copySecretsFromClusterToCluster Tests:
@@ -455,45 +453,4 @@ func TestRequiresUpdate(t *testing.T) {
 
 	syncSecrets(orig, dest)
 	assert.False(requiresUpdate(orig, dest))
-}
-
-func managedReplicatedSecret(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	targetCtxs := make([]string, 0, len(testEnv.Clients))
-
-	for k, _ := range testEnv.Clients {
-		targetCtxs = append(targetCtxs, k)
-	}
-
-	err := secret.ReconcileReplicatedSecret(ctx, f.Client, "test", namespace, targetCtxs)
-	require.NoError(err)
-
-	replSecret := &api.ReplicatedSecret{}
-	replSecretKey := types.NamespacedName{Name: "test", Namespace: namespace}
-	err = f.Client.Get(context.Background(), replSecretKey, replSecret)
-	require.NoError(err)
-
-	// Verify data in it
-
-	val, exists := replSecret.Labels[coreapi.ManagedByLabel]
-	assert.True(exists)
-	assert.Equal(coreapi.NameLabelValue, val)
-	val, exists = replSecret.Labels[coreapi.K8ssandraClusterLabel]
-	assert.True(exists)
-	assert.Equal("test", val)
-
-	assert.Equal(len(testEnv.Clients), len(replSecret.Spec.ReplicationTargets))
-
-	// Create superuserSecret and verify it is correctly replicated also
-	err = secret.ReconcileSuperuserSecret(ctx, f.Client, "test-superuser", "test", namespace)
-	require.NoError(err)
-
-	var empty struct{}
-	require.Eventually(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, targetCtxs, map[string]struct{}{
-			"test-superuser": empty,
-		}, namespace)
-	}, timeout, interval)
 }

--- a/pkg/secret/replicated.go
+++ b/pkg/secret/replicated.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
 	"math/big"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -80,21 +83,42 @@ func ReconcileSuperuserSecret(ctx context.Context, c client.Client, secretName, 
 }
 
 // ReconcileReplicatedSecret ensures that the correct replicatedSecret for all managed secrets is created
-func ReconcileReplicatedSecret(ctx context.Context, c client.Client, clusterName, namespace string, targetContexts []string) error {
-	// We use leaderID to ensure that this leader instance of k8ssandra-operator is using the correct ReplicatedSecret (it can be shared between different k8ssandra-operators)
-	targetRepSec := generateReplicatedSecret(clusterName, namespace, targetContexts)
+//func ReconcileReplicatedSecret(ctx context.Context, c client.Client, clusterName, namespace string, targetContexts []string) (*api.ReplicatedSecret, error) {
+func ReconcileReplicatedSecret(ctx context.Context, c client.Client, scheme *runtime.Scheme, kc *api.K8ssandraCluster, logger logr.Logger) error {
+	replicationTargets := make([]string, 0, len(kc.Spec.Cassandra.Datacenters))
+	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+		if dcTemplate.K8sContext != "" {
+			replicationTargets = append(replicationTargets, dcTemplate.K8sContext)
+		}
+	}
+
+	targetRepSec := generateReplicatedSecret(kc.Spec.Cassandra.Cluster, kc.Namespace, replicationTargets)
+	key := client.ObjectKey{Namespace: targetRepSec.Namespace, Name: targetRepSec.Name}
 	repSec := &replicationapi.ReplicatedSecret{}
-	err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, repSec)
+
+	err := controllerutil.SetControllerReference(kc, targetRepSec, scheme)
+	if err != nil {
+		logger.Error(err, "Failed to set owner reference on ReplicatedSecret", "ReplicatedSect", key)
+		return err
+	}
+
+	err = c.Get(ctx, types.NamespacedName{Name: kc.Spec.Cassandra.Cluster, Namespace: kc.Namespace}, repSec)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return c.Create(ctx, targetRepSec)
+			logger.Info("Creating ReplicatedSecret", "ReplicatedSecret", key)
+			if err = c.Create(ctx, targetRepSec); err == nil {
+				return nil
+			}
 		}
+		return err
 	}
 
 	// It exists, override whatever was in it
 	currentResourceVersion := repSec.ResourceVersion
+	finalizers := repSec.Finalizers
 	targetRepSec.DeepCopyInto(repSec)
 	repSec.ResourceVersion = currentResourceVersion
+	repSec.Finalizers = finalizers
 	return c.Update(ctx, repSec)
 }
 

--- a/pkg/secret/replicated.go
+++ b/pkg/secret/replicated.go
@@ -115,6 +115,8 @@ func ReconcileReplicatedSecret(ctx context.Context, c client.Client, scheme *run
 
 	// It exists, override whatever was in it
 	currentResourceVersion := repSec.ResourceVersion
+	// Need to copy the finalizers here; otherwise, they get overwritten and lost. This
+	// will be refactored in https://github.com/k8ssandra/k8ssandra-operator/issues/206
 	finalizers := repSec.Finalizers
 	targetRepSec.DeepCopyInto(repSec)
 	repSec.ResourceVersion = currentResourceVersion

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -264,15 +264,7 @@ func cleanUp(t *testing.T, namespace string, f *framework.E2eFramework, deployTr
 	timeout := 3 * time.Minute
 	interval := 10 * time.Second
 
-	if err := f.DeleteStargates(namespace, timeout, interval); err != nil {
-		return err
-	}
-
-	if err := f.DeleteDatacenters(namespace, timeout, interval); err != nil {
-		return err
-	}
-
-	if err := f.DeleteReplicatedSecrets(namespace, timeout, interval); err != nil {
+	if err := f.WaitForK8ssadraClusterDeletion(namespace, timeout, interval); err != nil {
 		return err
 	}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -259,7 +259,15 @@ func cleanUp(t *testing.T, namespace string, f *framework.E2eFramework, deployTr
 	timeout := 3 * time.Minute
 	interval := 10 * time.Second
 
-	if err := f.WaitForK8ssadraClusterDeletion(namespace, timeout, interval); err != nil {
+	if err := f.DeleteStargates(namespace, timeout, interval); err != nil {
+		return err
+	}
+
+	if err := f.DeleteDatacenters(namespace, timeout, interval); err != nil {
+		return err
+	}
+
+	if err := f.DeleteReplicatedSecrets(namespace, timeout, interval); err != nil {
 		return err
 	}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -152,11 +152,6 @@ func beforeTest(t *testing.T, namespace, fixtureDir string, f *framework.E2eFram
 		return err
 	}
 
-	if err := f.DeployCassOperator(namespace); err != nil {
-		t.Log("failed to deploy cass-operator")
-		return err
-	}
-
 	if err := f.DeployCassandraConfigMap(namespace); err != nil {
 		t.Log("failed to deploy cassandra configmap")
 		return err

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -545,7 +545,7 @@ func (f *E2eFramework) deleteAllResources(
 			list := &corev1.PodList{}
 			if err := remoteClient.List(context.TODO(), list, podListOptions...); err != nil {
 				f.logger.Error(err, "failed to list pods", "Context", k8sContext)
-				return false, err
+				return false, nil
 			}
 			if len(list.Items) > 0 {
 				return false, nil

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -12,15 +12,11 @@ import (
 	"text/template"
 	"time"
 
-	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	replicationapi "github.com/k8ssandra/k8ssandra-operator/apis/replication/v1alpha1"
-	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/kubectl"
 	"github.com/k8ssandra/k8ssandra-operator/test/kustomize"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
@@ -468,48 +464,14 @@ func (f *E2eFramework) DumpClusterInfo(test, namespace string) error {
 	return nil
 }
 
-// DeleteDatacenters deletes all CassandraDatacenters in namespace in all remote clusters.
-// This function blocks until all pods from all CassandraDatacenters have terminated.
-func (f *E2eFramework) DeleteDatacenters(namespace string, timeout, interval time.Duration) error {
-	f.logger.Info("deleting all CassandraDatacenters", "Namespace", namespace)
-	return f.deleteAllResources(
-		namespace,
-		&cassdcapi.CassandraDatacenter{},
-		timeout,
-		interval,
-		client.HasLabels{cassdcapi.ClusterLabel},
-	)
-}
-
-// DeleteStargates deletes all Stargates in namespace in all remote clusters.
-// This function blocks until all pods from all Stargates have terminated.
-func (f *E2eFramework) DeleteStargates(namespace string, timeout, interval time.Duration) error {
-	f.logger.Info("deleting all Stargates", "Namespace", namespace)
-	return f.deleteAllResources(
-		namespace,
-		&stargateapi.Stargate{},
-		timeout,
-		interval,
-		client.HasLabels{stargateapi.StargateLabel},
-	)
-}
-
-// DeleteReplicatedSecrets deletes all the ReplicatedSecrets in the namespace. This causes
-// some delay while secret controller removes the finalizers and clears the replicated secrets from
-// remote clusters.
-func (f *E2eFramework) DeleteReplicatedSecrets(namespace string, timeout, interval time.Duration) error {
-	f.logger.Info("deleting all ReplicatedSecrets", "Namespace", namespace)
-
-	if err := f.Client.DeleteAllOf(context.Background(), &replicationapi.ReplicatedSecret{}, client.InNamespace(namespace)); err != nil {
-		f.logger.Error(err, "failed to delete ReplicatedSecrets")
-		return err
-	}
-
+// WaitForK8ssadraClusterDeletion blocks until either the timeout is reached or until there
+// no K8ssandraCluster objects in namespace.
+func (f *E2eFramework) WaitForK8ssadraClusterDeletion(namespace string, timeout, interval time.Duration) error {
 	return wait.Poll(interval, timeout, func() (bool, error) {
-		list := &replicationapi.ReplicatedSecretList{}
+		list := &api.K8ssandraClusterList{}
 		if err := f.Client.List(context.Background(), list, client.InNamespace(namespace)); err != nil {
-			f.logger.Error(err, "failed to list ReplicatedSecrets")
-			return false, err
+			f.logger.Error(err, "failed to list K8ssandraClusters")
+			return false, nil
 		}
 		return len(list.Items) == 0, nil
 	})
@@ -521,38 +483,6 @@ func (f *E2eFramework) DeleteK8ssandraOperatorPods(namespace string, timeout, in
 		return err
 	}
 	return nil
-}
-
-func (f *E2eFramework) deleteAllResources(
-	namespace string,
-	resource client.Object,
-	timeout, interval time.Duration,
-	podListOptions ...client.ListOption,
-) error {
-	for _, remoteClient := range f.remoteClients {
-		if err := remoteClient.DeleteAllOf(context.TODO(), resource, client.InNamespace(namespace)); err != nil {
-			// If the CRD wasn't deployed at all to this cluster, keep going
-			if _, ok := err.(*meta.NoKindMatchError); !ok {
-				return err
-			}
-		}
-	}
-	// Check that all pods created by resources are terminated
-	// FIXME Should there be a separate wait.Poll call per cluster?
-	return wait.Poll(interval, timeout, func() (bool, error) {
-		podListOptions = append(podListOptions, client.InNamespace(namespace))
-		for k8sContext, remoteClient := range f.remoteClients {
-			list := &corev1.PodList{}
-			if err := remoteClient.List(context.TODO(), list, podListOptions...); err != nil {
-				f.logger.Error(err, "failed to list pods", "Context", k8sContext)
-				return false, err
-			}
-			if len(list.Items) > 0 {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
 }
 
 func (f *E2eFramework) UndeployK8ssandraOperator(namespace string) error {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -213,6 +213,15 @@ func (f *Framework) WaitForDeploymentToBeReady(key ClusterKey, timeout, interval
 	})
 }
 
+func (f *Framework) DeleteK8ssandraCluster(ctx context.Context, key client.ObjectKey) error {
+	kc := &api.K8ssandraCluster{}
+	err := f.Client.Get(ctx, key, kc)
+	if err != nil {
+		return err
+	}
+	return f.Client.Delete(ctx, kc)
+}
+
 func (f *Framework) DeleteK8ssandraClusters(namespace string) error {
 	// TODO This will need to be updated when we add a finalizer in K8ssandraCluster
 	// We will want to block until that finalizer is removed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* [ ] Create and manage the additional seeds service Endpoints objects in k8ssandra-operator
* [ ] Do not set `AdditionalSeeds` on the CassandraDatacenters
* [ ] Add unit tests
* [ ] Update integration tests
* [ ] Update e2e tests

**Which issue(s) this PR fixes**:
Fixes #210 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
