### PR TITLE
reset image tag for development

### DIFF
--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: 1.0.0-alpha.3
+    newTag: latest
 


### PR DESCRIPTION
This resets the image tag in `config/deployments/default/kustomization.yaml` back to latest. In the future, releases should be done out of branches so we can avoid the changes in main.