### PR TITLE
Revisit cluster name and derived resource names [K8SSAND-1125]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -25,6 +25,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#234](https://github.com/k8ssandra/k8ssandra-operator/issues/234) Add logic to configure and reconcile a Prometheus ServiceMonitor for each Stargate deployment.
 * [CHANGE] [#136](https://github.com/k8ssandra/k8ssandra-operator/issues/136) Add shortNames for the K8ssandraCluster CRD
 * [ENHANCEMENT] [#170](https://github.com/k8ssandra/k8ssandra-operator/issues/170) Enforce cluster-wide authentication by default 
+* [ENHANCEMENT] [#267](https://github.com/k8ssandra/k8ssandra-operator/issues/267) Use the K8ssandraCluster name as cluster name for CassandraDatacenter objects
 
 ## v1.0.0-alpha.2 - 2021-12-03
 

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -110,7 +110,8 @@ type K8ssandraStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=k8ssandraclusters,shortName=k8c;k8cs
 
-// K8ssandraCluster is the Schema for the k8ssandraclusters API
+// K8ssandraCluster is the Schema for the k8ssandraclusters API. The K8ssandraCluster CRD name is also the name of the
+// Cassandra cluster (which corresponds to cluster_name in cassandra.yaml).
 type K8ssandraCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -165,14 +166,10 @@ type K8ssandraClusterList struct {
 }
 
 type CassandraClusterTemplate struct {
-	// Cluster is the name of the cluster. This corresponds to cluster_name in
-	// cassandra.yaml.
-	// +kubebuilder:validation:MinLength=2
-	Cluster string `json:"cluster,omitempty"`
 
 	// The reference to the superuser secret to use for Cassandra. If unspecified, a default secret will be generated
 	// with a random password; the generated secret name will be "<cluster_name>-superuser" where <cluster_name> is the
-	// Cassandra cluster name specified above.
+	// K8ssandraCluster CRD name.
 	// +optional
 	SuperuserSecretRef corev1.LocalObjectReference `json:"superuserSecretRef,omitempty"`
 

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types_test.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types_test.go
@@ -36,7 +36,6 @@ func testK8ssandraClusterHasStargates(t *testing.T) {
 		kc := K8ssandraCluster{
 			Spec: K8ssandraClusterSpec{
 				Cassandra: &CassandraClusterTemplate{
-					Cluster: "cluster1",
 					Datacenters: []CassandraDatacenterTemplate{
 						{
 							Size:     3,
@@ -81,7 +80,6 @@ func testK8ssandraClusterHasReapers(t *testing.T) {
 		kc := K8ssandraCluster{
 			Spec: K8ssandraClusterSpec{
 				Cassandra: &CassandraClusterTemplate{
-					Cluster: "cluster1",
 					Datacenters: []CassandraDatacenterTemplate{
 						{
 							Size:   3,

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -22,7 +22,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: K8ssandraCluster is the Schema for the k8ssandraclusters API
+        description: K8ssandraCluster is the Schema for the k8ssandraclusters API.
+          The K8ssandraCluster CRD name is also the name of the Cassandra cluster
+          (which corresponds to cluster_name in cassandra.yaml).
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -74,11 +76,6 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  cluster:
-                    description: Cluster is the name of the cluster. This corresponds
-                      to cluster_name in cassandra.yaml.
-                    minLength: 2
-                    type: string
                   config:
                     description: CassandraConfig is configuration settings that are
                       applied to cassandra.yaml and jvm-options for 3.11.x or jvm-server-options
@@ -8229,8 +8226,7 @@ spec:
                     description: The reference to the superuser secret to use for
                       Cassandra. If unspecified, a default secret will be generated
                       with a random password; the generated secret name will be "<cluster_name>-superuser"
-                      where <cluster_name> is the Cassandra cluster name specified
-                      above.
+                      where <cluster_name> is the K8ssandraCluster CRD name.
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -26,12 +26,11 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      "cluster1",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Auth: pointer.BoolPtr(false),
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "cluster1",
 				Datacenters: []api.CassandraDatacenterTemplate{{
 					Meta:          api.EmbeddedObjectMeta{Name: "dc1"},
 					K8sContext:    "cluster-1",
@@ -59,8 +58,8 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Spec.Cassandra.Cluster))
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Spec.Cassandra.Cluster))
+	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Name))
+	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Name))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
@@ -145,12 +144,11 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      "cluster1",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Auth: pointer.BoolPtr(true),
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "cluster1",
 				Datacenters: []api.CassandraDatacenterTemplate{{
 					Meta:          api.EmbeddedObjectMeta{Name: "dc1"},
 					K8sContext:    "cluster-1",
@@ -178,8 +176,8 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
-	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Spec.Cassandra.Cluster))
-	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Spec.Cassandra.Cluster))
+	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Name))
+	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Name))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -47,7 +47,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
 		// its fields are pointers, and without the copy we could end of with shared
 		// references that would lead to unexpected and incorrect values.
-		dcConfig := cassandra.Coalesce(kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
+		dcConfig := cassandra.Coalesce(kc.Name, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
 		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled())
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -114,7 +114,6 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -236,7 +235,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 		return true
 	}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
 
-	//Test that prometheus servicemonitor comes up when it is requested in the CassandraDatacenter.
+	// Test that prometheus servicemonitor comes up when it is requested in the CassandraDatacenter.
 	kcPatch := client.MergeFrom(kc.DeepCopy())
 	kc.Spec.Cassandra.Datacenters[0].CassandraTelemetry = &telemetryapi.TelemetrySpec{
 		Prometheus: &telemetryapi.PrometheusTelemetrySpec{
@@ -309,11 +308,10 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      clusterName,
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster:            clusterName,
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
 				ServerVersion:      serverVersion,
 				StorageConfig: &cassdcapi.StorageConfig{
@@ -374,7 +372,7 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 	err = f.Get(ctx, dc1Key, dc1)
 	require.NoError(err, "failed to get dc1")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc1.Spec.ClusterName)
+	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(kc.Spec.Cassandra.ServerVersion, dc1.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(dc1Size, dc1.Spec.Size)
@@ -400,7 +398,7 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc2.Spec.ClusterName)
+	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(kc.Spec.Cassandra.ServerVersion, dc2.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(dc2Size, dc2.Spec.Size)
@@ -437,11 +435,10 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      clusterName,
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster:       clusterName,
 				ServerVersion: serverVersion,
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
@@ -532,7 +529,7 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 	err = f.Get(ctx, dc1Key, dc1)
 	require.NoError(err, "failed to get dc1")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc1.Spec.ClusterName)
+	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(serverVersion, dc1.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.Datacenters[0].StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[0].Networking, dc1.Spec.Networking)
@@ -558,7 +555,7 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc2.Spec.ClusterName)
+	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(serverVersion, dc2.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].Networking, dc2.Spec.Networking)
@@ -596,11 +593,10 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      clusterName,
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster:       clusterName,
 				ServerVersion: serverVersion,
 				StorageConfig: &cassdcapi.StorageConfig{
 					CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
@@ -687,7 +683,7 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	err = f.Get(ctx, dc1Key, dc1)
 	require.NoError(err, "failed to get dc1")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc1.Spec.ClusterName)
+	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(serverVersion, dc1.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Networking, dc1.Spec.Networking)
@@ -713,7 +709,7 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	err = f.Get(ctx, dc2Key, dc2)
 	require.NoError(err, "failed to get dc2")
 
-	assert.Equal(kc.Spec.Cassandra.Cluster, dc2.Spec.ClusterName)
+	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(serverVersion, dc2.Spec.ServerVersion)
 	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].Networking, dc2.Spec.Networking)
@@ -758,14 +754,14 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	k8sCtx0 := "cluster-0"
 	k8sCtx1 := "cluster-1"
 
+	clusterName := "cluster-multi"
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      clusterName,
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "cluster-multi",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -823,7 +819,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 	})
 	require.NoError(err, "failed to patch datacenter status")
 
