### PR TITLE
start using result.ReconcileResult

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -13,6 +13,7 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## Unreleased
+* [CHANGE] [#232](https://github.com/k8ssandra/k8ssandra-operator/issues/232) Use ReconcileResult in K8ssandraClusterReconciler
 
 * [ENHANCEMENT] [#218](https://github.com/k8ssandra/k8ssandra-operator/issues/218) Add `CassandraInitialized` status condition
 

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -139,7 +139,7 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 		return recResult.Output()
 	}
 
-	if recResult := r.recocileReaperSchema(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
+	if recResult := r.reconcileReaperSchema(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
 		return recResult.Output()
 	}
 

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -19,31 +19,30 @@ package k8ssandra
 import (
 	"context"
 	"fmt"
-	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
-	"k8s.io/apimachinery/pkg/labels"
-	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sort"
-
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/secret"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -100,95 +99,12 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ssandraCluster, kcLogger logr.Logger) (ctrl.Result, error) {
-	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
-
-	if kc.DeletionTimestamp != nil {
-		if !controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
-			return ctrl.Result{}, nil
-		}
-
-		kcLogger.Info("Starting deletion")
-
-		hasErrors := false
-
-		for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
-			namespace := dcTemplate.Meta.Namespace
-			if namespace == "" {
-				namespace = kc.Namespace
-			}
-			dcKey := client.ObjectKey{Namespace: namespace, Name: dcTemplate.Meta.Name}
-
-			remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
-			if err != nil {
-				kcLogger.Error(err, "Failed to get remote client", "Context", dcTemplate.K8sContext)
-				hasErrors = true
-				continue
-			}
-
-			dc := &cassdcapi.CassandraDatacenter{}
-			err = remoteClient.Get(ctx, dcKey, dc)
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					kcLogger.Error(err, "Failed to get CassandraDatacenter for deletion",
-						"CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
-					hasErrors = true
-				}
-			} else if err = remoteClient.Delete(ctx, dc); err != nil {
-				kcLogger.Error(err, "Failed to delete CassandraDatacenter", "CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
-				hasErrors = true
-			}
-
-			selector := utils.CreatedByK8ssandraControllerLabels(kcKey)
-			stargateList := &stargateapi.StargateList{}
-			options := client.ListOptions{
-				Namespace:     namespace,
-				LabelSelector: labels.SelectorFromSet(selector),
-			}
-
-			err = remoteClient.List(ctx, stargateList, &options)
-			if err != nil {
-				kcLogger.Error(err, "Failed to list Stargate objects", "Context", dcTemplate.K8sContext)
-				hasErrors = true
-				continue
-			}
-
-			for _, sg := range stargateList.Items {
-				if err = remoteClient.Delete(ctx, &sg); err != nil {
-					key := client.ObjectKey{Namespace: namespace, Name: sg.Name}
-					if !errors.IsNotFound(err) {
-						kcLogger.Error(err, "Failed to delete Stargate", "Stargate", key,
-							"Context", dcTemplate.K8sContext)
-						hasErrors = true
-					}
-				}
-			}
-
-			if r.deleteReapers(ctx, kc, dcTemplate, namespace, remoteClient, kcLogger) {
-				hasErrors = true
-			}
-		}
-
-		if hasErrors {
-			return ctrl.Result{RequeueAfter: r.DefaultDelay}, nil
-		}
-
-		patch := client.MergeFrom(kc.DeepCopy())
-		controllerutil.RemoveFinalizer(kc, k8ssandraClusterFinalizer)
-		if err := r.Client.Patch(ctx, kc, patch); err != nil {
-			kcLogger.Error(err, "Failed to remove finalizer")
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, nil
+	if recResult := r.checkDeletion(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	if !controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
-		patch := client.MergeFrom(kc.DeepCopy())
-		controllerutil.AddFinalizer(kc, k8ssandraClusterFinalizer)
-		if err := r.Client.Patch(ctx, kc, patch); err != nil {
-			kcLogger.Error(err, "Failed to add finalizer")
-			return ctrl.Result{}, err
-		}
+	if recResult := r.checkFinalizer(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
 	if kc.Spec.Cassandra == nil {
@@ -197,239 +113,61 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 	}
 
 	// Reconcile the ReplicatedSecret and superuserSecret first (otherwise CassandraDatacenter will not start)
-	if kc.Spec.Cassandra.SuperuserSecretName == "" {
-		// Note that we do not persist this change because doing so would prevent us from
-		// differentiating between a default secret by the operator vs one provided by the
-		// client that happens to have the same name as the default name.
-		kc.Spec.Cassandra.SuperuserSecretName = secret.DefaultSuperuserSecretName(kc.Spec.Cassandra.Cluster)
-		kcLogger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretName)
+
+	if recResult := r.reconcileSuperuserSecret(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	if err := secret.ReconcileSecret(ctx, r.Client, kc.Spec.Cassandra.SuperuserSecretName, kcKey); err != nil {
-		kcLogger.Error(err, "Failed to verify existence of superuserSecret")
-		return ctrl.Result{}, err
+	if recResult := r.reconcileReaperSecrets(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	if err := r.reconcileReaperSecrets(ctx, kc, kcLogger); err != nil {
-		return ctrl.Result{}, err
+	if recResult := r.reconcileReplicatedSecret(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, r.Scheme, kc, kcLogger); err != nil {
-		kcLogger.Error(err, "Failed to reconcile ReplicatedSecret")
-		return ctrl.Result{}, err
-	}
-
-	systemReplication := cassandra.ComputeSystemReplication(kc)
-
-	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
-
-	seeds, err := r.findSeeds(ctx, kc, kcLogger)
-	if err != nil {
-		kcLogger.Error(err, "Failed to find seed nodes")
-		return ctrl.Result{}, err
-	}
-
-	// Reconcile CassandraDatacenter objects only
-	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
-
-		if !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcTemplate.K8sContext) {
-			// ReplicatedSecret has not replicated yet, wait until it has
-			kcLogger.Info("Waiting for replication to complete")
-			return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
-		}
-
-		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
-		// its fields are pointers, and without the copy we could end of with shared
-		// references that would lead to unexpected and incorrect values.
-		dcConfig := cassandra.Coalesce(kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
-		cassandra.ApplySystemReplication(dcConfig, systemReplication)
-		if !cassandra.IsCassandra3(dcConfig.ServerVersion) && kc.HasStargates() {
-			// if we're not running Cassandra 3.11 and have Stargate pods, we need to allow alter RF during range movements
-			cassandra.AllowAlterRfDuringRangeMovement(dcConfig)
-		}
-		reaperTemplate := reaper.Coalesce(kc.Spec.Reaper.DeepCopy(), dcTemplate.Reaper.DeepCopy())
-		if reaperTemplate != nil {
-			reaper.AddReaperSettingsToDcConfig(reaperTemplate, dcConfig)
-		}
-		desiredDc, err := cassandra.NewDatacenter(kcKey, dcConfig)
-		dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
-		logger := kcLogger.WithValues("CassandraDatacenter", dcKey, "K8SContext", dcTemplate.K8sContext)
-
-		if err != nil {
-			logger.Error(err, "Failed to create new CassandraDatacenter")
-			return ctrl.Result{}, err
-		}
-
-		desiredDcHash := utils.DeepHashString(desiredDc)
-		desiredDc.Annotations[api.ResourceHashAnnotation] = desiredDcHash
-
-		actualDc := &cassdcapi.CassandraDatacenter{}
-
-		remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		// reconcile seeds
-		//
-		// The following if block was basically taken straight out of cass-operator. See
-		// https://github.com/k8ssandra/k8ssandra-operator/issues/210 for a detailed
-		// explanation of why this is being done.
-		//
-		// TODO Refactor the if block into a separate method/function.
-		// Note: Some other refactoring needs to be done first so that this can be done cleanly.
-		logger.Info("Reconciling seeds")
-		desiredEndpoints := newEndpoints(desiredDc, seeds)
-		actualEndpoints := &corev1.Endpoints{}
-		endpointsKey := client.ObjectKey{Namespace: desiredEndpoints.Namespace, Name: desiredEndpoints.Name}
-
-		if err = remoteClient.Get(ctx, endpointsKey, actualEndpoints); err == nil {
-			// If we already have an Endpoints object but no seeds then it probably means all
-			// Cassandra pods are down or not ready for some reason. In this case we will
-			// delete the Endpoints and let it get recreated once we have seed nodes.
-			if len(seeds) == 0 {
-				logger.Info("Deleting endpoints")
-				if err := remoteClient.Delete(ctx, actualEndpoints); err != nil {
-					logger.Error(err, "Failed to delete endpoints")
-					return ctrl.Result{}, err
-				}
-			} else {
-				if !utils.CompareAnnotations(actualEndpoints, desiredEndpoints, api.ResourceHashAnnotation) {
-					logger.Info("Updating endpoints", "Endpoints", endpointsKey)
-					actualEndpoints := actualEndpoints.DeepCopy()
-					resourceVersion := actualEndpoints.GetResourceVersion()
-					desiredEndpoints.DeepCopyInto(actualEndpoints)
-					actualEndpoints.SetResourceVersion(resourceVersion)
-					if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
-						logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
-						return ctrl.Result{}, err
-					}
-				}
-			}
-		} else {
-			if errors.IsNotFound(err) {
-				// If we have seeds then we want to go ahead and create the Endpoints. But
-				// if we don't have seeds, then we don't need to do anything for a couple
-				// of reasons. First, no seeds means that cass-operator has not labeled any
-				// pods as seeds which would be the case when the CassandraDatacenter is f
-				// first created and no pods have reached the ready state. Secondly, you
-				// cannot create an Endpoints object that has both empty Addresses and
-				// empty NotReadyAddresses.
-				if len(seeds) > 0 {
-					logger.Info("Creating endpoints", "Endpoints", endpointsKey)
-					if err = remoteClient.Create(ctx, desiredEndpoints); err != nil {
-						logger.Error(err, "Failed to create endpoints", "Endpoints", endpointsKey)
-						return ctrl.Result{}, err
-					}
-				}
-			} else {
-				logger.Error(err, "Failed to get endpoints", "Endpoints", endpointsKey)
-				return ctrl.Result{}, err
-			}
-		}
-
-		if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
-			// cassdc already exists, we'll update it
-			if err = r.setStatusForDatacenter(kc, actualDc); err != nil {
-				logger.Error(err, "Failed to update status for datacenter")
-				return ctrl.Result{}, err
-			}
-
-			if actualHash, found := actualDc.Annotations[api.ResourceHashAnnotation]; !(found && actualHash == desiredDcHash) {
-				logger.Info("Updating datacenter")
-
-				if actualDc.Spec.SuperuserSecretName != desiredDc.Spec.SuperuserSecretName {
-					// If actualDc is created with SuperuserSecretName, it can't be changed anymore. We should reject all changes coming from K8ssandraCluster
-					desiredDc.Spec.SuperuserSecretName = actualDc.Spec.SuperuserSecretName
-					err = fmt.Errorf("tried to update superuserSecretName in K8ssandraCluster")
-					logger.Error(err, "SuperuserSecretName is immutable, reverting to existing value in CassandraDatacenter")
-				}
-
-				actualDc = actualDc.DeepCopy()
-				resourceVersion := actualDc.GetResourceVersion()
-				desiredDc.DeepCopyInto(actualDc)
-				actualDc.SetResourceVersion(resourceVersion)
-				if err = remoteClient.Update(ctx, actualDc); err != nil {
-					logger.Error(err, "Failed to update datacenter")
-					return ctrl.Result{}, err
-				}
-			}
-
-			if !cassandra.DatacenterReady(actualDc) {
-				logger.Info("Waiting for datacenter to become ready")
-				return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
-			}
-
-			logger.Info("The datacenter is ready")
-
-			actualDcs = append(actualDcs, actualDc)
-		} else {
-			if errors.IsNotFound(err) {
-				// cassdc doesn't exist, we'll create it
-				if err = remoteClient.Create(ctx, desiredDc); err != nil {
-					logger.Error(err, "Failed to create datacenter")
-					return ctrl.Result{}, err
-				}
-				return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
-			} else {
-				logger.Error(err, "Failed to get datacenter")
-				return ctrl.Result{}, err
-			}
-		}
-	}
-
-	// If we reach this point all CassandraDatacenters are ready. We only set the
-	// CassandraInitialized condition if it is unset, i.e., only once. This allows us to
-	// distinguish whether we are deploying a CassandraDatacenter as part of a new cluster
-	// or as part of an existing cluster.
-	if kc.Status.GetConditionStatus(api.CassandraInitialized) == corev1.ConditionUnknown {
-		now := metav1.Now()
-		(&kc.Status).SetCondition(api.K8ssandraClusterCondition{
-			Type:               api.CassandraInitialized,
-			Status:             corev1.ConditionTrue,
-			LastTransitionTime: &now,
-		})
+	var actualDcs []*cassdcapi.CassandraDatacenter
+	if recResult, dcs := r.reconcileDatacenters(ctx, kc, kcLogger); recResult.Completed() {
+		return recResult.Output()
+	} else {
+		actualDcs = dcs
 	}
 
 	kcLogger.Info("All dcs reconciled")
 
-	if kc.HasStargates() {
-		kcLogger.Info("Reconciling Stargate auth schema")
-		dcTemplate := kc.Spec.Cassandra.Datacenters[0]
-		if remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext); err != nil {
-			return ctrl.Result{}, err
-		} else if err := r.reconcileStargateAuthSchema(ctx, kc, actualDcs[0], remoteClient, kcLogger); err != nil {
-			return ctrl.Result{RequeueAfter: r.ReconcilerConfig.LongDelay}, err
-		}
+	if recResult := r.checkStargateAuthSchema(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	if kc.HasReapers() {
-		kcLogger.Info("Reconciling Reaper schema")
-		dcTemplate := kc.Spec.Cassandra.Datacenters[0]
-		if remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext); err != nil {
-			return ctrl.Result{}, err
-		} else if err := r.reconcileReaperSchema(ctx, kc, actualDcs[0], remoteClient, kcLogger); err != nil {
-			return ctrl.Result{RequeueAfter: r.ReconcilerConfig.LongDelay}, err
-		}
+	if recResult := r.checkReaperSchema(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
-	// Reconcile Stargate and Reaper across all datacenters
-	for i, dcTemplate := range kc.Spec.Cassandra.Datacenters {
-		actualDc := actualDcs[i]
-		dcKey := types.NamespacedName{Namespace: actualDc.Namespace, Name: actualDc.Name}
-		logger := kcLogger.WithValues("CassandraDatacenter", dcKey)
-		logger.Info("Reconciling Stargate and Reaper for dc " + actualDc.Name)
-		if remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext); err != nil {
-			return ctrl.Result{}, err
-		} else if result, err := r.reconcileStargate(ctx, kc, dcTemplate, actualDc, logger, remoteClient); !result.IsZero() || err != nil {
-			return result, err
-		} else if result, err := r.reconcileReaper(ctx, kc, dcTemplate, actualDc, logger, remoteClient); !result.IsZero() || err != nil {
-			return result, err
-		}
+	if recResult := r.reconcileStargateAndReaper(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
+		return recResult.Output()
 	}
 
 	kcLogger.Info("Finished reconciling the k8ssandracluster")
-	return ctrl.Result{}, nil
+
+	return result.Done().Output()
+}
+
+func (r *K8ssandraClusterReconciler) reconcileStargateAndReaper(ctx context.Context, kc *api.K8ssandraCluster, dcs []*cassdcapi.CassandraDatacenter, logger logr.Logger) result.ReconcileResult {
+	for i, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+		dc := dcs[i]
+		dcKey := utils.GetKey(dc)
+		logger := logger.WithValues("CassandraDatacenter", dcKey)
+		logger.Info("Reconciling Stargate and Reaper for dc " + dc.Name)
+		if remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext); err != nil {
+			logger.Error(err, "Failed to get remote client")
+			return result.Error(err)
+		} else if recResult := r.reconcileStargate(ctx, kc, dcTemplate, dc, logger, remoteClient); recResult.Completed() {
+			return recResult
+		} else if recResult := r.reconcileReaper(ctx, kc, dcTemplate, dc, logger, remoteClient); recResult.Completed() {
+			return recResult
+		}
+	}
+	return result.Continue()
 }
 
 func (r *K8ssandraClusterReconciler) reconcileStargate(
@@ -439,7 +177,7 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 	actualDc *cassdcapi.CassandraDatacenter,
 	logger logr.Logger,
 	remoteClient client.Client,
-) (ctrl.Result, error) {
+) result.ReconcileResult {
 
 	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
 	stargateTemplate := dcTemplate.Stargate.Coalesce(kc.Spec.Stargate)
@@ -461,34 +199,34 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 				logger.Info("Creating Stargate resource")
 				if err := remoteClient.Create(ctx, desiredStargate); err != nil {
 					logger.Error(err, "Failed to create Stargate resource")
-					return ctrl.Result{}, err
+					return result.Error(err)
 				} else {
-					return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
+					return result.RequeueSoon(int(r.DefaultDelay))
 				}
 			} else {
 				logger.Error(err, "Failed to get Stargate resource")
-				return ctrl.Result{}, err
+				return result.Error(err)
 			}
 		} else {
 			if err = r.setStatusForStargate(kc, actualStargate, dcTemplate.Meta.Name); err != nil {
 				logger.Error(err, "Failed to update status for stargate")
-				return ctrl.Result{}, err
+				return result.Error(err)
 			}
 			if actualStargateHash, found := actualStargate.Annotations[api.ResourceHashAnnotation]; !found || actualStargateHash != desiredStargateHash {
-				logger.Info("Updating Stargate resource")
+				logger.Info("Updating Stargate")
 				resourceVersion := actualStargate.GetResourceVersion()
 				desiredStargate.DeepCopyInto(actualStargate)
 				actualStargate.SetResourceVersion(resourceVersion)
 				if err = remoteClient.Update(ctx, actualStargate); err == nil {
-					return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
+					return result.RequeueSoon(int(r.DefaultDelay))
 				} else {
-					logger.Error(err, "Failed to update Stargate resource")
-					return ctrl.Result{}, err
+					logger.Error(err, "Failed to update Stargate")
+					return result.Error(err)
 				}
 			}
 			if !actualStargate.Status.IsReady() {
 				logger.Info("Waiting for Stargate to become ready")
-				return ctrl.Result{RequeueAfter: r.ReconcilerConfig.DefaultDelay}, nil
+				return result.RequeueSoon(int(r.DefaultDelay))
 			}
 			logger.Info("Stargate is ready")
 		}
@@ -498,22 +236,22 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 			if errors.IsNotFound(err) {
 				// OK
 			} else {
-				logger.Error(err, "Failed to get Stargate resource", "Stargate", stargateKey)
-				return ctrl.Result{}, err
+				logger.Error(err, "Failed to get Stargate")
+				return result.Error(err)
 			}
 		} else if utils.IsCreatedByK8ssandraController(actualStargate, kcKey) {
 			if err := remoteClient.Delete(ctx, actualStargate); err != nil {
-				logger.Error(err, "Failed to delete Stargate resource", "Stargate", stargateKey)
-				return ctrl.Result{}, err
+				logger.Error(err, "Failed to delete Stargate")
+				return result.Error(err)
 			} else {
 				r.removeStargateStatus(kc, dcTemplate.Meta.Name)
-				logger.Info("Stargate deleted", "Stargate", stargateKey)
+				logger.Info("Stargate deleted")
 			}
 		} else {
-			logger.Info("Not deleting Stargate since it wasn't created by this controller", "Stargate", stargateKey)
+			logger.Info("Not deleting Stargate since it wasn't created by this controller")
 		}
 	}
-	return ctrl.Result{}, nil
+	return result.Continue()
 }
 
 func (r *K8ssandraClusterReconciler) newStargate(stargateKey types.NamespacedName, kc *api.K8ssandraCluster, stargateTemplate *stargateapi.StargateDatacenterTemplate, actualDc *cassdcapi.CassandraDatacenter) *stargateapi.Stargate {
@@ -537,25 +275,6 @@ func (r *K8ssandraClusterReconciler) newStargate(stargateKey types.NamespacedNam
 		},
 	}
 	return desiredStargate
-}
-
-// addSeedEndpoints returns a new slice with endpoints added to seeds and duplicates
-// removed.
-func addSeedEndpoints(seeds []string, endpoints ...string) []string {
-	updatedSeeds := make([]string, 0, len(seeds))
-	updatedSeeds = append(updatedSeeds, seeds...)
-
-	for _, endpoint := range endpoints {
-		if !utils.SliceContains(updatedSeeds, endpoint) {
-			updatedSeeds = append(updatedSeeds, endpoint)
-		}
-	}
-
-	// We must sort the results here to ensure consistent ordering. See
-	// https://github.com/k8ssandra/k8ssandra-operator/issues/80 for details.
-	sort.Strings(updatedSeeds)
-
-	return updatedSeeds
 }
 
 func (r *K8ssandraClusterReconciler) setStatusForDatacenter(kc *api.K8ssandraCluster, dc *cassdcapi.CassandraDatacenter) error {
@@ -600,6 +319,323 @@ func (r *K8ssandraClusterReconciler) setStatusForStargate(kc *api.K8ssandraClust
 		kc.Status.Datacenters[dcName].Stargate.Progress = stargateapi.StargateProgressPending
 	}
 	return nil
+}
+
+func (r *K8ssandraClusterReconciler) checkDeletion(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	if kc.DeletionTimestamp == nil {
+		return result.Continue()
+	}
+
+	if !controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
+		return result.Done()
+	}
+
+	logger.Info("Starting deletion")
+
+	kcKey := utils.GetKey(kc)
+	hasErrors := false
+
+	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+		namespace := dcTemplate.Meta.Namespace
+		if namespace == "" {
+			namespace = kc.Namespace
+		}
+
+		dcKey := client.ObjectKey{Namespace: namespace, Name: dcTemplate.Meta.Name}
+
+		remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+		if err != nil {
+			logger.Error(err, "Failed to get remote client", "Context", dcTemplate.K8sContext)
+			hasErrors = true
+			continue
+		}
+
+		dc := &cassdcapi.CassandraDatacenter{}
+		err = remoteClient.Get(ctx, dcKey, dc)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to get CassandraDatacenter for deletion",
+					"CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+				hasErrors = true
+			}
+		} else if err = remoteClient.Delete(ctx, dc); err != nil {
+			logger.Error(err, "Failed to delete CassandraDatacenter", "CassandraDatacenter", dcKey, "Context", dcTemplate.K8sContext)
+			hasErrors = true
+		}
+
+		selector := utils.CreatedByK8ssandraControllerLabels(kcKey)
+		stargateList := &stargateapi.StargateList{}
+		options := client.ListOptions{
+			Namespace:     namespace,
+			LabelSelector: labels.SelectorFromSet(selector),
+		}
+
+		err = remoteClient.List(ctx, stargateList, &options)
+		if err != nil {
+			logger.Error(err, "Failed to list Stargate objects", "Context", dcTemplate.K8sContext)
+			hasErrors = true
+			continue
+		}
+
+		for _, sg := range stargateList.Items {
+			if err = remoteClient.Delete(ctx, &sg); err != nil {
+				key := client.ObjectKey{Namespace: namespace, Name: sg.Name}
+				if !errors.IsNotFound(err) {
+					logger.Error(err, "Failed to delete Stargate", "Stargate", key,
+						"Context", dcTemplate.K8sContext)
+					hasErrors = true
+				}
+			}
+		}
+
+		if r.deleteReapers(ctx, kc, dcTemplate, namespace, remoteClient, logger) {
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		return result.RequeueSoon(int(r.DefaultDelay.Seconds()))
+	}
+
+	patch := client.MergeFrom(kc.DeepCopy())
+	controllerutil.RemoveFinalizer(kc, k8ssandraClusterFinalizer)
+	if err := r.Client.Patch(ctx, kc, patch); err != nil {
+		logger.Error(err, "Failed to remove finalizer")
+		return result.Error(err)
+	}
+
+	return result.Done()
+}
+
+func (r *K8ssandraClusterReconciler) checkFinalizer(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	if controllerutil.ContainsFinalizer(kc, k8ssandraClusterFinalizer) {
+		return result.Continue()
+	}
+
+	patch := client.MergeFrom(kc.DeepCopy())
+	controllerutil.AddFinalizer(kc, k8ssandraClusterFinalizer)
+	if err := r.Client.Patch(ctx, kc, patch); err != nil {
+		logger.Error(err, "Failed to add finalizer")
+		return result.Error(err)
+	}
+
+	return result.Continue()
+}
+
+func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	if kc.Spec.Cassandra.SuperuserSecretName == "" {
+		// Note that we do not persist this change because doing so would prevent us from
+		// differentiating between a default secret by the operator vs one provided by the
+		// client that happens to have the same name as the default name.
+		kc.Spec.Cassandra.SuperuserSecretName = secret.DefaultSuperuserSecretName(kc.Spec.Cassandra.Cluster)
+		logger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretName)
+	}
+
+	if err := secret.ReconcileSecret(ctx, r.Client, kc.Spec.Cassandra.SuperuserSecretName, utils.GetKey(kc)); err != nil {
+		logger.Error(err, "Failed to verify existence of superuserSecret")
+		return result.Error(err)
+	}
+
+	return result.Continue()
+}
+
+func (r *K8ssandraClusterReconciler) reconcileReplicatedSecret(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, r.Scheme, kc, logger); err != nil {
+		logger.Error(err, "Failed to reconcile ReplicatedSecret")
+		return result.Error(err)
+	}
+	return result.Continue()
+}
+
+func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) (result.ReconcileResult, []*cassdcapi.CassandraDatacenter) {
+	kcKey := utils.GetKey(kc)
+	systemReplication := cassandra.ComputeSystemReplication(kc)
+
+	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
+
+	seeds, err := r.findSeeds(ctx, kc, logger)
+	if err != nil {
+		logger.Error(err, "Failed to find seed nodes")
+		return result.Error(err), actualDcs
+	}
+
+	// Reconcile CassandraDatacenter objects only
+	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+
+		if !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcTemplate.K8sContext) {
+			// ReplicatedSecret has not replicated yet, wait until it has
+			logger.Info("Waiting for replication to complete")
+			return result.RequeueSoon(int(r.DefaultDelay.Seconds())), actualDcs
+		}
+
+		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
+		// its fields are pointers, and without the copy we could end of with shared
+		// references that would lead to unexpected and incorrect values.
+		dcConfig := cassandra.Coalesce(kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
+		cassandra.ApplySystemReplication(dcConfig, systemReplication)
+		if !cassandra.IsCassandra3(dcConfig.ServerVersion) && kc.HasStargates() {
+			// if we're not running Cassandra 3.11 and have Stargate pods, we need to allow alter RF during range movements
+			cassandra.AllowAlterRfDuringRangeMovement(dcConfig)
+		}
+		reaperTemplate := reaper.Coalesce(kc.Spec.Reaper.DeepCopy(), dcTemplate.Reaper.DeepCopy())
+		if reaperTemplate != nil {
+			reaper.AddReaperSettingsToDcConfig(reaperTemplate, dcConfig)
+		}
+		desiredDc, err := cassandra.NewDatacenter(kcKey, dcConfig)
+		dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
+		logger := logger.WithValues("CassandraDatacenter", dcKey, "K8SContext", dcTemplate.K8sContext)
+
+		if err != nil {
+			logger.Error(err, "Failed to create new CassandraDatacenter")
+			return result.Error(err), actualDcs
+		}
+
+		desiredDcHash := utils.DeepHashString(desiredDc)
+		desiredDc.Annotations[api.ResourceHashAnnotation] = desiredDcHash
+
+		actualDc := &cassdcapi.CassandraDatacenter{}
+
+		remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext)
+		if err != nil {
+			logger.Error(err, "Failed to get remote client")
+			return result.Error(err), actualDcs
+		}
+
+		// reconcile seeds
+		//
+		// The following if block was basically taken straight out of cass-operator. See
+		// https://github.com/k8ssandra/k8ssandra-operator/issues/210 for a detailed
+		// explanation of why this is being done.
+		//
+		// TODO Refactor the if block into a separate method/function.
+		// Note: Some other refactoring needs to be done first so that this can be done cleanly.
+		logger.Info("Reconciling seeds")
+		desiredEndpoints := newEndpoints(desiredDc, seeds)
+		actualEndpoints := &corev1.Endpoints{}
+		endpointsKey := client.ObjectKey{Namespace: desiredEndpoints.Namespace, Name: desiredEndpoints.Name}
+
+		if err = remoteClient.Get(ctx, endpointsKey, actualEndpoints); err == nil {
+			// If we already have an Endpoints object but no seeds then it probably means all
+			// Cassandra pods are down or not ready for some reason. In this case we will
+			// delete the Endpoints and let it get recreated once we have seed nodes.
+			if len(seeds) == 0 {
+				logger.Info("Deleting endpoints")
+				if err := remoteClient.Delete(ctx, actualEndpoints); err != nil {
+					logger.Error(err, "Failed to delete endpoints")
+					return result.Error(err), actualDcs
+				}
+			} else {
+				if !utils.CompareAnnotations(actualEndpoints, desiredEndpoints, api.ResourceHashAnnotation) {
+					logger.Info("Updating endpoints", "Endpoints", endpointsKey)
+					actualEndpoints := actualEndpoints.DeepCopy()
+					resourceVersion := actualEndpoints.GetResourceVersion()
+					desiredEndpoints.DeepCopyInto(actualEndpoints)
+					actualEndpoints.SetResourceVersion(resourceVersion)
+					if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
+						logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
+						return result.Error(err), actualDcs
+					}
+				}
+			}
+		} else {
+			if errors.IsNotFound(err) {
+				// If we have seeds then we want to go ahead and create the Endpoints. But
+				// if we don't have seeds, then we don't need to do anything for a couple
+				// of reasons. First, no seeds means that cass-operator has not labeled any
+				// pods as seeds which would be the case when the CassandraDatacenter is f
+				// first created and no pods have reached the ready state. Secondly, you
+				// cannot create an Endpoints object that has both empty Addresses and
+				// empty NotReadyAddresses.
+				if len(seeds) > 0 {
+					logger.Info("Creating endpoints", "Endpoints", endpointsKey)
+					if err = remoteClient.Create(ctx, desiredEndpoints); err != nil {
+						logger.Error(err, "Failed to create endpoints", "Endpoints", endpointsKey)
+						return result.Error(err), actualDcs
+					}
+				}
+			} else {
+				logger.Error(err, "Failed to get endpoints", "Endpoints", endpointsKey)
+				return result.Error(err), actualDcs
+			}
+		}
+
+		if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
+			// cassdc already exists, we'll update it
+			if err = r.setStatusForDatacenter(kc, actualDc); err != nil {
+				logger.Error(err, "Failed to update status for datacenter")
+				return result.Error(err), actualDcs
+			}
+
+			if actualHash, found := actualDc.Annotations[api.ResourceHashAnnotation]; !(found && actualHash == desiredDcHash) {
+				logger.Info("Updating datacenter")
+
+				if actualDc.Spec.SuperuserSecretName != desiredDc.Spec.SuperuserSecretName {
+					// If actualDc is created with SuperuserSecretName, it can't be changed anymore. We should reject all changes coming from K8ssandraCluster
+					desiredDc.Spec.SuperuserSecretName = actualDc.Spec.SuperuserSecretName
+					err = fmt.Errorf("tried to update superuserSecretName in K8ssandraCluster")
+					logger.Error(err, "SuperuserSecretName is immutable, reverting to existing value in CassandraDatacenter")
+				}
+
+				actualDc = actualDc.DeepCopy()
+				resourceVersion := actualDc.GetResourceVersion()
+				desiredDc.DeepCopyInto(actualDc)
+				actualDc.SetResourceVersion(resourceVersion)
+				if err = remoteClient.Update(ctx, actualDc); err != nil {
+					logger.Error(err, "Failed to update datacenter")
+					return result.Error(err), actualDcs
+				}
+			}
+
+			if !cassandra.DatacenterReady(actualDc) {
+				logger.Info("Waiting for datacenter to become ready")
+				return result.RequeueSoon(int(r.DefaultDelay)), actualDcs
+			}
+
+			logger.Info("The datacenter is ready")
+
+			actualDcs = append(actualDcs, actualDc)
+		} else {
+			if errors.IsNotFound(err) {
+				// cassdc doesn't exist, we'll create it
+				if err = remoteClient.Create(ctx, desiredDc); err != nil {
+					logger.Error(err, "Failed to create datacenter")
+					return result.Error(err), actualDcs
+				}
+				return result.RequeueSoon(int(r.DefaultDelay)), actualDcs
+			} else {
+				logger.Error(err, "Failed to get datacenter")
+				return result.Error(err), actualDcs
+			}
+		}
+	}
+
+	// If we reach this point all CassandraDatacenters are ready. We only set the
+	// CassandraInitialized condition if it is unset, i.e., only once. This allows us to
+	// distinguish whether we are deploying a CassandraDatacenter as part of a new cluster
+	// or as part of an existing cluster.
+	if kc.Status.GetConditionStatus(api.CassandraInitialized) == corev1.ConditionUnknown {
+		now := metav1.Now()
+		(&kc.Status).SetCondition(api.K8ssandraClusterCondition{
+			Type:               api.CassandraInitialized,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: &now,
+		})
+	}
+
+	return result.Continue(), actualDcs
+}
+
+func (r *K8ssandraClusterReconciler) checkStargateAuthSchema(ctx context.Context, kc *api.K8ssandraCluster, dcs []*cassdcapi.CassandraDatacenter, logger logr.Logger) result.ReconcileResult {
+	if kc.HasStargates() {
+		logger.Info("Reconciling Stargate auth schema")
+		dcTemplate := kc.Spec.Cassandra.Datacenters[0]
+		if remoteClient, err := r.ClientCache.GetRemoteClient(dcTemplate.K8sContext); err != nil {
+			return result.Error(err)
+		} else if err := r.reconcileStargateAuthSchema(ctx, kc, dcs[0], remoteClient, logger); err != nil {
+			return result.Error(err)
+		}
+	}
+	return result.Continue()
 }
 
 func (r *K8ssandraClusterReconciler) reconcileStargateAuthSchema(

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -135,10 +135,6 @@ func (r *K8ssandraClusterReconciler) reconcile(ctx context.Context, kc *api.K8ss
 
 	kcLogger.Info("All dcs reconciled")
 
-	if len(kc.Spec.Cassandra.Datacenters) > 1 {
-		kcLogger.Info("DEBUG::TEMPLATE", "DcTemplate", kc.Spec.Cassandra.Datacenters[1])
-	}
-
 	if recResult := r.reconcileStargateAuthSchema(ctx, kc, actualDcs, kcLogger); recResult.Completed() {
 		return recResult.Output()
 	}
@@ -184,7 +180,6 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 ) result.ReconcileResult {
 
 	kcKey := client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}
-	logger.Info("DEBUG", "DcTemplate", dcTemplate)
 	stargateTemplate := dcTemplate.Stargate.Coalesce(kc.Spec.Stargate)
 	stargateKey := types.NamespacedName{
 		Namespace: actualDc.Namespace,

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -201,7 +201,7 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 					logger.Error(err, "Failed to create Stargate resource")
 					return result.Error(err)
 				} else {
-					return result.RequeueSoon(int(r.DefaultDelay))
+					return result.RequeueSoon(r.DefaultDelay)
 				}
 			} else {
 				logger.Error(err, "Failed to get Stargate resource")
@@ -218,7 +218,7 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 				desiredStargate.DeepCopyInto(actualStargate)
 				actualStargate.SetResourceVersion(resourceVersion)
 				if err = remoteClient.Update(ctx, actualStargate); err == nil {
-					return result.RequeueSoon(int(r.DefaultDelay))
+					return result.RequeueSoon(r.DefaultDelay)
 				} else {
 					logger.Error(err, "Failed to update Stargate")
 					return result.Error(err)
@@ -226,7 +226,7 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 			}
 			if !actualStargate.Status.IsReady() {
 				logger.Info("Waiting for Stargate to become ready")
-				return result.RequeueSoon(int(r.DefaultDelay))
+				return result.RequeueSoon(r.DefaultDelay)
 			}
 			logger.Info("Stargate is ready")
 		}
