### PR TITLE
Fix Reaper secret reconciliation

### DIFF
--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -40,8 +40,10 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 		if kc.Spec.IsAuthEnabled() {
 			logger.Info("Reconciling Reaper user secrets")
 			var cassandraUserSecretRef corev1.LocalObjectReference
+			var jmxUserSecretRef corev1.LocalObjectReference
 			if kc.Spec.Reaper != nil {
 				cassandraUserSecretRef = kc.Spec.Reaper.CassandraUserSecretRef
+				jmxUserSecretRef = kc.Spec.Reaper.JmxUserSecretRef
 			}
 			if cassandraUserSecretRef.Name == "" {
 				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Name)

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/secret"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
@@ -38,11 +39,17 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 		// Reaper secrets are only required when authentication is enabled on the cluster
 		if kc.Spec.IsAuthEnabled() {
 			logger.Info("Reconciling Reaper user secrets")
-			cassandraUserSecretRef := kc.Spec.Reaper.CassandraUserSecretRef
+			var cassandraUserSecretRef corev1.LocalObjectReference
+			if kc.Spec.Reaper != nil {
+				cassandraUserSecretRef = kc.Spec.Reaper.CassandraUserSecretRef
+			}
 			if cassandraUserSecretRef.Name == "" {
 				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Name)
 			}
-			jmxUserSecretRef := kc.Spec.Reaper.JmxUserSecretRef
+			var jmxUserSecretRef corev1.LocalObjectReference
+			if kc.Spec.Reaper != nil {
+				jmxUserSecretRef = kc.Spec.Reaper.JmxUserSecretRef
+			}
 			if jmxUserSecretRef.Name == "" {
 				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.Name)
 			}

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -48,10 +48,6 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 			if cassandraUserSecretRef.Name == "" {
 				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Name)
 			}
-			var jmxUserSecretRef corev1.LocalObjectReference
-			if kc.Spec.Reaper != nil {
-				jmxUserSecretRef = kc.Spec.Reaper.JmxUserSecretRef
-			}
 			if jmxUserSecretRef.Name == "" {
 				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.Name)
 			}

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -34,7 +34,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 }
 
 func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
-	if kc.Spec.Reaper != nil {
+	if kc.HasReapers() {
 		// Reaper secrets are only required when authentication is enabled on the cluster
 		if kc.Spec.IsAuthEnabled() {
 			logger.Info("Reconciling Reaper user secrets")

--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: reaper-cql-secret
+  name: reaper-jmx-secret
 data:
   # username: reaper-cql
   username: cmVhcGVyLWNxbA==
@@ -16,9 +16,9 @@ spec:
   reaper:
     keyspace: reaper_ks # custom name
     cassandraUserSecretRef:
-      name: reaper-cql-secret # pre-existing secret
+      name: reaper-cql-secret # will be created with non-default name
     jmxUserSecretRef:
-      name: reaper-jmx-secret # will be created with non-default name
+      name: reaper-jmx-secret # pre-existing secret
   cassandra:
     serverVersion: "4.0.1"
     datacenters:

--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: reaper-jmx-secret
+  name: reaper-cql-secret
 data:
   # username: reaper-cql
   username: cmVhcGVyLWNxbA==
@@ -16,9 +16,9 @@ spec:
   reaper:
     keyspace: reaper_ks # custom name
     cassandraUserSecretRef:
-      name: reaper-cql-secret # will be created with non-default name
+      name: reaper-cql-secret # pre-existing secret
     jmxUserSecretRef:
-      name: reaper-jmx-secret # pre-existing secret
+      name: reaper-jmx-secret # will be created with non-default name
   cassandra:
     serverVersion: "4.0.1"
     datacenters:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This commit fixes Reaper secret reconciliation when
Reaper is present for some dcs, but not for all of them.

If the Reaper secret doesn't exist when the dc is created,
we get the following error:

    Validation of user secret failed due to an error:
    Secret \"test-reaper\" not found

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
