### PR TITLE
create image tag for release for use in e2e tests

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -16,6 +16,8 @@ jobs:
   build_image:
     name: Build Image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.set_image_var.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -28,6 +30,23 @@ jobs:
           key: ${{ runner.os }}-buildx-integ-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-integ-
+      - name: Set build tags
+        id: set_build_tags
+        run: |
+          image="k8ssandra-operator/k8ssandra-operator:latest"
+          echo "build_tags=$image" >> $GITHUB_ENV
+          echo "image=$image" >> $GITHUB_ENV
+      - name: Update build tags
+        id: update_build_tags
+        if: startsWith(github.head_ref, 'prepare-release-')
+        run: |
+          branch_name=${{ github.head_ref }}
+          release_tag=k8ssandra/k8ssandra-operator:${branch_name:16}
+          echo "image=$release_tag" >> $GITHUB_ENV
+          echo "build_tags=k8ssandra/k8ssandra-operator:latest,$release_tag" >> $GITHUB_ENV
+      - name: Set immage output var
+        id: set_image_var
+        run: echo ::set-output name=image::${{ env.image }}
       - name: Build image
         id: docker_build
         uses: docker/build-push-action@v2
@@ -35,7 +54,7 @@ jobs:
           file: Dockerfile
           context: .
           push: false
-          tags: k8ssandra/k8ssandra-operator:latest
+          tags: ${{ env.build_tags }}
           platforms: linux/amd64
           outputs: type=docker,dest=/tmp/k8ssandra-operator.tar
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -107,7 +126,7 @@ jobs:
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
       - name: Setup kind cluster
-        run: make e2e-setup-single
+        run: make IMG=${{ needs.build_image.outputs.image }} e2e-setup-single
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} e2e-test
       - name: Archive k8s logs

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -16,6 +16,8 @@ jobs:
   build_image:
     name: Build Image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.set_image_var.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -28,6 +30,23 @@ jobs:
           key: ${{ runner.os }}-buildx-integ-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-integ-
+      - name: Set build tags
+        id: set_build_tags
+        run: |
+          image="k8ssandra-operator/k8ssandra-operator:latest"
+          echo "build_tags=$image" >> $GITHUB_ENV
+          echo "image=$image" >> $GITHUB_ENV
+      - name: Update build tags
+        id: update_build_tags
+        if: startsWith(github.head_ref, 'prepare-release-')
+        run: |
+          branch_name=${{ github.head_ref }}
+          release_tag=k8ssandra/k8ssandra-operator:${branch_name:16}
+          echo "image=$release_tag" >> $GITHUB_ENV
+          echo "build_tags=k8ssandra/k8ssandra-operator:latest,$release_tag" >> $GITHUB_ENV
+      - name: Set immage output var
+        id: set_image_var
+        run: echo ::set-output name=image::${{ env.image }}
       - name: Build image
         id: docker_build
         uses: docker/build-push-action@v2
@@ -35,7 +54,7 @@ jobs:
           file: Dockerfile
           context: .
           push: false
-          tags: k8ssandra/k8ssandra-operator:latest
+          tags: ${{ env.build_tags }}
           platforms: linux/amd64
           outputs: type=docker,dest=/tmp/k8ssandra-operator.tar
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -109,7 +128,7 @@ jobs:
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
       - name: Setup kind clusters
-        run: make e2e-setup-multi
+        run: make IMG=${{ needs.build_image.outputs.image }} e2e-setup-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} NODETOOL_STATUS_TIMEOUT=2m e2e-test
       - name: Archive k8s logs

--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -16,6 +16,8 @@ jobs:
   build_image:
     name: Build image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.set_image_var.outputs.image }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -28,10 +30,23 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-  uses: docker/setup-buildx-action@v1
-      - name: Set git parsed values
-        id: vars
+      - name: Set build tags
+        id: set_build_tags
         run: |
-          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
+          image="k8ssandra-operator/k8ssandra-operator:latest"
+          echo "build_tags=$image" >> $GITHUB_ENV
+          echo "image=$image" >> $GITHUB_ENV
+      - name: Update build tags
+        id: update_build_tags
+        if: startsWith(github.head_ref, 'prepare-release-')
+        run: |
+          branch_name=${{ github.head_ref }}
+          release_tag=k8ssandra/k8ssandra-operator:${branch_name:16}
+          echo "image=$release_tag" >> $GITHUB_ENV
+          echo "build_tags=k8ssandra/k8ssandra-operator:latest,$release_tag" >> $GITHUB_ENV
+      - name: Set immage output var
+        id: set_image_var
+        run: echo ::set-output name=image::${{ env.image }}
       - name: Build Docker image
         id: docker_build
         uses: docker/build-push-action@v2
@@ -39,7 +54,7 @@ jobs:
           file: Dockerfile
           context: .
           push: false
-          tags: k8ssandra/k8ssandra-operator:${{ steps.vars.outputs.sha_short }}, k8ssandra/k8ssandra-operator:latest
+          tags: ${{ env.build_tags }}
           platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -66,10 +81,6 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-  uses: docker/setup-buildx-action@v1
-    - name: Set git parsed values
-      id: vars
-      run: |
-        echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
     - name: Kind kube-proxy issue workaround
       run: sudo sysctl net/netfilter/nf_conntrack_max=524288
     - name: Download k8ssandra-operator image
@@ -87,4 +98,16 @@ jobs:
       run: |
         # We are running tests against k8s 1.20 - 1.22 currently. 
         # Additional versions must be added in kind config files under ./test/config/kind
-        make KUTTL_KIND_CFG="./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml" kuttl-test
+
+        # Currently we aren't using the kuttl-test Makefile target while trying to iron out the
+        # release process. The following changes have been made to stay as close as possible
+        # to the existing behavior with kuttl tests while supporting the ability to use a release
+        # image tag of the operator. 
+
+        kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
+        make IMG=${{ needs.build_image.outputs.image }} kind-load-image
+        ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-servicemonitors
+        kind delete cluster --name k8ssandra-0
+        kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
+        make IMG=${{ needs.build_image.outputs.image }} kind-load-image
+        ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-config-control-plane

--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -104,6 +104,7 @@ jobs:
         # to the existing behavior with kuttl tests while supporting the ability to use a release
         # image tag of the operator. 
 
+        make install-kuttl
         kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
         make IMG=${{ needs.build_image.outputs.image }} kind-load-image
         ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-servicemonitors

--- a/Makefile
+++ b/Makefile
@@ -343,8 +343,8 @@ catalog-push: ## Push a catalog image.
 
 # E2E tests from kuttl
 kuttl-test: install-kuttl docker-build
-	./bin/kubectl-kuttl test --kind-config=${KUTTL_KIND_CFG} --test test-servicemonitors
-	./bin/kubectl-kuttl test --kind-config=${KUTTL_KIND_CFG} --test test-config-control-plane
+	./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-servicemonitors
+	./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-config-control-plane
 
  # Install kuttl for e2e tests.
 install-kuttl: 

--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: latest
+    newTag: 1.0.0-alpha.3
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates GHA test workflows to create an operator image tag for the release for use in testing. No images are pushed to any remote registries. The images are only loaded into kind for tests to run.

**Which issue(s) this PR fixes**:
Fixes #314

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
