### PR TITLE
K8SSAND-995 Mgmt api heap

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -19,7 +19,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#15](https://github.com/k8ssandra/k8ssandra-operator/pull/15) Add finalizer for K8ssandraCluster
 * [BUGFIX] [#203](https://github.com/k8ssandra/k8ssandra-operator/issues/203) Superuser secret name not set on CassandraDatacenters
 * [BUGFIX] [#156](https://github.com/k8ssandra/k8ssandra-operator/issues/156) Stargate auth table creation may trigger a table ID mismatch
-
+* [FEATURE] [#212](https://github.com/k8ssandra/k8ssandra-operator/issues/212) Allow management API heap size to be configured
 ## v1.0.0-alpha.1 - 2021-09-30
 
 [FEATURE] [#98](https://github.com/k8ssandra/k8ssandra-operator/issues/98) Create Helm chart for the operator

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -227,6 +227,10 @@ type CassandraDatacenterTemplate struct {
 	// deploying Reaper in this datacenter.
 	// +optional
 	Reaper *reaperapi.ReaperDatacenterTemplate `json:"reaper,omitempty"`
+	// MgmtAPIHeap defines the amount of memory (in java format - i.e. an int followed by a G or M) devoted to the management
+	// api heap.
+	// +optional
+	MgmtAPIHeap string `json:"mgmtAPIHeap,omitempty"`
 }
 
 type EmbeddedObjectMeta struct {

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -171,6 +171,11 @@ type CassandraClusterTemplate struct {
 	// Datacenters a list of the DCs in the cluster.
 	// +optional
 	Datacenters []CassandraDatacenterTemplate `json:"datacenters,omitempty"`
+
+	// MgmtAPIHeap defines the amount of memory devoted to the management
+	// api heap.
+	// +optional
+	MgmtAPIHeap *resource.Quantity `json:"mgmtAPIHeap,omitempty"`
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields
@@ -227,10 +232,10 @@ type CassandraDatacenterTemplate struct {
 	// deploying Reaper in this datacenter.
 	// +optional
 	Reaper *reaperapi.ReaperDatacenterTemplate `json:"reaper,omitempty"`
-	// MgmtAPIHeap defines the amount of memory (in java format - i.e. an int followed by a G or M) devoted to the management
+	// MgmtAPIHeap defines the amount of memory devoted to the management
 	// api heap.
 	// +optional
-	MgmtAPIHeap string `json:"mgmtAPIHeap,omitempty"`
+	MgmtAPIHeap *resource.Quantity `json:"mgmtAPIHeap,omitempty"`
 }
 
 type EmbeddedObjectMeta struct {

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -203,10 +203,13 @@ spec:
                           - name
                           type: object
                         mgmtAPIHeap:
-                          description: MgmtAPIHeap defines the amount of memory (in
-                            java format - i.e. an int followed by a G or M) devoted
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: MgmtAPIHeap defines the amount of memory devoted
                             to the management api heap.
-                          type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         networking:
                           description: Networking enables host networking and configures
                             a NodePort ports.
@@ -5401,6 +5404,14 @@ spec:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     type: array
+                  mgmtAPIHeap:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MgmtAPIHeap defines the amount of memory devoted
+                      to the management api heap.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   networking:
                     description: Networking enables host networking and configures
                       a NodePort ports.

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -202,6 +202,11 @@ spec:
                           required:
                           - name
                           type: object
+                        mgmtAPIHeap:
+                          description: MgmtAPIHeap defines the amount of memory (in
+                            java format - i.e. an int followed by a G or M) devoted
+                            to the management api heap.
+                          type: string
                         networking:
                           description: Networking enables host networking and configures
                             a NodePort ports.

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -54,6 +54,10 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 		return nil, err
 	}
 
+	if template.StorageConfig == nil {
+		return nil, DCConfigIncomplete{"template.StorageConfig"}
+	}
+
 	dc := &cassdcapi.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespace,

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -94,16 +94,14 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 	}
 
 	if len(template.MgmtAPIHeap) != 0 {
-		if err := SetMgmtAPIHeap(dc, template.MgmtAPIHeap); err != nil {
-			return nil, err
-		}
+		SetMgmtAPIHeap(dc, template.MgmtAPIHeap)
 	}
 
 	return dc, nil
 }
 
 // SetMgmtAPIHeap sets the management API heap size on a CassandraDatacenter
-func SetMgmtAPIHeap(dc *cassdcapi.CassandraDatacenter, heapSize string) error {
+func SetMgmtAPIHeap(dc *cassdcapi.CassandraDatacenter, heapSize string) {
 	// TODO: it would be nice to have a generic `StrategicMergePatch` method which produces merged API objects instead
 	// of this ad hoc append logic here or the `Patch` types produced by `StrategicMergeFrom`.
 	if dc.Spec.PodTemplateSpec == nil {
@@ -116,6 +114,7 @@ func SetMgmtAPIHeap(dc *cassdcapi.CassandraDatacenter, heapSize string) error {
 	for i, container := range dc.Spec.PodTemplateSpec.Spec.Containers {
 		if container.Name == "cassandra" {
 			cassIndex = i
+			break
 		}
 	}
 	dc.Spec.PodTemplateSpec.Spec.Containers[cassIndex].Env = append(
@@ -125,7 +124,6 @@ func SetMgmtAPIHeap(dc *cassdcapi.CassandraDatacenter, heapSize string) error {
 			Value: heapSize,
 		},
 	)
-	return nil
 }
 
 // Coalesce combines the cluster and dc templates with override semantics. If a property is

--- a/pkg/cassandra/errors.go
+++ b/pkg/cassandra/errors.go
@@ -1,0 +1,7 @@
+package cassandra
+
+type DCConfigIncomplete struct{ missingfield string }
+
+func (detail DCConfigIncomplete) Error() string {
+	return "DatacenterConfig did not contain required fields to process into a CassandraDatacenter, missing field " + detail.missingfield
+}


### PR DESCRIPTION
**What this PR does**:

* Make the management API heap size configurable via a field in the `K8ssandraCluster`.
* Add error handling for cases where `StorageConfig` or `CassandraConfig` are not defined in a `DatacenterConfig`. (These conditions previously caused a runtime panic).
* Add unit tests for all of the above.
* Add new test function to get a minimal Cassandra `DatacenterConfig`.

**Which issue(s) this PR fixes**:
Fixes #212.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