-	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: clusterName}}
 
 	t.Log("check that the K8ssandraCluster status is updated")
 	require.Eventually(func() bool {
@@ -927,14 +923,14 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	k8sCtx0 := "cluster-0"
 	k8sCtx1 := "cluster-1"
 
+	clusterName := "cluster-multi-stargate"
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "test",
+			Name:      clusterName,
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "cluster-multi-stargate",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -1002,7 +998,7 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 	})
 	require.NoError(err, "failed to patch datacenter status")
 
-	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+	kcKey := framework.ClusterKey{K8sContext: k8sCtx0, NamespacedName: types.NamespacedName{Namespace: namespace, Name: clusterName}}
 
 	t.Log("check that the K8ssandraCluster status is updated")
 	require.Eventually(func() bool {
@@ -1036,7 +1032,7 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 		K8sContext: k8sCtx0,
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      kc.Spec.Cassandra.Cluster + "-" + dc1Key.Name + "-stargate"},
+			Name:      kc.Name + "-" + dc1Key.Name + "-stargate"},
 	}
 
 	t.Logf("check that stargate %s has not been created", sg1Key)
@@ -1068,7 +1064,7 @@ func createMultiDcClusterWithStargate(t *testing.T, ctx context.Context, f *fram
 		K8sContext: k8sCtx1,
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      kc.Spec.Cassandra.Cluster + "-" + dc2Key.Name + "-stargate"},
+			Name:      kc.Name + "-" + dc2Key.Name + "-stargate"},
 	}
 
 	t.Log("update dc2 status to ready")
