### PR TITLE
Set annotation before computing hash

### DIFF
--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -73,14 +73,15 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 			logger.Error(err, "Failed to create new CassandraDatacenter")
 			return result.Error(err), actualDcs
 		}
+		if idx > 0 {
+			desiredDc.Annotations[cassdcapi.SkipUserCreationAnnotation] = "true"
+		}
+
+		// Note: desiredDc should not be modified from now on
 		annotations.AddHashAnnotation(desiredDc)
 
 		dcKey := types.NamespacedName{Namespace: desiredDc.Namespace, Name: desiredDc.Name}
 		logger := logger.WithValues("CassandraDatacenter", dcKey, "K8SContext", dcTemplate.K8sContext)
-
-		if idx > 0 {
-			desiredDc.Annotations[cassdcapi.SkipUserCreationAnnotation] = "true"
-		}
 
 		if recResult := r.checkRebuildAnnotation(ctx, kc, dcKey.Name); recResult.Completed() {
 			return recResult, actualDcs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Sets the SkipUSer annotation on desiredDc before computing the hash.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
