### PR TITLE
Fix broken Reaper and Stargate status updates

### DIFF
--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -246,7 +246,8 @@ type ReaperStatus struct {
 
 	// Progress is the progress of this Reaper object.
 	// +kubebuilder:validation:Enum=Pending;Deploying;Configuring;Running
-	Progress ReaperProgress `json:"progress"`
+	// +optional
+	Progress ReaperProgress `json:"progress,omitempty"`
 
 	// +optional
 	Conditions []ReaperCondition `json:"conditions,omitempty"`

--- a/apis/stargate/v1alpha1/stargate_types.go
+++ b/apis/stargate/v1alpha1/stargate_types.go
@@ -194,7 +194,8 @@ type StargateStatus struct {
 
 	// Progress is the progress of this Stargate object.
 	// +kubebuilder:validation:Enum=Pending;Deploying;Running
-	Progress StargateProgress `json:"progress"`
+	// +optional
+	Progress StargateProgress `json:"progress,omitempty"`
 
 	// +optional
 	Conditions []StargateCondition `json:"conditions,omitempty"`

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -9686,8 +9686,6 @@ spec:
                           - Configuring
                           - Running
                           type: string
-                      required:
-                      - progress
                       type: object
                     stargate:
                       description: StargateStatus defines the observed state of a
@@ -9760,7 +9758,6 @@ spec:
                           type: integer
                       required:
                       - availableReplicas
-                      - progress
                       - readyReplicas
                       - replicas
                       - updatedReplicas

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1876,8 +1876,6 @@ spec:
                 - Configuring
                 - Running
                 type: string
-            required:
-            - progress
             type: object
         type: object
     served: true

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -2745,7 +2745,6 @@ spec:
                 type: integer
             required:
             - availableReplicas
-            - progress
             - readyReplicas
             - replicas
             - updatedReplicas


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
When a Reaper or a Stargate resource is created,
it has no status, but currently this means that
they are transmitted to the API server with a
JSON payload that contains:

    status:{progress:""}

This is obviously not valid and the following
error is raised when the K8ssandraCluster
resource status is updated:

    ERRO[0048] failed to update k8ssandracluster status
    K8ssandraCluster="{\"Namespace\":\"tnkdjg4zx\",\"Name\":\"test\"}"
    error="K8ssandraCluster.k8ssandra.io \"test\" is invalid:
    status.datacenters.dc1.reaper.progress: Unsupported value: \"\":
    supported values: \"Pending\", \"Deploying\", \"Configuring\",
    \"Running\""

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