@@ -396,7 +396,7 @@ func (r *K8ssandraClusterReconciler) checkDeletion(ctx context.Context, kc *api.
 	}
 
 	if hasErrors {
-		return result.RequeueSoon(int(r.DefaultDelay.Seconds()))
+		return result.RequeueSoon(r.DefaultDelay)
 	}
 
 	patch := client.MergeFrom(kc.DeepCopy())
@@ -467,7 +467,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		if !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcTemplate.K8sContext) {
 			// ReplicatedSecret has not replicated yet, wait until it has
 			logger.Info("Waiting for replication to complete")
-			return result.RequeueSoon(int(r.DefaultDelay.Seconds())), actualDcs
+			return result.RequeueSoon(r.DefaultDelay), actualDcs
 		}
 
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
@@ -535,7 +535,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 			if !cassandra.DatacenterReady(actualDc) {
 				logger.Info("Waiting for datacenter to become ready")
-				return result.RequeueSoon(int(r.DefaultDelay)), actualDcs
+				return result.RequeueSoon(r.DefaultDelay), actualDcs
 			}
 
 			logger.Info("The datacenter is ready")
@@ -548,7 +548,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 					logger.Error(err, "Failed to create datacenter")
 					return result.Error(err), actualDcs
 				}
-				return result.RequeueSoon(int(r.DefaultDelay)), actualDcs
+				return result.RequeueSoon(r.DefaultDelay), actualDcs
 			} else {
 				logger.Error(err, "Failed to get datacenter")
 				return result.Error(err), actualDcs

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -735,13 +735,6 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	err := f.Client.Create(ctx, cluster)
 	require.NoError(err, "failed to create K8ssandraCluster")
 
-	dc1PodIps := []string{"10.10.100.1", "10.10.100.2", "10.10.100.3"}
-	dc2PodIps := []string{"10.11.100.1", "10.11.100.2", "10.11.100.3"}
-
-	allPodIps := make([]string, 0, 6)
-	allPodIps = append(allPodIps, dc1PodIps...)
-	allPodIps = append(allPodIps, dc2PodIps...)
-
 	verifySuperUserSecretCreated(ctx, t, f, cluster)
 
 	verifyReplicatedSecretReconciled(ctx, t, f, cluster)
@@ -917,13 +910,6 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	err := f.Client.Create(ctx, kc)
 	require.NoError(err, "failed to create K8ssandraCluster")
 
-	dc1PodIps := []string{"10.10.100.1", "10.10.100.2", "10.10.100.3"}
-	dc2PodIps := []string{"10.11.100.1", "10.11.100.2", "10.11.100.3"}
-
-	allPodIps := make([]string, 0, 6)
-	allPodIps = append(allPodIps, dc1PodIps...)
-	allPodIps = append(allPodIps, dc2PodIps...)
-
 	verifySuperUserSecretCreated(ctx, t, f, kc)
 
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
@@ -1004,11 +990,6 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	t.Log("check that dc2 was created")
 	require.Eventually(f.DatacenterExists(ctx, dc2Key), timeout, interval)
 
-	t.Log("check that remote seeds are set on dc2")
-	dc2 = &cassdcapi.CassandraDatacenter{}
-	err = f.Get(ctx, dc2Key, dc2)
-	require.NoError(err, "failed to get dc2")
-
 	sg2Key := framework.ClusterKey{
 		K8sContext: k8sCtx1,
 		NamespacedName: types.NamespacedName{
@@ -1045,6 +1026,11 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 		})
 	})
 	require.NoError(err, "failed to patch stargate status")