@@ -1211,7 +1207,6 @@ func changeNumTokensValue(t *testing.T, ctx context.Context, f *framework.Framew
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "test",
 				CassandraConfig: &api.CassandraConfig{
 					CassandraYaml: api.CassandraYaml{
 						NumTokens: pointer.Int(16),
@@ -1317,7 +1312,7 @@ func verifySuperuserSecretCreated(ctx context.Context, t *testing.T, f *framewor
 func superuserSecretExists(f *framework.Framework, ctx context.Context, kluster *api.K8ssandraCluster) func() bool {
 	secretName := kluster.Spec.Cassandra.SuperuserSecretRef.Name
 	if secretName == "" {
-		secretName = secret.DefaultSuperuserSecretName(kluster.Spec.Cassandra.Cluster)
+		secretName = secret.DefaultSuperuserSecretName(kluster.Name)
 	}
 	return secretExists(f, ctx, kluster.Namespace, secretName)
 }

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -98,11 +98,11 @@ func (r *K8ssandraClusterReconciler) reconcileMedusaConfigMap(
 		medusaIni := medusa.CreateMedusaIni(kc)
 		configMapKey := client.ObjectKey{
 			Namespace: kc.Namespace,
-			Name:      fmt.Sprintf("%s-medusa", kc.Spec.Cassandra.Cluster),
+			Name:      fmt.Sprintf("%s-medusa", kc.Name),
 		}
 
 		logger := logger.WithValues("MedusaConfigMap", configMapKey)
-		desiredConfigMap := medusa.CreateMedusaConfigMap(namespace, kc.Spec.Cassandra.Cluster, medusaIni)
+		desiredConfigMap := medusa.CreateMedusaConfigMap(namespace, kc.Name, medusaIni)
 		// Compute a hash which will allow to compare desired and actual configMaps
 		annotations.AddHashAnnotation(desiredConfigMap)
 		actualConfigMap := &corev1.ConfigMap{}

--- a/controllers/k8ssandra/medusa_reconciler_test.go
+++ b/controllers/k8ssandra/medusa_reconciler_test.go
@@ -38,7 +38,6 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -232,7 +231,7 @@ func checkMedusaObjectsCompliance(t *testing.T, f *framework.Framework, dc *cass
 		assert.True(t, f.ContainerHasVolumeMount(container, "server-data", "/var/lib/cassandra"), "Missing Volume Mount for medusa-restore server-data")
 		assert.True(t, f.ContainerHasVolumeMount(container, "podinfo", "/etc/podinfo"), "Missing Volume Mount for medusa-restore podinfo")
 		assert.True(t, f.ContainerHasVolumeMount(container, cassandraUserSecret, "/etc/medusa-secrets"), "Missing Volume Mount for medusa-restore podinfo")
-		assert.True(t, f.ContainerHasVolumeMount(container, fmt.Sprintf("%s-medusa", kc.Spec.Cassandra.Cluster), "/etc/medusa"), "Missing Volume Mount for medusa-restore medusa config")
+		assert.True(t, f.ContainerHasVolumeMount(container, fmt.Sprintf("%s-medusa", kc.Name), "/etc/medusa"), "Missing Volume Mount for medusa-restore medusa config")
 
 		// Check env vars
 		if container.Name == "medusa" {

--- a/controllers/k8ssandra/reaper_test.go
+++ b/controllers/k8ssandra/reaper_test.go
@@ -30,7 +30,6 @@ func createMultiDcClusterWithReaper(t *testing.T, ctx context.Context, f *framew
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -21,7 +21,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 		// Note that we do not persist this change because doing so would prevent us from
 		// differentiating between a default secret by the operator vs one provided by the
 		// client that happens to have the same name as the default name.
-		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.Spec.Cassandra.Cluster)
+		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.Name)
 		logger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretRef.Name)
 	}
 
@@ -40,11 +40,11 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 			logger.Info("Reconciling Reaper user secrets")
 			cassandraUserSecretRef := kc.Spec.Reaper.CassandraUserSecretRef
 			if cassandraUserSecretRef.Name == "" {
-				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Spec.Cassandra.Cluster)
+				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Name)
 			}
 			jmxUserSecretRef := kc.Spec.Reaper.JmxUserSecretRef
 			if jmxUserSecretRef.Name == "" {
-				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.Spec.Cassandra.Cluster)
+				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.Name)
 			}
 			kcKey := utils.GetKey(kc)
 			if err := secret.ReconcileSecret(ctx, r.Client, cassandraUserSecretRef.Name, kcKey); err != nil {

--- a/controllers/k8ssandra/seeds.go
+++ b/controllers/k8ssandra/seeds.go
@@ -32,7 +32,7 @@ func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ss
 
 		list := &corev1.PodList{}
 		selector := map[string]string{
-			cassdcapi.ClusterLabel:    kc.Spec.Cassandra.Cluster,
+			cassdcapi.ClusterLabel:    kc.Name,
 			cassdcapi.DatacenterLabel: dcTemplate.Meta.Name,
 			cassdcapi.SeedNodeLabel:   "true",
 		}

--- a/controllers/medusa/backup_controller_test.go
+++ b/controllers/medusa/backup_controller_test.go
@@ -43,7 +43,6 @@ func testBackupDatacenter(t *testing.T, ctx context.Context, f *framework.Framew
 		},
 		Spec: k8ss.K8ssandraClusterSpec{
 			Cassandra: &k8ss.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []k8ss.CassandraDatacenterTemplate{
 					{
 						Meta: k8ss.EmbeddedObjectMeta{

--- a/controllers/medusa/cassandrabackup_controller.go
+++ b/controllers/medusa/cassandrabackup_controller.go
@@ -1,6 +1,7 @@
 /*
 
 
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -214,7 +215,7 @@ func (r *CassandraBackupReconciler) addCassdcSpecToStatus(ctx context.Context, b
 			// I had to comment out the following line because it was causing the backup to fail as it seems to expect bytes for the config
 			// The next version of k8ssandra backup/restore will remove all references to a cassdc anyway and rather rely on the token map stored
 			// in the medusa backups.
-			//Config:                 cassdc.Spec.Config,
+			// Config:                 cassdc.Spec.Config,
 			ManagementApiAuth:      cassdc.Spec.ManagementApiAuth,
 			Resources:              cassdc.Spec.Resources,
 			SystemLoggerResources:  cassdc.Spec.SystemLoggerResources,

--- a/controllers/medusa/restore_controller_test.go
+++ b/controllers/medusa/restore_controller_test.go
@@ -33,7 +33,6 @@ func testInPlaceRestore(t *testing.T, ctx context.Context, f *framework.Framewor
 		},
 		Spec: k8ss.K8ssandraClusterSpec{
 			Cassandra: &k8ss.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []k8ss.CassandraDatacenterTemplate{
 					{
 						Meta: k8ss.EmbeddedObjectMeta{

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -191,11 +191,11 @@ func UpdateInitContainer(p *corev1.PodTemplateSpec, name string, f func(c *corev
 
 // Coalesce combines the cluster and dc templates with override semantics. If a property is
 // defined in both templates, the dc-level property takes precedence.
-func Coalesce(clusterTemplate *api.CassandraClusterTemplate, dcTemplate *api.CassandraDatacenterTemplate) *DatacenterConfig {
+func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate, dcTemplate *api.CassandraDatacenterTemplate) *DatacenterConfig {
 	dcConfig := &DatacenterConfig{}
 
 	// Handler cluster-wide settings first
-	dcConfig.Cluster = clusterTemplate.Cluster
+	dcConfig.Cluster = clusterName
 	dcConfig.SuperuserSecretRef = clusterTemplate.SuperuserSecretRef
 
 	// DC-level settings

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -21,24 +21,21 @@ func TestCoalesce(t *testing.T) {
 	mgmtAPIHeap := resource.MustParse("999M")
 
 	type test struct {
-		name string
-
+		name            string
+		clusterName     string
 		clusterTemplate *api.CassandraClusterTemplate
-
-		dcTemplate *api.CassandraDatacenterTemplate
-
-		got *DatacenterConfig
-
-		want *DatacenterConfig
+		dcTemplate      *api.CassandraDatacenterTemplate
+		got             *DatacenterConfig
+		want            *DatacenterConfig
 	}
 
 	tests := []test{
 		{
 			// There are some properties that should only be set at the cluster-level
 			// and should not differ among DCs.
-			name: "Set non-override configs",
+			name:        "Set non-override configs",
+			clusterName: "k8ssandra",
 			clusterTemplate: &api.CassandraClusterTemplate{
-				Cluster:            "k8ssandra",
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
 			},
 			dcTemplate: &api.CassandraDatacenterTemplate{
@@ -239,9 +236,9 @@ func TestCoalesce(t *testing.T) {
 			},
 		},
 		{
-			name: "set management api heap size from DatacenterTemplate",
+			name:        "set management api heap size from DatacenterTemplate",
+			clusterName: "k8ssandra",
 			clusterTemplate: &api.CassandraClusterTemplate{
-				Cluster:            "k8ssandra",
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
 			},
 			dcTemplate: &api.CassandraDatacenterTemplate{
@@ -270,9 +267,9 @@ func TestCoalesce(t *testing.T) {
 			},
 		},
 		{
-			name: "set management api heap size from CassandraClusterTemplate",
+			name:        "set management api heap size from CassandraClusterTemplate",
+			clusterName: "k8ssandra",
 			clusterTemplate: &api.CassandraClusterTemplate{
-				Cluster:            "k8ssandra",
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
 				MgmtAPIHeap:        &mgmtAPIHeap,
 			},
@@ -316,7 +313,7 @@ func TestCoalesce(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.got = Coalesce(tc.clusterTemplate, tc.dcTemplate)
+			tc.got = Coalesce(tc.clusterName, tc.clusterTemplate, tc.dcTemplate)
 			require.Equal(t, tc.want, tc.got)
 		})
 	}

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -39,7 +39,7 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster) string {
     [storage]
     storage_provider = {{ .Spec.Medusa.StorageProperties.StorageProvider }}
     {{- if eq .Spec.Medusa.StorageProperties.StorageProvider "local" }}
-    bucket_name = {{ .Spec.Cassandra.Cluster }}
+    bucket_name = {{ .Name }}
     base_path = /mnt/backups
     {{- else }}
     bucket_name = {{ .Spec.Medusa.StorageProperties.BucketName }}
@@ -48,7 +48,7 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster) string {
     {{- if .Spec.Medusa.StorageProperties.Prefix }}
     prefix = {{ .Spec.Medusa.StorageProperties.Prefix }}
     {{- else }}
-    prefix = {{ .Spec.Cassandra.Cluster }}
+    prefix = {{ .Name }}
     {{- end }}
     max_backup_age = {{ .Spec.Medusa.StorageProperties.MaxBackupAge }}
     max_backup_count = {{ .Spec.Medusa.StorageProperties.MaxBackupCount }}

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -26,7 +26,6 @@ func testMedusaIniFull(t *testing.T) {
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "test",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -85,11 +84,10 @@ func testMedusaIniNoPrefix(t *testing.T) {
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
-			Name:      "test",
+			Name:      "demo",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "demo",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -146,11 +144,10 @@ func testMedusaIniSecured(t *testing.T) {
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
-			Name:      "test",
+			Name:      "demo",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "demo",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -207,11 +204,10 @@ func testMedusaIniUnsecured(t *testing.T) {
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
-			Name:      "test",
+			Name:      "demo",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "demo",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{
@@ -268,11 +264,10 @@ func testMedusaIniMissingOptionalSettings(t *testing.T) {
 	kc := &api.K8ssandraCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
-			Name:      "test",
+			Name:      "demo",
 		},
 		Spec: api.K8ssandraClusterSpec{
 			Cassandra: &api.CassandraClusterTemplate{
-				Cluster: "demo",
 				Datacenters: []api.CassandraDatacenterTemplate{
 					{
 						Meta: api.EmbeddedObjectMeta{

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -52,10 +52,10 @@ func NewReaper(
 		// that the k8ssandra controller created two secrets with default names, and we need to manually fill in this
 		// info in desiredReaper.Spec since it wasn't persisted in reaperTemplate.
 		if desiredReaper.Spec.CassandraUserSecretRef.Name == "" {
-			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.Spec.Cassandra.Cluster)
+			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.Name)
 		}
 		if desiredReaper.Spec.JmxUserSecretRef.Name == "" {
-			desiredReaper.Spec.JmxUserSecretRef.Name = DefaultJmxUserSecretName(kc.Spec.Cassandra.Cluster)
+			desiredReaper.Spec.JmxUserSecretRef.Name = DefaultJmxUserSecretName(kc.Name)
 		}
 	}
 	annotations.AddHashAnnotation(desiredReaper)

--- a/pkg/reaper/secrets.go
+++ b/pkg/reaper/secrets.go
@@ -2,7 +2,6 @@ package reaper
 
 import (
 	"fmt"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/secret"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -23,12 +22,12 @@ var EnableCassAuthVar = &corev1.EnvVar{
 
 // DefaultUserSecretName generates a name for the Reaper CQL user, that is derived from the Cassandra cluster name.
 func DefaultUserSecretName(clusterName string) string {
-	return fmt.Sprintf("%v-reaper", secret.SanitizeSecretName(clusterName))
+	return fmt.Sprintf("%v-reaper", clusterName)
 }
 
 // DefaultJmxUserSecretName generates a name for the Reaper JMX user, that is derived from the Cassandra cluster name.
 func DefaultJmxUserSecretName(clusterName string) string {
-	return fmt.Sprintf("%v-reaper-jmx", secret.SanitizeSecretName(clusterName))
+	return fmt.Sprintf("%v-reaper-jmx", clusterName)
 }
 
 func GetCassandraAuthEnvironmentVars(secret *corev1.Secret) (*corev1.EnvVar, *corev1.EnvVar, error) {

--- a/pkg/secret/replicated.go
+++ b/pkg/secret/replicated.go
@@ -7,17 +7,15 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"math/big"
-	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"math/big"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	replicationapi "github.com/k8ssandra/k8ssandra-operator/apis/replication/v1alpha1"
@@ -46,25 +44,10 @@ func generateRandomString(charset string, length int) ([]byte, error) {
 }
 
 // DefaultSuperuserSecretName returns a default name for the superuser secret. It is of the general form
-// <cluster_name>-superuser.
+// <cluster_name>-superuser. Note that we expect clusterName to be a valid DNS subdomain name as defined in RFC 1123,
+// otherwise the secret name won't be valid.
 func DefaultSuperuserSecretName(clusterName string) string {
-	return fmt.Sprintf("%s-superuser", SanitizeSecretName(clusterName))
-}
-
-// SanitizeSecretName returns a string suitable for creating secret names derived from the given cluster name.
-// Secret names must be a valid DNS subdomain name as defined in RFC 1123.
-func SanitizeSecretName(name string) string {
-	// FIXME maybe move this function to pkg/utils/objects.go? It could also be used for resource, service and deployment names.
-	// see https://github.com/k8ssandra/k8ssandra-operator/issues/267
-	// FIXME this is not really what is needed to make the string compliant with a DNS subdomain string, see
-	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-	// Names must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric
-	// character (e.g. 'example.com').
-	// Regex for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"
-	clean := name
-	clean = strings.ReplaceAll(clean, "_", "")
-	clean = strings.ReplaceAll(clean, "-", "")
-	return clean
+	return fmt.Sprintf("%s-superuser", clusterName)
 }
 
 // ReconcileSecret creates a new secret with proper "managed-by" annotations, or ensure the existing secret has such

--- a/pkg/secret/replicated_test.go
+++ b/pkg/secret/replicated_test.go
@@ -32,16 +32,12 @@ func TestRandomPasswordGen(t *testing.T) {
 func TestDefaultSuperuserSecretName(t *testing.T) {
 	clusterName := "dc1"
 	clusterName2 := "d-c-1"
-	clusterName3 := "d_c1"
 
 	superUsername := DefaultSuperuserSecretName(clusterName)
 	superUsername2 := DefaultSuperuserSecretName(clusterName2)
-	superUsername3 := DefaultSuperuserSecretName(clusterName3)
-
-	assert.Equal(t, superUsername, superUsername2)
-	assert.Equal(t, superUsername, superUsername3)
 
 	assert.Equal(t, "dc1-superuser", superUsername)
+	assert.Equal(t, "d-c-1-superuser", superUsername2)
 }
 
 func TestRequiresUpdate(t *testing.T) {

--- a/pkg/test/test_objects.go
+++ b/pkg/test/test_objects.go
@@ -24,7 +24,6 @@ func NewK8ssandraCluster(name string, namespace string) k8ssandraapi.K8ssandraCl
 		},
 		Spec: k8ssandraapi.K8ssandraClusterSpec{
 			Cassandra: &k8ssandraapi.CassandraClusterTemplate{
-				Cluster:         "test-cluster",
 				ServerVersion:   "4.0.0",
 				CassandraConfig: nil,
 				StorageConfig: &cassdcapi.StorageConfig{

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -24,7 +24,7 @@ import (
 
 func multiDcAuthOnOff(t *testing.T, ctx context.Context, namespace string, f *framework.E2eFramework) {
 
-	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
+	kcKey := types.NamespacedName{Namespace: namespace, Name: "cluster1"}
 
 	dc1Key := framework.ClusterKey{K8sContext: "kind-k8ssandra-0", NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: "kind-k8ssandra-1", NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -65,7 +65,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, dc1Namespace, k8ssandra.Spec.Cassandra.Cluster)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, dc1Namespace, k8ssandra.Name)
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -511,7 +511,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	checkStargateReady(t, f, ctx, stargateKey)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Spec.Cassandra.Cluster)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Name)
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("deploying Stargate ingress routes in kind-k8ssandra-0")
@@ -599,7 +599,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Spec.Cassandra.Cluster)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Name)
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -727,7 +727,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Spec.Cassandra.Cluster)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, k8ssandra.Name)
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")

--- a/test/kuttl/config/fixtures/k8ssandra-base/k8ssandra-cluster.yaml
+++ b/test/kuttl/config/fixtures/k8ssandra-base/k8ssandra-cluster.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: "3.11.11"
     datacenters:
       - metadata:

--- a/test/testdata/fixtures/multi-dc-auth/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-auth/k8ssandra.yaml
@@ -1,11 +1,10 @@
 apiVersion: k8ssandra.io/v1alpha1
 kind: K8ssandraCluster
 metadata:
-  name: test
+  name: cluster1
 spec:
   auth: false
   cassandra:
-    cluster: cluster1
     serverVersion: "4.0.1"
     datacenters:
       - metadata:

--- a/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: test-0
 spec:
   cassandra:
-    cluster: test
     serverVersion: "3.11.11"
     storageConfig:
       cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/multi-dc-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-medusa/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: "4.0.0"
     serverImage: k8ssandra/cass-management-api:4.0.0
     storageConfig:

--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -20,7 +20,6 @@ spec:
     jmxUserSecretRef:
       name: reaper-jmx-secret # will be created with non-default name
   cassandra:
-    cluster: test
     serverVersion: "4.0.1"
     datacenters:
       - metadata:

--- a/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: "3.11.11"
     storageConfig:
       cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: "3.11.11"
     storageConfig:
       cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/single-dc-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-medusa/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: "4.0.1"
     serverImage: k8ssandra/cass-management-api:4.0.1
     storageConfig:

--- a/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
@@ -7,7 +7,6 @@ spec:
     autoScheduling:
       enabled: false
   cassandra:
-    cluster: test
     serverVersion: "3.11.11"
     jmxInitContainerImage:
       repository: library

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    cluster: test
     serverVersion: 3.11.11
     datacenters:
       - metadata:

--- a/test/testdata/samples/k8ssandra-multi-kind.yaml
+++ b/test/testdata/samples/k8ssandra-multi-kind.yaml
@@ -4,7 +4,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     serverImage: k8ssandra/cass-management-api:4.0.1
     storageConfig:

--- a/test/testdata/samples/k8ssandra-single-kind-medusa.yaml
+++ b/test/testdata/samples/k8ssandra-single-kind-medusa.yaml
@@ -4,7 +4,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     serverImage: k8ssandra/cass-management-api:4.0.1
     storageConfig:

--- a/test/testdata/samples/k8ssandra-single-kind.yaml
+++ b/test/testdata/samples/k8ssandra-single-kind.yaml
@@ -4,7 +4,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     serverImage: k8ssandra/cass-management-api:4.0.1
     storageConfig:


### PR DESCRIPTION

**What this PR does**:
This commit removes CassandraClusterTemplate.Cluster
completely, and uses K8ssandraCluster name consistently
instead.

CRD names must be valid DNS subdomain names, which means
that, by using the K8ssandraCluster name, we don't need
to sanitize derived resource names anymore. So this
commit also removes the sanitizing function used to
create the superuser secret.

**Which issue(s) this PR fixes**:
Fixes #267 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
