### PR TITLE
Update cass-operator to 9d1c58a5 with the decommission support

### DIFF
--- a/config/cass-operator-cluster-scope/kustomization.yaml
+++ b/config/cass-operator-cluster-scope/kustomization.yaml
@@ -13,12 +13,12 @@ namePrefix: cass-operator-
 namespace: cass-operator
 
 resources:
-  - github.com/k8ssandra/cass-operator/config/default?ref=6a78a8237173d9322e6c0cab94c615b1f043a906
+  - github.com/k8ssandra/cass-operator/config/default?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
 
 components:
   - ../components/cass-operator-cluster-scope
-  - github.com/k8ssandra/cass-operator/config/components/webhook?ref=6a78a8237173d9322e6c0cab94c615b1f043a906
+  - github.com/k8ssandra/cass-operator/config/components/webhook?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
 
 images:
   - name: k8ssandra/cass-operator
-    newTag: 6a78a823
+    newTag: 9d1c58a5

--- a/config/deployments/control-plane/kustomization.yaml
+++ b/config/deployments/control-plane/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: k8ssandra-operator
 
 resources:
   - ../default
-  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=6a78a8237173d9322e6c0cab94c615b1f043a906
+  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
 
 images:
   - name: k8ssandra/cass-operator
-    newTag: 6a78a823
+    newTag: 9d1c58a5

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -176,7 +176,7 @@ The integration test framework installs CRDs. We have to specify the version to 
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d"
-	cassOperatorVersion       = "6a78a8237173d9322e6c0cab94c615b1f043a906"
+	cassOperatorVersion       = "9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa"
 	prometheusOperatorVersion = "v0.9.0"
 )
 ```
@@ -187,11 +187,11 @@ There are a couple of places in the Kustomize manifests that need to be updated.
 ```yaml
 resources:
   - ../default
-  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=6a78a8237173d9322e6c0cab94c615b1f043a906
+  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
 
 images:
   - name: k8ssandra/cass-operator
-    newTag: 6a78a823
+    newTag: 9d1c58a5
 ```
 
 In this example the `resources` entry happens to specify a commit hash. Note that the full hash must be specified. The images transform specifies the corresponding image tag.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gruntwork-io/terratest v0.37.7
-	github.com/k8ssandra/cass-operator v1.8.0-rc.2.0.20220114225934-6a78a8237173
+	github.com/k8ssandra/cass-operator v1.8.0-rc.2.0.20220124145237-9d1c58a5dec6
 	github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -37,7 +37,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d"
-	cassOperatorVersion       = "6a78a8237173d9322e6c0cab94c615b1f043a906"
+	cassOperatorVersion       = "9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa"
 	prometheusOperatorVersion = "v0.9.0"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates cass-operator version to one with the datacenter decommission support

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