+
+	k := &api.K8ssandraCluster{}
+	err = f.Get(ctx, kcKey, k)
+	require.NoError(err)
+	require.NotNil(k.Spec.Cassandra.Datacenters[1].Stargate)
 
 	t.Logf("check that stargate %s has not been created", sg2Key)
 	sg2 := &stargateapi.Stargate{}

--- a/controllers/k8ssandra/reaper_reconciler.go
+++ b/controllers/k8ssandra/reaper_reconciler.go
@@ -133,7 +133,7 @@ func (r *K8ssandraClusterReconciler) reconcileReaper(
 					logger.Error(err, "Failed to create Reaper resource")
 					return result.Error(err)
 				} else {
-					return result.RequeueSoon(int(r.DefaultDelay))
+					return result.RequeueSoon(r.DefaultDelay)
 				}
 			} else {
 				logger.Error(err, "failed to retrieve reaper instance")
@@ -157,12 +157,12 @@ func (r *K8ssandraClusterReconciler) reconcileReaper(
 				logger.Error(err, "Failed to update Reaper resource")
 				return result.Error(err)
 			}
-			return result.RequeueSoon(int(r.DefaultDelay))
+			return result.RequeueSoon(r.DefaultDelay)
 		}
 
 		if !actualReaper.Status.IsReady() {
 			logger.Info("Waiting for Reaper to become ready")
-			return result.RequeueSoon(int(r.DefaultDelay))
+			return result.RequeueSoon(r.DefaultDelay)
 		}
 
 		logger.Info("Reaper is ready")

