### PR TITLE
ClientConfig controller [K8SSAND-944]

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -79,6 +79,7 @@ jobs:
           - CreateSingleReaper
           - CreateReaperAndDatacenter
           - CreateSingleMedusa
+          - ConfigControllerRestarts
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -36,6 +36,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#267](https://github.com/k8ssandra/k8ssandra-operator/issues/267) Use the K8ssandraCluster name as cluster name for CassandraDatacenter objects
 * [ENHANCEMENT] [#297](https://github.com/k8ssandra/k8ssandra-operator/issues/297) Reconcile standalone Stargate auth schema
 * [TESTING] [#299](https://github.com/k8ssandra/k8ssandra-operator/issues/299) Cluster-scoped e2e test failing
+* [FEATURE] [#178](https://github.com/k8ssandra/k8ssandra-operator/issues/178) If ClientConfig is modified, automatically restart the k8ssandra-operator
 
 ## v1.0.0-alpha.2 - 2021-12-03
 

--- a/controllers/config/clientconfig_controller.go
+++ b/controllers/config/clientconfig_controller.go
@@ -2,15 +2,31 @@ package config
 
 import (
 	"context"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
+	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
+)
+
+const (
+	ClientConfigHashAnnotation = k8ssandraapi.ResourceHashAnnotation
+	KubeSecretHashAnnotation   = "k8ssandra.io/secret-hash"
 )
 
 type ClientConfigReconciler struct {
@@ -18,6 +34,9 @@ type ClientConfigReconciler struct {
 	Scheme       *runtime.Scheme
 	ClientCache  *clientcache.ClientCache
 	shutdownFunc context.CancelFunc
+
+	// filterMutex  sync.RWMutex
+	secretFilter map[types.NamespacedName]types.NamespacedName
 }
 
 /*
@@ -46,7 +65,111 @@ func (r *ClientConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // SetupWithManager will only set this controller to listen in control plane cluster
 func (r *ClientConfigReconciler) SetupWithManager(mgr ctrl.Manager, cancelFunc context.CancelFunc) error {
 	r.shutdownFunc = cancelFunc
+
+	// We should only reconcile objects that match the rules
+	toMatchingClientConfig := func(secret client.Object) []reconcile.Request {
+		requests := []reconcile.Request{}
+		if clientConfigName, found := r.secretFilter[types.NamespacedName{Name: secret.GetName(), Namespace: secret.GetNamespace()}]; found {
+			requests = append(requests, reconcile.Request{NamespacedName: clientConfigName})
+		}
+		return requests
+	}
+
 	cb := ctrl.NewControllerManagedBy(mgr).
-		For(&configapi.ClientConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+		For(&configapi.ClientConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, handler.EnqueueRequestsFromMapFunc(toMatchingClientConfig))
+
 	return cb.Complete(r)
+}
+
+// InitClientConfigs will fetch clientConfigs from the current cluster (control plane cluster) and create all the required Cluster objects for
+// other controllers to use. Not called from SetupWithManager since other controllers need the []cluster.Cluster array
+func (r *ClientConfigReconciler) InitClientConfigs(ctx context.Context, mgr ctrl.Manager, watchNamespace string) ([]cluster.Cluster, error) {
+	uncachedClient := r.ClientCache.GetLocalNonCacheClient()
+	clientConfigs := make([]configapi.ClientConfig, 0)
+	namespaces := strings.Split(watchNamespace, ",")
+
+	secretMapper := make(map[types.NamespacedName]types.NamespacedName)
+
+	for _, ns := range namespaces {
+		cConfigs := configapi.ClientConfigList{}
+		err := uncachedClient.List(ctx, &cConfigs, client.InNamespace(ns))
+		if err != nil {
+			return nil, err
+		}
+		clientConfigs = append(clientConfigs, cConfigs.Items...)
+	}
+
+	additionalClusters := make([]cluster.Cluster, 0, len(clientConfigs))
+
+	for _, cCfg := range clientConfigs {
+		// Calculate hashes
+		cCfgName := types.NamespacedName{Name: cCfg.Name, Namespace: cCfg.Namespace}
+		secretName := types.NamespacedName{Name: cCfg.Spec.KubeConfigSecret.Name, Namespace: cCfg.Namespace}
+
+		cCfgHash, secretHash, err := calculateHashes(ctx, uncachedClient, cCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		metav1.SetMetaDataAnnotation(&cCfg.ObjectMeta, ClientConfigHashAnnotation, cCfgHash)
+		metav1.SetMetaDataAnnotation(&cCfg.ObjectMeta, KubeSecretHashAnnotation, secretHash)
+
+		if err := uncachedClient.Update(ctx, &cCfg); err != nil {
+			return nil, err
+		}
+
+		// Add the Secret to the cache
+		secretMapper[secretName] = cCfgName
+
+		// Create clients and add them to the client cache
+		cfg, err := r.ClientCache.GetRestConfig(&cCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add cluster to the manager
+		var c cluster.Cluster
+		if strings.Contains(watchNamespace, ",") {
+			c, err = cluster.New(cfg, func(o *cluster.Options) {
+				o.Scheme = r.Scheme
+				o.Namespace = ""
+				o.NewCache = cache.MultiNamespacedCacheBuilder(namespaces)
+			})
+		} else {
+			c, err = cluster.New(cfg, func(o *cluster.Options) {
+				o.Scheme = r.Scheme
+				o.Namespace = watchNamespace
+			})
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		r.ClientCache.AddClient(cCfg.GetContextName(), c.GetClient())
+
+		err = mgr.Add(c)
+		if err != nil {
+			return nil, err
+		}
+
+		additionalClusters = append(additionalClusters, c)
+	}
+
+	r.secretFilter = secretMapper
+	return additionalClusters, nil
+}
+
+func calculateHashes(ctx context.Context, anyClient client.Client, clientCfg configapi.ClientConfig) (string, string, error) {
+	secret := &corev1.Secret{}
+	secretName := types.NamespacedName{Name: clientCfg.Spec.KubeConfigSecret.Name, Namespace: clientCfg.Namespace}
+
+	if err := anyClient.Get(ctx, secretName, secret); err != nil {
+		return "", "", err
+	}
+
+	cfgHash := utils.DeepHashString(clientCfg)
+	secretHash := utils.DeepHashString(secret)
+
+	return cfgHash, secretHash, nil
 }

--- a/controllers/config/clientconfig_controller.go
+++ b/controllers/config/clientconfig_controller.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+)
+
+type ClientConfigReconciler struct {
+	client.Client
+	Scheme       *runtime.Scheme
+	ClientCache  *clientcache.ClientCache
+	shutdownFunc context.CancelFunc
+}
+
+/*
+	What about situations:
+		- Remove clientconfig when the cluster is still added?
+			* Cluster properties get updated?
+				* Do we accept or not?
+			* Could just be a cert-update etc, short-term, long-term ones
+		- New ClientConfig doesn't work?
+		- Add cluster points to a clientconfig that doesn't exist?
+		- What if the ClientConfig's kubeConfig is changed in the secret?
+		- What if certs expire? What if client connection fails - how do we detect when we need to do something to clientConfig?
+		- Do we load clientConfigs from all watch namespaces (or empty - cluster wide) or just from where operator is installed?
+			- Security /  user rights? If a namespace is allowed to add a K8ssandraCluster, but not new Kubernetes clusters to connect to?
+*/
+
+/*
+	TODO Add a channel that other controllers listen? So that they can add new Watches?
+	TODO Expose new cluster loading watchers in each controller?
+*/
+
+func (r *ClientConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager will only set this controller to listen in control plane cluster
+func (r *ClientConfigReconciler) SetupWithManager(mgr ctrl.Manager, cancelFunc context.CancelFunc) error {
+	r.shutdownFunc = cancelFunc
+	cb := ctrl.NewControllerManagedBy(mgr).
+		For(&configapi.ClientConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+	return cb.Complete(r)
+}

--- a/controllers/config/clientconfig_controller_test.go
+++ b/controllers/config/clientconfig_controller_test.go
@@ -81,7 +81,6 @@ func TestClientConfigReconciler(t *testing.T) {
 
 	// Secret controller tests
 	t.Run("InitClientConfigs", testEnv.ControllerTest(ctx, testInitClientConfigs))
-	t.Run("ClientConfigModification", testEnv.ControllerTest(ctx, testClientConfigModification))
 	t.Run("SecretModification", testEnv.ControllerTest(ctx, testSecretModification))
 }
 

--- a/controllers/config/clientconfig_controller_test.go
+++ b/controllers/config/clientconfig_controller_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+	testutils "github.com/k8ssandra/k8ssandra-operator/pkg/test"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
+	"github.com/k8ssandra/k8ssandra-operator/test/framework"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
+)
+
+const (
+	timeout  = time.Second * 5
+	interval = time.Millisecond * 500
+)
+
+var (
+	testEnv     *testutils.MultiClusterTestEnv
+	scheme      *runtime.Scheme
+	logger      logr.Logger
+	cancelCalls int
+	// secretFilter map[types.NamespacedName]types.NamespacedName
+	reconciler *ClientConfigReconciler
+	usedMgr    manager.Manager
+	kubeConfig []byte
+)
+
+func TestClientConfigReconciler(t *testing.T) {
+	ctx := testutils.TestSetup(t)
+	ctx, cancel := context.WithCancel(ctx)
+	testEnv = &testutils.MultiClusterTestEnv{}
+	cancelCalls = 0
+	shutDownFunc := func() {
+		// We don't want to actually call the shutdown in these tests - we just want to know the cancel function was called
+		cancelCalls++
+	}
+	// secretFilter = make(map[types.NamespacedName]types.NamespacedName)
+	reconciler = &ClientConfigReconciler{}
+	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
+		scheme = mgr.GetScheme()
+		logger = mgr.GetLogger()
+		reconciler.ClientCache = clientCache
+		reconciler.Scheme = scheme
+		// reconciler.secretFilter = secretFilter
+		usedMgr = mgr
+		return reconciler.SetupWithManager(mgr, shutDownFunc)
+	})
+	if err != nil {
+		t.Fatalf("failed to start test environment: %s", err)
+	}
+
+	user, err := testEnv.GetControlPlaneEnvTest().ControlPlane.AddUser(envtest.User{
+		Name:   "envtest-admin",
+		Groups: []string{"system:masters"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to create envtest user: %v", err)
+	}
+
+	kubeConfig, err = user.KubeConfig()
+	if err != nil {
+		t.Fatalf("failed to get envtest kubeconfig: %v", err)
+	}
+
+	defer testEnv.Stop(t)
+	defer cancel()
+
+	// Secret controller tests
+	t.Run("InitClientConfigs", testEnv.ControllerTest(ctx, testInitClientConfigs))
+	t.Run("ClientConfigModification", testEnv.ControllerTest(ctx, testClientConfigModification))
+	t.Run("SecretModification", testEnv.ControllerTest(ctx, testSecretModification))
+}
+
+func insertKubeConfigSecret(ctx context.Context, localClient client.Client, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-kubeconfig-secret",
+		},
+		Type: "Opaque",
+		Data: map[string][]byte{
+			"kubeconfig": kubeConfig,
+		},
+	}
+
+	err := localClient.Create(ctx, secret)
+	return secret, err
+}
+
+func insertClientConfig(ctx context.Context, localClient client.Client, namespace, name, secretName string) (*configapi.ClientConfig, error) {
+	clientConfig := &configapi.ClientConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: configapi.ClientConfigSpec{
+			KubeConfigSecret: corev1.LocalObjectReference{
+				Name: secretName,
+			},
+		},
+	}
+
+	err := localClient.Create(ctx, clientConfig)
+	return clientConfig, err
+}
+
+func testInitClientConfigs(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	assert := assert.New(t)
+
+	secret, err := insertKubeConfigSecret(ctx, f.Client, namespace)
+	assert.NoError(err)
+
+	clientConfig, err := insertClientConfig(ctx, f.Client, namespace, "envtest", secret.Name)
+	assert.NoError(err)
+
+	t.Log("Verify initClientConfig loads the clusters correctly")
+	clusters, err := reconciler.InitClientConfigs(ctx, usedMgr, namespace)
+	assert.NoError(err)
+	assert.Equal(1, len(clusters))
+
+	secretKey := types.NamespacedName{Namespace: namespace, Name: secret.Name}
+	clientConfigKey := types.NamespacedName{Namespace: namespace, Name: clientConfig.Name}
+
+	t.Log("Verify that the client updated secret and clientConfig with hashes")
+	assert.Eventually(func() bool {
+		currentConfig := &configapi.ClientConfig{}
+		err = f.Client.Get(ctx, clientConfigKey, currentConfig)
+		if err != nil {
+			return false
+		}
+
+		_, found := reconciler.secretFilter[secretKey]
+		return metav1.HasAnnotation(currentConfig.ObjectMeta, KubeSecretHashAnnotation) &&
+			metav1.HasAnnotation(currentConfig.ObjectMeta, ClientConfigHashAnnotation) &&
+			found
+	}, timeout, interval)
+
+	t.Log("Create clientConfig which has incorrect context-name")
+	_, err = insertClientConfig(ctx, f.Client, namespace, "envtest-failed", secret.Name)
+	assert.NoError(err)
+
+	_, err = reconciler.InitClientConfigs(ctx, usedMgr, namespace)
+	assert.Error(err)
+}
+
+func testSecretModification(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	// Intentionally different from previous test. This wants to test the internal behavior more, without
+	// relying on the controller itself creating "necessary" requirements
+
+	assert := assert.New(t)
+	reconciler.secretFilter = make(map[types.NamespacedName]types.NamespacedName)
+
+	secret, err := insertKubeConfigSecret(ctx, f.Client, namespace)
+	assert.NoError(err)
+
+	clientConfig, err := insertClientConfig(ctx, f.Client, namespace, "kind-k8ssandra-0", secret.Name)
+	assert.NoError(err)
+
+	configHash := utils.DeepHashString(clientConfig)
+	secretHash := utils.DeepHashString(secret)
+
+	metav1.SetMetaDataAnnotation(&clientConfig.ObjectMeta, KubeSecretHashAnnotation, secretHash)
+	metav1.SetMetaDataAnnotation(&clientConfig.ObjectMeta, ClientConfigHashAnnotation, configHash)
+
+	err = f.Client.Update(ctx, clientConfig)
+	assert.NoError(err)
+
+	// Now update the secretFilter
+	secretKey := types.NamespacedName{Namespace: namespace, Name: secret.Name}
+	clientConfigKey := types.NamespacedName{Namespace: namespace, Name: clientConfig.Name}
+	reconciler.secretFilter[secretKey] = clientConfigKey
+
+	// Store currentCount of cancelFunc
+	currentCount := cancelCalls
+
+	secretCurrent := &corev1.Secret{}
+	err = f.Client.Get(ctx, secretKey, secretCurrent)
+	assert.NoError(err)
+
+	secretCurrent.Data["new-key"] = []byte("excellent")
+	err = f.Client.Update(ctx, secretCurrent)
+	assert.NoError(err)
+
+	assert.Eventually(func() bool {
+		return cancelCalls > currentCount
+	}, timeout, interval)
+}

--- a/controllers/k8ssandra/add_dc_test.go
+++ b/controllers/k8ssandra/add_dc_test.go
@@ -180,7 +180,7 @@ func addDcSetupForMultiDc(ctx context.Context, t *testing.T, f *framework.Framew
 
 func addDcTest(ctx context.Context, f *framework.Framework, test addDcTestFunc, single bool) func(*testing.T) {
 	return func(t *testing.T) {
-		namespace := rand.String(9)
+		namespace := framework.CleanupForKubernetes(rand.String(9))
 		if err := f.CreateNamespace(namespace); err != nil {
 			t.Fatalf("failed to create namespace %s: %v", namespace, err)
 		}

--- a/main.go
+++ b/main.go
@@ -146,7 +146,6 @@ func main() {
 		clientCache := clientcache.New(mgr.GetClient(), uncachedClient, scheme)
 
 		configCtrler := &configctrl.ClientConfigReconciler{
-			Client:      mgr.GetClient(),
 			Scheme:      mgr.GetScheme(),
 			ClientCache: clientCache,
 		}

--- a/main.go
+++ b/main.go
@@ -145,17 +145,19 @@ func main() {
 		// Fetch ClientConfigs and create the clientCache
 		clientCache := clientcache.New(mgr.GetClient(), uncachedClient, scheme)
 
-		additionalClusters, err := config.InitClientConfigs(ctx, mgr, clientCache, scheme, watchNamespace)
+		configCtrler := &configctrl.ClientConfigReconciler{
+			Client:      mgr.GetClient(),
+			Scheme:      mgr.GetScheme(),
+			ClientCache: clientCache,
+		}
+
+		additionalClusters, err := configCtrler.InitClientConfigs(ctx, mgr, watchNamespace)
 		if err != nil {
 			setupLog.Error(err, "unable to create manager cluster connections")
 			os.Exit(1)
 		}
 
-		if err = (&configctrl.ClientConfigReconciler{
-			Client:      mgr.GetClient(),
-			Scheme:      mgr.GetScheme(),
-			ClientCache: clientCache,
-		}).SetupWithManager(mgr, cancel); err != nil {
+		if err = configCtrler.SetupWithManager(mgr, cancel); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClientConfig")
 			os.Exit(1)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,20 +1,9 @@
 package config
 
 import (
-	"context"
 	"log"
 	"os"
-	"strings"
 	"time"
-
-	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
-
-	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
 )
 
 type ReconcilerConfig struct {
@@ -62,61 +51,4 @@ func InitConfig() *ReconcilerConfig {
 		DefaultDelay: defaultDelay,
 		LongDelay:    longDelay,
 	}
-}
-
-// InitClientConfigs will fetch clientConfigs from the current cluster (control plane cluster) and create all the required Cluster objects for
-// other controllers to use
-func InitClientConfigs(ctx context.Context, mgr ctrl.Manager, clientCache *clientcache.ClientCache, scheme *runtime.Scheme, watchNamespace string) ([]cluster.Cluster, error) {
-	uncachedClient := clientCache.GetLocalNonCacheClient()
-	clientConfigs := make([]configapi.ClientConfig, 0)
-	namespaces := strings.Split(watchNamespace, ",")
-
-	for _, ns := range namespaces {
-		cConfigs := configapi.ClientConfigList{}
-		err := uncachedClient.List(ctx, &cConfigs, client.InNamespace(ns))
-		if err != nil {
-			return nil, err
-		}
-		clientConfigs = append(clientConfigs, cConfigs.Items...)
-	}
-
-	additionalClusters := make([]cluster.Cluster, 0, len(clientConfigs))
-
-	for _, cCfg := range clientConfigs {
-		// TODO If the cCfg does not have hash annotation, add it
-		// Create clients and add them to the client cache
-		cfg, err := clientCache.GetRestConfig(&cCfg)
-		if err != nil {
-			return nil, err
-		}
-
-		// Add cluster to the manager
-		var c cluster.Cluster
-		if strings.Contains(watchNamespace, ",") {
-			c, err = cluster.New(cfg, func(o *cluster.Options) {
-				o.Scheme = scheme
-				o.Namespace = ""
-				o.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))
-			})
-		} else {
-			c, err = cluster.New(cfg, func(o *cluster.Options) {
-				o.Scheme = scheme
-				o.Namespace = watchNamespace
-			})
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		clientCache.AddClient(cCfg.GetContextName(), c.GetClient())
-
-		err = mgr.Add(c)
-		if err != nil {
-			return nil, err
-		}
-
-		additionalClusters = append(additionalClusters, c)
-	}
-
-	return additionalClusters, nil
 }

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -211,6 +211,10 @@ func (e *MultiClusterTestEnv) Stop(t *testing.T) {
 	}
 }
 
+func (e *MultiClusterTestEnv) GetControlPlaneEnvTest() *envtest.Environment {
+	return e.testEnvs[0]
+}
+
 type ControllerTest func(*testing.T, context.Context, *framework.Framework, string)
 
 func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test ControllerTest) func(*testing.T) {

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -218,7 +218,8 @@ func (e *MultiClusterTestEnv) GetControlPlaneEnvTest() *envtest.Environment {
 type ControllerTest func(*testing.T, context.Context, *framework.Framework, string)
 
 func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test ControllerTest) func(*testing.T) {
-	namespace := rand.String(9)
+	namespace := framework.CleanupForKubernetes(rand.String(9))
+
 	return func(t *testing.T) {
 		primaryCluster := fmt.Sprintf(clusterProtoName, 0)
 		controlPlaneCluster := e.Clients[primaryCluster]

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -30,7 +30,8 @@ func controllerRestart(t *testing.T, ctx context.Context, namespace string, f *f
 
 	clientConfig := &configapi.ClientConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "configlist-to-crash-them-all",
+			Name:      "configlist-to-crash-them-all",
+			Namespace: namespace,
 		},
 		Spec: configapi.ClientConfigSpec{
 			ContextName: "so-fatally-wrong",

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
+	"github.com/k8ssandra/k8ssandra-operator/test/framework"
+)
+
+func controllerRestart(t *testing.T, ctx context.Context, namespace string, f *framework.E2eFramework) {
+	require := require.New(t)
+
+	operatorPod, err := getOperatorPod(ctx, f.Client, namespace)
+	require.NoError(err)
+	require.NotNil(operatorPod)
+
+	clientConfigList := &configapi.ClientConfigList{}
+	err = f.Client.List(ctx, clientConfigList, client.InNamespace(namespace))
+	require.NoError(err)
+	require.True(len(clientConfigList.Items) > 0)
+
+	currentRestartCount := operatorPod.Status.ContainerStatuses[0].RestartCount
+
+	clientConfig := &configapi.ClientConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "configlist-to-crash-them-all",
+		},
+		Spec: configapi.ClientConfigSpec{
+			ContextName: "so-fatally-wrong",
+		},
+	}
+
+	err = f.Client.Create(ctx, clientConfig)
+	require.NoError(err)
+
+	require.Eventually(func() bool {
+		operatorPod, err := getOperatorPod(ctx, f.Client, namespace)
+		if err != nil {
+			return false
+		}
+		return operatorPod.Status.ContainerStatuses[0].RestartCount > currentRestartCount
+	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "Pod restartCount hasn't changed")
+}
+
+func getOperatorPod(ctx context.Context, anyClient client.Client, namespace string) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	err := anyClient.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{"control-plane": "k8ssandra-operator"})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(podList.Items) < 1 {
+		return nil, fmt.Errorf("No operator pod found")
+	}
+
+	return &podList.Items[0], nil
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 
 	"github.com/k8ssandra/k8ssandra-operator/test/kustomize"
 	"github.com/rs/zerolog"
@@ -135,6 +136,9 @@ func TestOperator(t *testing.T) {
 		testFunc:      multiDcAuthOnOff,
 		fixture:       "multi-dc-auth",
 		deployTraefik: true,
+	}))
+	t.Run("ConfigControllerRestarts", e2eTest(ctx, &e2eTestOpts{
+		testFunc: controllerRestart,
 	}))
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -261,7 +261,11 @@ func setTestNamespaceNames(opts *e2eTestOpts) {
 	if opts.clusterScoped {
 		opts.operatorNamespace = "k8ssandra-operator"
 	} else {
-		opts.operatorNamespace = string(opts.fixture) + "-" + rand.String(6)
+		if opts.fixture != "" {
+			opts.operatorNamespace = string(opts.fixture) + "-" + rand.String(6)
+		} else {
+			opts.operatorNamespace = framework.CleanupForKubernetes(rand.String(9))
+		}
 		opts.sutNamespace = opts.operatorNamespace
 	}
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -236,9 +236,12 @@ func e2eTest(ctx context.Context, opts *e2eTestOpts) func(*testing.T) {
 
 		setTestNamespaceNames(opts)
 
-		fixtureDir, err := getTestFixtureDir(opts.fixture)
-		if err != nil {
-			t.Fatalf("failed to get fixture directory for %s: %v", opts.fixture, err)
+		fixtureDir := ""
+		if opts.fixture != "" {
+			fixtureDir, err = getTestFixtureDir(opts.fixture)
+			if err != nil {
+				t.Fatalf("failed to get fixture directory for %s: %v", opts.fixture, err)
+			}
 		}
 
 		err = beforeTest(t, f, fixtureDir, opts)
@@ -356,14 +359,16 @@ func beforeTest(t *testing.T, f *framework.E2eFramework, fixtureDir string, opts
 		}
 	}
 
-	fixtureDir, err := filepath.Abs(fixtureDir)
-	if err != nil {
-		return err
-	}
+	if fixtureDir != "" {
+		fixtureDir, err := filepath.Abs(fixtureDir)
+		if err != nil {
+			return err
+		}
 
-	if err := kubectl.Apply(kubectl.Options{Namespace: opts.sutNamespace, Context: f.ControlPlaneContext}, fixtureDir); err != nil {
-		t.Log("kubectl apply failed")
-		return err
+		if err := kubectl.Apply(kubectl.Options{Namespace: opts.sutNamespace, Context: f.ControlPlaneContext}, fixtureDir); err != nil {
+			t.Log("kubectl apply failed")
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
When a ClientConfig is modified or the Secret that ClientConfig refers to, the k8ssandra-operator is shutdown to allow automated restart.

Also, fixes a bug where watchNamespace having a comma would prevent correct loading of ClientConfigs.

**Which issue(s) this PR fixes**:
Fixes #178 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
