### PR TITLE
Create first Stargate deployment with one replica, before others

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -25,6 +25,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#234](https://github.com/k8ssandra/k8ssandra-operator/issues/234) Add logic to configure and reconcile a Prometheus ServiceMonitor for each Stargate deployment.
 * [CHANGE] [#136](https://github.com/k8ssandra/k8ssandra-operator/issues/136) Add shortNames for the K8ssandraCluster CRD
 * [ENHANCEMENT] [#170](https://github.com/k8ssandra/k8ssandra-operator/issues/170) Enforce cluster-wide authentication by default 
+* [ENHANCEMENT] [#297](https://github.com/k8ssandra/k8ssandra-operator/issues/297) Don't create additional Stargate 
+  pods until first one is ready
 
 ## v1.0.0-alpha.2 - 2021-12-03
 

--- a/controllers/stargate/stargate_controller_test.go
+++ b/controllers/stargate/stargate_controller_test.go
@@ -144,7 +144,7 @@ func testCreateStargateSingleRack(t *testing.T, testClient client.Client) {
 		return err == nil && sg.Status.Progress == api.StargateProgressDeploying
 	}, timeout, interval)
 
-	deploymentKey := types.NamespacedName{Namespace: namespace, Name: "test-dc1-default-stargate-deployment"}
+	deploymentKey := types.NamespacedName{Namespace: namespace, Name: "test-dc1-default-stargate"}
 	deployment := &appsv1.Deployment{}
 	require.Eventually(t, func() bool {
 		err := testClient.Get(ctx, deploymentKey, deployment)
@@ -337,21 +337,21 @@ func testCreateStargateMultiRack(t *testing.T, testClient client.Client) {
 	assert.Len(t, deploymentList.Items, 3)
 
 	deployment1 := deploymentList.Items[0]
-	assert.Equal(t, "cluster1-dc2-rack1-stargate-deployment", deployment1.Name)
+	assert.Equal(t, "cluster1-dc2-rack1-stargate", deployment1.Name)
 	assert.EqualValues(t, 1, *deployment1.Spec.Replicas)
 	requirement1 := deployment1.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
 	assert.Equal(t, "topology.kubernetes.io/zone", requirement1.Key)
 	assert.Contains(t, requirement1.Values[0], "us-east-1a")
 
 	deployment2 := deploymentList.Items[1]
-	assert.Equal(t, "cluster1-dc2-rack2-stargate-deployment", deployment2.Name)
+	assert.Equal(t, "cluster1-dc2-rack2-stargate", deployment2.Name)
 	assert.EqualValues(t, 1, *deployment2.Spec.Replicas)
 	requirement2 := deployment2.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
 	assert.Equal(t, "topology.kubernetes.io/zone", requirement2.Key)
 	assert.Contains(t, requirement2.Values[0], "us-east-1b")
 
 	deployment3 := deploymentList.Items[2]
-	assert.Equal(t, "cluster1-dc2-rack3-stargate-deployment", deployment3.Name)
+	assert.Equal(t, "cluster1-dc2-rack3-stargate", deployment3.Name)
 	assert.EqualValues(t, 1, *deployment3.Spec.Replicas)
 	requirement3 := deployment3.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
 	assert.Equal(t, "topology.kubernetes.io/zone", requirement3.Key)

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -185,7 +185,7 @@ Status:
           Status:                True
           Type:                  Ready
         Deployment Refs:
-          demo-dc1-default-stargate-deployment
+          demo-dc1-default-stargate
         Progress:              Running
         Ready Replicas:        1
         Ready Replicas Ratio:  1/1
@@ -352,7 +352,7 @@ Status:
           Status:                True
           Type:                  Ready
         Deployment Refs:
-          demo-dc1-default-stargate-deployment
+          demo-dc1-default-stargate
         Progress:              Running
         Ready Replicas:        1
         Ready Replicas Ratio:  1/1
@@ -370,7 +370,7 @@ Status:
           Status:                True
           Type:                  Ready
         Deployment Refs:
-          demo-dc2-default-stargate-deployment
+          demo-dc2-default-stargate
         Progress:              Running
         Ready Replicas:        1
         Ready Replicas Ratio:  1/1
@@ -556,7 +556,7 @@ Status:
           Status:                True
           Type:                  Ready
         Deployment Refs:
-          demo-dc1-default-stargate-deployment
+          demo-dc1-default-stargate
         Progress:              Running
         Ready Replicas:        1
         Ready Replicas Ratio:  1/1
@@ -1005,7 +1005,7 @@ Status:
           Status:                True
           Type:                  Ready
         Deployment Refs:
-          demo-dc1-default-stargate-deployment
+          demo-dc1-default-stargate
         Progress:              Running
         Ready Replicas:        1
         Ready Replicas Ratio:  1/1

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -231,8 +231,8 @@ func newDeployment(
 	if stargate.Spec.IsAuthEnabled() {
 		// Stargate reacts to the sole presence of this variable, regardless of its contents.
 		// When this variable is absent, Stargate will use AllowAllAuthenticator.
-		// When this variable is present, Stargate will by default use PasswordAuthenticator, unless overridden
-		// by the stargate.authenticator_class_name system property (see below, computeJvmOptions).
+		// When this variable is present, Stargate will by default use PasswordAuthenticator, unless overridden by the
+		// stargate.authenticator_class_name system property, but we currently do not allow this property to be set.
 		// Note that any other authenticator than PasswordAuthenticator will cause the REST APIs to be unusable,
 		// however the CQL API will still be usable.
 		deployment.Spec.Template.Spec.Containers[0].Env = append(

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -59,10 +59,9 @@ func testNewDeploymentsDefaultRackSingleReplica(t *testing.T) {
 
 	deployments := NewDeployments(stargate, dc)
 	require.Len(t, deployments, 1)
-	require.Contains(t, deployments, "cluster1-dc1-default-stargate-deployment")
-	deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+	deployment := deployments[0]
 
-	assert.Equal(t, "cluster1-dc1-default-stargate-deployment", deployment.Name)
+	assert.Equal(t, "cluster1-dc1-default-stargate", deployment.Name)
 	assert.Equal(t, namespace, deployment.Namespace)
 	assert.Contains(t, deployment.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment.Labels[api.StargateLabel])
@@ -70,12 +69,12 @@ func testNewDeploymentsDefaultRackSingleReplica(t *testing.T) {
 	assert.EqualValues(t, 1, *deployment.Spec.Replicas)
 
 	assert.Contains(t, deployment.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-default-stargate-deployment", deployment.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-default-stargate", deployment.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 
 	assert.Contains(t, deployment.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-default-stargate-deployment", deployment.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-default-stargate", deployment.Spec.Template.Labels[api.StargateDeploymentLabel])
 
 	assert.Equal(t, "default", deployment.Spec.Template.Spec.ServiceAccountName)
 	assert.Equal(t, affinityForRack(dc, "default"), deployment.Spec.Template.Spec.Affinity)
@@ -148,39 +147,53 @@ func testNewDeploymentsSingleRackManyReplicas(t *testing.T) {
 	stargate.Spec.Size = 3
 
 	deployments := NewDeployments(stargate, dc)
-	require.Len(t, deployments, 1)
-	require.Contains(t, deployments, "cluster1-dc1-rack1-stargate-deployment")
-	deployment := deployments["cluster1-dc1-rack1-stargate-deployment"]
+	require.Len(t, deployments, 2)
 
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment.Name)
-	assert.Equal(t, namespace, deployment.Namespace)
-	assert.Contains(t, deployment.Labels, api.StargateLabel)
-	assert.Equal(t, "s1", deployment.Labels[api.StargateLabel])
-
-	assert.EqualValues(t, 3, *deployment.Spec.Replicas)
-
-	assert.Contains(t, deployment.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
-
-	assert.Contains(t, deployment.Spec.Template.Labels, api.StargateLabel)
-	assert.Equal(t, "s1", deployment.Spec.Template.Labels[api.StargateLabel])
-	assert.Contains(t, deployment.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment.Spec.Template.Labels[api.StargateDeploymentLabel])
-
-	assert.Equal(t, affinityForRack(dc, "rack1"), deployment.Spec.Template.Spec.Affinity)
-	assert.Nil(t, deployment.Spec.Template.Spec.Tolerations)
-
-	container := findContainer(&deployment, deployment.Name)
+	deployment1a := deployments[0]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Name)
+	assert.EqualValues(t, 1, *deployment1a.Spec.Replicas)
+	assert.Equal(t, namespace, deployment1a.Namespace)
+	assert.Contains(t, deployment1a.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1a.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1a.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1a.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1a.Spec.Template.Spec.Affinity)
+	assert.Nil(t, deployment1a.Spec.Template.Spec.Tolerations)
+	container := findContainer(&deployment1a, deployment1a.Name)
 	require.NotNil(t, container, "failed to find stargate container")
-
 	rackName := findEnvVar(container, "RACK_NAME")
 	require.NotNil(t, rackName, "failed to find RACK_NAME env var")
 	assert.Equal(t, "rack1", rackName.Value)
-
 	seed := findEnvVar(container, "SEED")
 	require.NotNil(t, seed, "failed to find SEED env var")
 	assert.Equal(t, "cluster1-seed-service.namespace1.svc.cluster.local", seed.Value)
 
+	deployment1b := deployments[1]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Name)
+	assert.EqualValues(t, 2, *deployment1b.Spec.Replicas)
+	assert.Equal(t, namespace, deployment1b.Namespace)
+	assert.Contains(t, deployment1b.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1b.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1b.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1b.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1b.Spec.Template.Spec.Affinity)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.Tolerations)
+	container = findContainer(&deployment1b, deployment1b.Name)
+	require.NotNil(t, container, "failed to find stargate container")
+	rackName = findEnvVar(container, "RACK_NAME")
+	require.NotNil(t, rackName, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName.Value)
+	seed = findEnvVar(container, "SEED")
+	require.NotNil(t, seed, "failed to find SEED env var")
+	assert.Equal(t, "cluster1-seed-service.namespace1.svc.cluster.local", seed.Value)
 }
 
 func testNewDeploymentsManyRacksManyReplicas(t *testing.T) {
@@ -197,59 +210,74 @@ func testNewDeploymentsManyRacksManyReplicas(t *testing.T) {
 
 	deployments := NewDeployments(stargate, dc)
 
-	require.Len(t, deployments, 3)
-	require.Contains(t, deployments, "cluster1-dc1-rack1-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack2-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack3-stargate-deployment")
+	require.Len(t, deployments, 4)
 
-	deployment1 := deployments["cluster1-dc1-rack1-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Name)
-	assert.EqualValues(t, 3, *deployment1.Spec.Replicas)
-	assert.Contains(t, deployment1.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateLabel)
-	assert.Equal(t, "s1", deployment1.Spec.Template.Labels[api.StargateLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Template.Labels[api.StargateDeploymentLabel])
-	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1.Spec.Template.Spec.Affinity)
-	assert.Nil(t, deployment1.Spec.Template.Spec.NodeSelector)
-	assert.Nil(t, deployment1.Spec.Template.Spec.Tolerations)
-	container1 := findContainer(&deployment1, deployment1.Name)
-	require.NotNil(t, container1, "failed to find stargate container")
-	rackName1 := findEnvVar(container1, "RACK_NAME")
-	require.NotNil(t, rackName1, "failed to find RACK_NAME env var")
-	assert.Equal(t, "rack1", rackName1.Value)
+	deployment1a := deployments[0]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Name)
+	assert.EqualValues(t, 1, *deployment1a.Spec.Replicas)
+	assert.Contains(t, deployment1a.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1a.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1a.Spec.Template.Spec.Affinity)
+	assert.Nil(t, deployment1a.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, deployment1a.Spec.Template.Spec.Tolerations)
+	container1a := findContainer(&deployment1a, deployment1a.Name)
+	require.NotNil(t, container1a, "failed to find stargate container")
+	rackName1a := findEnvVar(container1a, "RACK_NAME")
+	require.NotNil(t, rackName1a, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1a.Value)
 
-	deployment2 := deployments["cluster1-dc1-rack2-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Name)
+	deployment1b := deployments[1]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Name)
+	assert.EqualValues(t, 2, *deployment1b.Spec.Replicas)
+	assert.Contains(t, deployment1b.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1b.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1b.Spec.Template.Spec.Affinity)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.Tolerations)
+	container1b := findContainer(&deployment1b, deployment1b.Name)
+	require.NotNil(t, container1b, "failed to find stargate container")
+	rackName1b := findEnvVar(container1b, "RACK_NAME")
+	require.NotNil(t, rackName1b, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1b.Value)
+
+	deployment2 := deployments[2]
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Name)
 	assert.EqualValues(t, 3, *deployment2.Spec.Replicas)
 	assert.Contains(t, deployment2.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment2.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, affinityForRack(dc, "rack2"), deployment2.Spec.Template.Spec.Affinity)
-	assert.Nil(t, deployment1.Spec.Template.Spec.NodeSelector)
-	assert.Nil(t, deployment1.Spec.Template.Spec.Tolerations)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.Tolerations)
 	container2 := findContainer(&deployment2, deployment2.Name)
 	require.NotNil(t, container2, "failed to find stargate container")
 	rackName2 := findEnvVar(container2, "RACK_NAME")
 	require.NotNil(t, rackName2, "failed to find RACK_NAME env var")
 	assert.Equal(t, "rack2", rackName2.Value)
 
-	deployment3 := deployments["cluster1-dc1-rack3-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Name)
+	deployment3 := deployments[3]
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Name)
 	assert.EqualValues(t, 2, *deployment3.Spec.Replicas)
 	assert.Contains(t, deployment3.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment3.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, affinityForRack(dc, "rack3"), deployment3.Spec.Template.Spec.Affinity)
-	assert.Nil(t, deployment1.Spec.Template.Spec.NodeSelector)
-	assert.Nil(t, deployment1.Spec.Template.Spec.Tolerations)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.NodeSelector)
+	assert.Nil(t, deployment1b.Spec.Template.Spec.Tolerations)
 	container3 := findContainer(&deployment3, deployment3.Name)
 	require.NotNil(t, container3, "failed to find stargate container")
 	rackName3 := findEnvVar(container3, "RACK_NAME")
@@ -279,38 +307,53 @@ func testNewDeploymentsManyRacksCustomAffinityDc(t *testing.T) {
 	stargate.Spec.Size = 8
 
 	deployments := NewDeployments(stargate, dc)
-	require.Len(t, deployments, 3)
-	require.Contains(t, deployments, "cluster1-dc1-rack1-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack2-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack3-stargate-deployment")
+	require.Len(t, deployments, 4)
 
-	deployment1 := deployments["cluster1-dc1-rack1-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Name)
-	assert.EqualValues(t, 3, *deployment1.Spec.Replicas)
-	assert.Contains(t, deployment1.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateLabel)
-	assert.Equal(t, "s1", deployment1.Spec.Template.Labels[api.StargateLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Template.Labels[api.StargateDeploymentLabel])
-	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1.Spec.Template.Spec.Affinity)
-	assert.Equal(t, dc.Spec.NodeSelector, deployment1.Spec.Template.Spec.NodeSelector)
-	assert.Equal(t, dc.Spec.Tolerations, deployment1.Spec.Template.Spec.Tolerations)
-	container1 := findContainer(&deployment1, deployment1.Name)
-	require.NotNil(t, container1, "failed to find stargate container")
-	rackName1 := findEnvVar(container1, "RACK_NAME")
-	require.NotNil(t, rackName1, "failed to find RACK_NAME env var")
-	assert.Equal(t, "rack1", rackName1.Value)
+	deployment1a := deployments[0]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Name)
+	assert.EqualValues(t, 1, *deployment1a.Spec.Replicas)
+	assert.Contains(t, deployment1a.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1a.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1a.Spec.Template.Spec.Affinity)
+	assert.Equal(t, dc.Spec.NodeSelector, deployment1a.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, dc.Spec.Tolerations, deployment1a.Spec.Template.Spec.Tolerations)
+	container1a := findContainer(&deployment1a, deployment1a.Name)
+	require.NotNil(t, container1a, "failed to find stargate container")
+	rackName1a := findEnvVar(container1a, "RACK_NAME")
+	require.NotNil(t, rackName1a, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1a.Value)
 
-	deployment2 := deployments["cluster1-dc1-rack2-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Name)
+	deployment1b := deployments[1]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Name)
+	assert.EqualValues(t, 2, *deployment1b.Spec.Replicas)
+	assert.Contains(t, deployment1b.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1b.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1b.Spec.Template.Spec.Affinity)
+	assert.Equal(t, dc.Spec.NodeSelector, deployment1b.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, dc.Spec.Tolerations, deployment1b.Spec.Template.Spec.Tolerations)
+	container1b := findContainer(&deployment1b, deployment1b.Name)
+	require.NotNil(t, container1b, "failed to find stargate container")
+	rackName1b := findEnvVar(container1b, "RACK_NAME")
+	require.NotNil(t, rackName1b, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1b.Value)
+
+	deployment2 := deployments[2]
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Name)
 	assert.EqualValues(t, 3, *deployment2.Spec.Replicas)
 	assert.Contains(t, deployment2.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment2.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, affinityForRack(dc, "rack2"), deployment2.Spec.Template.Spec.Affinity)
 	assert.Equal(t, dc.Spec.NodeSelector, deployment2.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, dc.Spec.Tolerations, deployment2.Spec.Template.Spec.Tolerations)
@@ -320,15 +363,15 @@ func testNewDeploymentsManyRacksCustomAffinityDc(t *testing.T) {
 	require.NotNil(t, rackName2, "failed to find RACK_NAME env var")
 	assert.Equal(t, "rack2", rackName2.Value)
 
-	deployment3 := deployments["cluster1-dc1-rack3-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Name)
+	deployment3 := deployments[3]
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Name)
 	assert.EqualValues(t, 2, *deployment3.Spec.Replicas)
 	assert.Contains(t, deployment3.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment3.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, affinityForRack(dc, "rack3"), deployment3.Spec.Template.Spec.Affinity)
 	assert.Equal(t, dc.Spec.NodeSelector, deployment3.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, dc.Spec.Tolerations, deployment3.Spec.Template.Spec.Tolerations)
@@ -391,38 +434,53 @@ func testNewDeploymentsManyRacksCustomAffinityStargate(t *testing.T) {
 	}}
 
 	deployments := NewDeployments(stargate, dc)
-	require.Len(t, deployments, 3)
-	require.Contains(t, deployments, "cluster1-dc1-rack1-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack2-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack3-stargate-deployment")
+	require.Len(t, deployments, 4)
 
-	deployment1 := deployments["cluster1-dc1-rack1-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Name)
-	assert.EqualValues(t, 3, *deployment1.Spec.Replicas)
-	assert.Contains(t, deployment1.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateLabel)
-	assert.Equal(t, "s1", deployment1.Spec.Template.Labels[api.StargateLabel])
-	assert.Contains(t, deployment1.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Spec.Template.Labels[api.StargateDeploymentLabel])
-	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1.Spec.Template.Spec.Affinity)
-	assert.Equal(t, stargate.Spec.NodeSelector, deployment1.Spec.Template.Spec.NodeSelector)
-	assert.Equal(t, stargate.Spec.Tolerations, deployment1.Spec.Template.Spec.Tolerations)
-	container1 := findContainer(&deployment1, deployment1.Name)
-	require.NotNil(t, container1, "failed to find stargate container")
-	rackName1 := findEnvVar(container1, "RACK_NAME")
-	require.NotNil(t, rackName1, "failed to find RACK_NAME env var")
-	assert.Equal(t, "rack1", rackName1.Value)
+	deployment1a := deployments[0]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Name)
+	assert.EqualValues(t, 1, *deployment1a.Spec.Replicas)
+	assert.Contains(t, deployment1a.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1a.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1a.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-1", deployment1a.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1a.Spec.Template.Spec.Affinity)
+	assert.Equal(t, stargate.Spec.NodeSelector, deployment1a.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, stargate.Spec.Tolerations, deployment1a.Spec.Template.Spec.Tolerations)
+	container1a := findContainer(&deployment1a, deployment1a.Name)
+	require.NotNil(t, container1a, "failed to find stargate container")
+	rackName1a := findEnvVar(container1a, "RACK_NAME")
+	require.NotNil(t, rackName1a, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1a.Value)
 
-	deployment2 := deployments["cluster1-dc1-rack2-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Name)
+	deployment1b := deployments[1]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Name)
+	assert.EqualValues(t, 2, *deployment1b.Spec.Replicas)
+	assert.Contains(t, deployment1b.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateLabel)
+	assert.Equal(t, "s1", deployment1b.Spec.Template.Labels[api.StargateLabel])
+	assert.Contains(t, deployment1b.Spec.Template.Labels, api.StargateDeploymentLabel)
+	assert.Equal(t, "cluster1-dc1-rack1-stargate-2", deployment1b.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, affinityForRack(dc, "rack1"), deployment1b.Spec.Template.Spec.Affinity)
+	assert.Equal(t, stargate.Spec.NodeSelector, deployment1b.Spec.Template.Spec.NodeSelector)
+	assert.Equal(t, stargate.Spec.Tolerations, deployment1b.Spec.Template.Spec.Tolerations)
+	container1b := findContainer(&deployment1b, deployment1b.Name)
+	require.NotNil(t, container1b, "failed to find stargate container")
+	rackName1b := findEnvVar(container1b, "RACK_NAME")
+	require.NotNil(t, rackName1b, "failed to find RACK_NAME env var")
+	assert.Equal(t, "rack1", rackName1b.Value)
+
+	deployment2 := deployments[2]
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Name)
 	assert.EqualValues(t, 3, *deployment2.Spec.Replicas)
 	assert.Contains(t, deployment2.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment2.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment2.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, affinityForRack(dc, "rack2"), deployment2.Spec.Template.Spec.Affinity)
 	assert.Equal(t, stargate.Spec.NodeSelector, deployment2.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, stargate.Spec.Tolerations, deployment2.Spec.Template.Spec.Tolerations)
@@ -432,15 +490,15 @@ func testNewDeploymentsManyRacksCustomAffinityStargate(t *testing.T) {
 	require.NotNil(t, rackName2, "failed to find RACK_NAME env var")
 	assert.Equal(t, "rack2", rackName2.Value)
 
-	deployment3 := deployments["cluster1-dc1-rack3-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Name)
+	deployment3 := deployments[3]
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Name)
 	assert.EqualValues(t, 2, *deployment3.Spec.Replicas)
 	assert.Contains(t, deployment3.Spec.Selector.MatchLabels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Selector.MatchLabels[api.StargateDeploymentLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateLabel)
 	assert.Equal(t, "s1", deployment3.Spec.Template.Labels[api.StargateLabel])
 	assert.Contains(t, deployment3.Spec.Template.Labels, api.StargateDeploymentLabel)
-	assert.Equal(t, "cluster1-dc1-rack3-stargate-deployment", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
+	assert.Equal(t, "cluster1-dc1-rack3-stargate", deployment3.Spec.Template.Labels[api.StargateDeploymentLabel])
 	assert.Equal(t, stargate.Spec.Racks[0].Affinity, deployment3.Spec.Template.Spec.Affinity)
 	assert.Equal(t, stargate.Spec.Racks[0].NodeSelector, deployment3.Spec.Template.Spec.NodeSelector)
 	assert.Equal(t, stargate.Spec.Racks[0].Tolerations, deployment3.Spec.Template.Spec.Tolerations)
@@ -466,15 +524,13 @@ func testNewDeploymentsManyRacksFewReplicas(t *testing.T) {
 
 	deployments := NewDeployments(stargate, dc)
 	require.Len(t, deployments, 2)
-	require.Contains(t, deployments, "cluster1-dc1-rack1-stargate-deployment")
-	require.Contains(t, deployments, "cluster1-dc1-rack2-stargate-deployment")
 
-	deployment1 := deployments["cluster1-dc1-rack1-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack1-stargate-deployment", deployment1.Name)
+	deployment1 := deployments[0]
+	assert.Equal(t, "cluster1-dc1-rack1-stargate", deployment1.Name)
 	assert.EqualValues(t, 1, *deployment1.Spec.Replicas)
 
-	deployment2 := deployments["cluster1-dc1-rack2-stargate-deployment"]
-	assert.Equal(t, "cluster1-dc1-rack2-stargate-deployment", deployment2.Name)
+	deployment2 := deployments[1]
+	assert.Equal(t, "cluster1-dc1-rack2-stargate", deployment2.Name)
 	assert.EqualValues(t, 1, *deployment2.Spec.Replicas)
 }
 
@@ -486,7 +542,7 @@ func testNewDeploymentsCassandraConfigMap(t *testing.T) {
 
 	deployments := NewDeployments(stargate, dc)
 	require.Len(t, deployments, 1)
-	deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+	deployment := deployments[0]
 
 	container := findContainer(&deployment, deployment.Name)
 	require.NotNil(t, container, "failed to find stargate container")
@@ -519,7 +575,7 @@ func testImages(t *testing.T) {
 		stargate.Spec.ContainerImage = nil
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, defaultImage3.String(), deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
@@ -531,7 +587,7 @@ func testImages(t *testing.T) {
 		dc.Spec.ServerVersion = "4.0.1"
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, defaultImage4.String(), deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
@@ -544,7 +600,7 @@ func testImages(t *testing.T) {
 		}
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, defaultImage3.String(), deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
@@ -559,7 +615,7 @@ func testImages(t *testing.T) {
 		dc.Spec.ServerVersion = "4.0.1"
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, defaultImage4.String(), deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
@@ -574,7 +630,7 @@ func testImages(t *testing.T) {
 		stargate.Spec.ContainerImage = image
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, "docker.io/my-custom-repo/stargate-3_11:latest", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
@@ -592,7 +648,7 @@ func testImages(t *testing.T) {
 		dc.Spec.ServerVersion = "4.0.1"
 		deployments := NewDeployments(stargate, dc)
 		require.Len(t, deployments, 1)
-		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		deployment := deployments[0]
 		assert.Equal(t, "docker.io/my-custom-repo/stargate-4_0:latest", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -16,5 +16,5 @@ func ServiceName(dc *cassdcapi.CassandraDatacenter) string {
 
 func DeploymentName(dc *cassdcapi.CassandraDatacenter, rack *cassdcapi.Rack) string {
 	// FIXME sanitize name
-	return dc.Spec.ClusterName + "-" + dc.Name + "-" + rack.Name + "-stargate-deployment"
+	return dc.Spec.ClusterName + "-" + dc.Name + "-" + rack.Name + "-stargate"
 }

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -123,11 +123,11 @@ func waitForAllComponentsReady(
 	// pod that has authentication enabled while we just turned it off.
 	options1 := kubectl.Options{Namespace: kcKey.Namespace, Context: "kind-k8ssandra-0"}
 	options2 := kubectl.Options{Namespace: kcKey.Namespace, Context: "kind-k8ssandra-1"}
-	err := kubectl.RolloutStatus(options1, "deployment", "cluster1-dc1-default-stargate-deployment")
+	err := kubectl.RolloutStatus(options1, "deployment", "cluster1-dc1-default-stargate")
 	assert.NoError(t, err)
 	err = kubectl.RolloutStatus(options1, "deployment", "cluster1-dc1-reaper")
 	assert.NoError(t, err)
-	err = kubectl.RolloutStatus(options2, "deployment", "cluster1-dc2-default-stargate-deployment")
+	err = kubectl.RolloutStatus(options2, "deployment", "cluster1-dc2-default-stargate")
 	assert.NoError(t, err)
 	err = kubectl.RolloutStatus(options2, "deployment", "cluster1-dc2-reaper")
 	assert.NoError(t, err)

--- a/test/testdata/fixtures/multi-stargate/cassdc.yaml
+++ b/test/testdata/fixtures/multi-stargate/cassdc.yaml
@@ -33,7 +33,7 @@ spec:
   serverVersion: 3.11.11
   networking:
     hostNetwork: false
-  size: 3
+  size: 2
   racks:
     - name: rack1
       nodeAffinityLabels:
@@ -41,9 +41,6 @@ spec:
     - name: rack2
       nodeAffinityLabels:
         "topology.kubernetes.io/zone": rack2
-    - name: rack3
-      nodeAffinityLabels:
-        "topology.kubernetes.io/zone": rack3
   storageConfig:
     cassandraDataVolumeClaimSpec:
       accessModes:

--- a/test/testdata/fixtures/multi-stargate/stargate.yaml
+++ b/test/testdata/fixtures/multi-stargate/stargate.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   datacenterRef:
     name: dc1
-  size: 3
+  # First rack will get 2 Stargate pods, each in a distinct deployment, so that
+  # the very first Stargate deployment contains exactly one replica.
+  # Second rack with get 2 Stargate pods, both grouped together in one single
+  # deployment.
+  size: 4
   allowStargateOnDataNodes: true
   heapSize: 384Mi
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Alternate solution for #297 (vs solution proposed in #298).

This commit modifies the Stargate deployment creation logic so that
the first Stargate deployment always contains one single replica.

Moreover, this commit also modifies the Stargate controller so that
it waits until the first deployment is fully rolled out before
proceeding to creating the following ones.

This eliminates the race condition where many Stargate pods are
created at once, and all of them attempt to modify the schema
concurrently.

**Which issue(s) this PR fixes**:
Fixes #297

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
