### PR TITLE
Fix cass-operator deployments

### DIFF
--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -127,7 +127,7 @@ func generateCassOperatorKustomization(namespace string) error {
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/default?ref=v1.8.0
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=211eac97af729b03d8551ebccb88c6e7e376c567
 namespace: {{ .Namespace }}
 `
 	k := Kustomization{Namespace: namespace}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This commit replaces `config/default` with `config/deployments/default` when generating kustomization for cass-operator.

This fixes the incorrect deployment of the controller-manager pod for cass-operator.

**Which issue(s) this PR fixes**:


**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
