### PR TITLE
Improve logic to compute Reaper availability mode [K8SSAND-1177]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -14,10 +14,12 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## Unreleased
 
+* [ENHANCEMENT] [#308](https://github.com/k8ssandra/k8ssandra-operator/issues/308) Improve logic to compute Reaper availability mode
+
 ## v1.0.0-alpha.3 2022-01-23
 
 * [CHANGE] [#232](https://github.com/k8ssandra/k8ssandra-operator/issues/232) Use ReconcileResult in K8ssandraClusterReconciler
-* [CHANGE] [#237](https://github.com/k8ssandra/k8ssandra-operator/issues/237) Add cass-operator dev kutomization
+* [CHANGE] [#237](https://github.com/k8ssandra/k8ssandra-operator/issues/237) Add cass-operator dev kustomization
 * [FEATURE] [#276](https://github.com/k8ssandra/k8ssandra-operator/issues/276) Enable Reaper UI authentication
 * [FEATURE] [#249](https://github.com/k8ssandra/k8ssandra-operator/issues/249) Expose all Cassandra yaml settings in a structured fashion in the k8c CRD
 * [FEATURE] [#45](https://github.com/k8ssandra/k8ssandra-operator/issues/45) Migrate the Medusa controllers to k8ssandra-operator

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -203,13 +203,12 @@ type ReaperSpec struct {
 	DatacenterRef CassandraDatacenterRef `json:"datacenterRef"`
 
 	// DatacenterAvailability indicates to Reaper its deployment in relation to the target datacenter's network.
-	// For single-DC clusters, the default (LOCAL) is fine. For multi-DC clusters, it is recommended to use EACH,
+	// For single-DC clusters, the default (ALL) is fine. For multi-DC clusters, it is recommended to use EACH,
 	// provided that there is one Reaper instance managing each DC in the cluster; otherwise, if one single Reaper
-	// instance is going to manage more than one DC in the cluster, use LOCAL and remote DCs will be handled internally
-	// by Cassandra itself.
+	// instance is going to manage more than one DC in the cluster, use ALL.
 	// See https://cassandra-reaper.io/docs/usage/multi_dc/.
 	// +optional
-	// +kubebuilder:default="LOCAL"
+	// +kubebuilder:default="ALL"
 	// +kubebuilder:validation:Enum:=LOCAL;ALL;EACH
 	DatacenterAvailability string `json:"datacenterAvailability,omitempty"`
 }

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1012,14 +1012,14 @@ spec:
                     type: string
                 type: object
               datacenterAvailability:
-                default: LOCAL
+                default: ALL
                 description: DatacenterAvailability indicates to Reaper its deployment
                   in relation to the target datacenter's network. For single-DC clusters,
-                  the default (LOCAL) is fine. For multi-DC clusters, it is recommended
+                  the default (ALL) is fine. For multi-DC clusters, it is recommended
                   to use EACH, provided that there is one Reaper instance managing
                   each DC in the cluster; otherwise, if one single Reaper instance
-                  is going to manage more than one DC in the cluster, use LOCAL and
-                  remote DCs will be handled internally by Cassandra itself. See https://cassandra-reaper.io/docs/usage/multi_dc/.
+                  is going to manage more than one DC in the cluster, use ALL. See
+                  https://cassandra-reaper.io/docs/usage/multi_dc/.
                 enum:
                 - LOCAL
                 - ALL

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -21,7 +21,7 @@ func TestNewDeployment(t *testing.T) {
 	reaper.Spec.InitContainerImage = initImage
 	reaper.Spec.AutoScheduling = reaperapi.AutoScheduling{Enabled: false}
 	reaper.Spec.ServiceAccountName = "reaper"
-	reaper.Spec.DatacenterAvailability = DatacenterAvailabilityLocal
+	reaper.Spec.DatacenterAvailability = DatacenterAvailabilityAll
 
 	labels := createServiceAndDeploymentLabels(reaper)
 	deployment := NewDeployment(reaper, newTestDatacenter())
@@ -70,7 +70,7 @@ func TestNewDeployment(t *testing.T) {
 		},
 		{
 			Name:  "REAPER_DATACENTER_AVAILABILITY",
-			Value: DatacenterAvailabilityLocal,
+			Value: DatacenterAvailabilityAll,
 		},
 		{
 			Name:  "REAPER_CASS_LOCAL_DC",
@@ -102,7 +102,7 @@ func TestNewDeployment(t *testing.T) {
 		},
 		{
 			Name:  "REAPER_DATACENTER_AVAILABILITY",
-			Value: DatacenterAvailabilityLocal,
+			Value: DatacenterAvailabilityAll,
 		},
 		{
 			Name:  "REAPER_CASS_LOCAL_DC",

--- a/pkg/reaper/resource_test.go
+++ b/pkg/reaper/resource_test.go
@@ -1,0 +1,134 @@
+package reaper
+
+import (
+	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_computeReaperDcAvailability(t *testing.T) {
+	tests := []struct {
+		name string
+		kc   *k8ssandraapi.K8ssandraCluster
+		want string
+	}{
+		{
+			"cluster-level reaper, single dc",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{Meta: k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"}},
+						},
+					},
+					Reaper: &reaperapi.ReaperClusterTemplate{},
+				},
+			},
+			DatacenterAvailabilityAll,
+		},
+		{
+			"cluster-level reaper, multi dc",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{Meta: k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"}},
+							{Meta: k8ssandraapi.EmbeddedObjectMeta{Name: "dc2"}},
+						},
+					},
+					Reaper: &reaperapi.ReaperClusterTemplate{},
+				},
+			},
+			DatacenterAvailabilityEach,
+		},
+		{
+			"dc-level reaper, single dc",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+						},
+					},
+				},
+			},
+			DatacenterAvailabilityAll,
+		},
+		{
+			"dc-level reaper, multi dc, single reaper",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+							{
+								Meta: k8ssandraapi.EmbeddedObjectMeta{Name: "dc2"},
+							},
+						},
+					},
+				},
+			},
+			DatacenterAvailabilityAll,
+		},
+		{
+			"dc-level reaper, multi dc, some reapers",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc2"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+							{
+								Meta: k8ssandraapi.EmbeddedObjectMeta{Name: "dc3"},
+							},
+						},
+					},
+				},
+			},
+			DatacenterAvailabilityAll,
+		},
+		{
+			"dc-level reaper, multi dc, all reapers",
+			&k8ssandraapi.K8ssandraCluster{
+				Spec: k8ssandraapi.K8ssandraClusterSpec{
+					Cassandra: &k8ssandraapi.CassandraClusterTemplate{
+						Datacenters: []k8ssandraapi.CassandraDatacenterTemplate{
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc1"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc2"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+							{
+								Meta:   k8ssandraapi.EmbeddedObjectMeta{Name: "dc3"},
+								Reaper: &reaperapi.ReaperDatacenterTemplate{},
+							},
+						},
+					},
+				},
+			},
+			DatacenterAvailabilityEach,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeReaperDcAvailability(tt.kc)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This commit changes the logic to be as follows:

* For single-DC clusters, always use ALL;
* For multi-DC clusters:
  * If all DCs have their Reaper instance, use EACH;
  * Otherwise use ALL.


**Which issue(s) this PR fixes**:
Fixes #308

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