--- a/controllers/k8ssandra/reaper_reconciler.go
+++ b/controllers/k8ssandra/reaper_reconciler.go
@@ -65,7 +65,7 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 	return result.Continue()
 }
 
-func (r *K8ssandraClusterReconciler) recocileReaperSchema(ctx context.Context, kc *api.K8ssandraCluster, dcs []*cassdcapi.CassandraDatacenter, logger logr.Logger) result.ReconcileResult {
+func (r *K8ssandraClusterReconciler) reconcileReaperSchema(ctx context.Context, kc *api.K8ssandraCluster, dcs []*cassdcapi.CassandraDatacenter, logger logr.Logger) result.ReconcileResult {
 	if !kc.HasReapers() {
 		return result.Continue()
 	}

--- a/pkg/result/result_helper.go
+++ b/pkg/result/result_helper.go
@@ -1,0 +1,71 @@
+package result
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
+)
+
+// Copyright DataStax, Inc.
+// Please see the included license file for details.
+
+type ReconcileResult interface {
+	Completed() bool
+	Output() (ctrl.Result, error)
+}
+
+type continueReconcile struct{}
+
+func (c continueReconcile) Completed() bool {
+	return false
+}
+func (c continueReconcile) Output() (ctrl.Result, error) {
+	panic("there was no Result to return")
+}
+
+type done struct{}
+
+func (d done) Completed() bool {
+	return true
+}
+func (d done) Output() (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+type callBackSoon struct {
+	secs int
+}
+
+func (c callBackSoon) Completed() bool {
+	return true
+}
+func (c callBackSoon) Output() (ctrl.Result, error) {
+	t := time.Duration(c.secs) * time.Second
+	return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+}
+
+type errorOut struct {
+	err error
+}
+
+func (e errorOut) Completed() bool {
+	return true
+}
+func (e errorOut) Output() (ctrl.Result, error) {
+	return ctrl.Result{}, e.err
+}
+
+func Continue() ReconcileResult {
+	return continueReconcile{}
+}
+
+func Done() ReconcileResult {
+	return done{}
+}
+
+func RequeueSoon(secs int) ReconcileResult {
+	return callBackSoon{secs: secs}
+}
+
+func Error(e error) ReconcileResult {
+	return errorOut{err: e}
+}

--- a/pkg/result/result_helper.go
+++ b/pkg/result/result_helper.go
@@ -32,15 +32,14 @@ func (d done) Output() (ctrl.Result, error) {
 }
 
 type callBackSoon struct {
-	secs int
+	after time.Duration
 }
 
 func (c callBackSoon) Completed() bool {
 	return true
 }
 func (c callBackSoon) Output() (ctrl.Result, error) {
-	t := time.Duration(c.secs) * time.Second
-	return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	return ctrl.Result{Requeue: true, RequeueAfter: c.after}, nil
 }
 
 type errorOut struct {
@@ -62,8 +61,8 @@ func Done() ReconcileResult {
 	return done{}
 }
 
-func RequeueSoon(secs int) ReconcileResult {
-	return callBackSoon{secs: secs}
+func RequeueSoon(after time.Duration) ReconcileResult {
+	return callBackSoon{after: after}
 }
 
 func Error(e error) ReconcileResult {

--- a/pkg/utils/objects.go
+++ b/pkg/utils/objects.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetKey(obj metav1.Object) client.ObjectKey {
+	return client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}


### PR DESCRIPTION
Temporarily copy ReconcileResult interface into project until it is publicly
available in cass-operator.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Introduces the usage of ReconcileResult in K8ssandraClusterReconciler. Using ReconcileResult allows us to more easily refactor the Reconciler into smaller methods.

Other Reconcilers, ReaperReconciler, StargateReconciler, and SecretSyncController, can be updated to use ReconcileResult as necessary in subsequent PRs. 

**Which issue(s) this PR fixes**:
Fixes #232

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
