### PR TITLE
Add the creation of the CQL user for Medusa

### DIFF
--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -51,7 +51,7 @@ func (r *K8ssandraClusterReconciler) ReconcileMedusa(
 		medusa.UpdateMedusaInitContainer(dcConfig, medusaSpec, logger)
 		medusa.UpdateMedusaMainContainer(dcConfig, medusaSpec, logger)
 		medusa.UpdateMedusaVolumes(dcConfig, medusaSpec, logger)
-		medusa.AddCqlUser(medusaSpec, dcConfig, kc.Name)
+		cassandra.AddCqlUser(medusaSpec.CassandraUserSecretRef, dcConfig, medusa.CassandraUserSecretName(medusaSpec, kc.Name))
 	} else {
 		logger.Info("Medusa is not enabled")
 	}

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -51,6 +51,7 @@ func (r *K8ssandraClusterReconciler) ReconcileMedusa(
 		medusa.UpdateMedusaInitContainer(dcConfig, medusaSpec, logger)
 		medusa.UpdateMedusaMainContainer(dcConfig, medusaSpec, logger)
 		medusa.UpdateMedusaVolumes(dcConfig, medusaSpec, logger)
+		medusa.AddCqlUser(medusaSpec, dcConfig, kc.Name)
 	} else {
 		logger.Info("Medusa is not enabled")
 	}

--- a/pkg/cassandra/auth.go
+++ b/pkg/cassandra/auth.go
@@ -2,6 +2,8 @@ package cassandra
 
 import (
 	"fmt"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	corev1 "k8s.io/api/core/v1"
@@ -105,4 +107,16 @@ func ApplyAuthSettings(config api.CassandraConfig, authEnabled bool) api.Cassand
 		config.CassandraYaml.RoleManager = pointer.String("CassandraRoleManager")
 	}
 	return config
+}
+
+// If auth is enabled in this cluster, we need to allow components to access the cluster through CQL. This is done by
+// declaring a Cassandra user whose credentials are pulled from CassandraUserSecretRef.
+func AddCqlUser(cassandraUserSecretRef corev1.LocalObjectReference, dcConfig *DatacenterConfig, cassandraUserSecretName string) {
+	if cassandraUserSecretRef.Name == "" {
+		cassandraUserSecretRef.Name = cassandraUserSecretName
+	}
+	dcConfig.Users = append(dcConfig.Users, cassdcapi.CassandraUser{
+		SecretName: cassandraUserSecretRef.Name,
+		Superuser:  true,
+	})
 }

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
-	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
@@ -360,17 +359,4 @@ func addOrUpdateAdditionalVolume(dcConfig *cassandra.DatacenterConfig, volume *v
 		// Overwrite existing volume
 		dcConfig.StorageConfig.AdditionalVolumes[volumeIndex] = *volume
 	}
-}
-
-// If auth is enabled in this cluster, we need to allow Medusa to access the cluster through CQL. This is done by
-// declaring a Cassandra user whose credentials are pulled from CassandraUserSecretRef.
-func AddCqlUser(medusaTemplate *api.MedusaClusterTemplate, dcConfig *cassandra.DatacenterConfig, clusterName string) {
-	cassandraUserSecretRef := medusaTemplate.CassandraUserSecretRef
-	if cassandraUserSecretRef.Name == "" {
-		cassandraUserSecretRef.Name = CassandraUserSecretName(medusaTemplate, clusterName)
-	}
-	dcConfig.Users = append(dcConfig.Users, cassdcapi.CassandraUser{
-		SecretName: cassandraUserSecretRef.Name,
-		Superuser:  true,
-	})
 }

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
@@ -359,4 +360,17 @@ func addOrUpdateAdditionalVolume(dcConfig *cassandra.DatacenterConfig, volume *v
 		// Overwrite existing volume
 		dcConfig.StorageConfig.AdditionalVolumes[volumeIndex] = *volume
 	}
+}
+
+// If auth is enabled in this cluster, we need to allow Medusa to access the cluster through CQL. This is done by
+// declaring a Cassandra user whose credentials are pulled from CassandraUserSecretRef.
+func AddCqlUser(medusaTemplate *api.MedusaClusterTemplate, dcConfig *cassandra.DatacenterConfig, clusterName string) {
+	cassandraUserSecretRef := medusaTemplate.CassandraUserSecretRef
+	if cassandraUserSecretRef.Name == "" {
+		cassandraUserSecretRef.Name = CassandraUserSecretName(medusaTemplate, clusterName)
+	}
+	dcConfig.Users = append(dcConfig.Users, cassdcapi.CassandraUser{
+		SecretName: cassandraUserSecretRef.Name,
+		Superuser:  true,
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The Medusa user was created as a secret but wasn't added to the cassdc spec, thus it wasn't created in system_auth.
This PR adds the necessary bits to get that user created correctly.


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
