### PR TITLE
[DO NOT MERGE] Demo of GHA failures for multiDcMultiCluster test

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -133,9 +133,15 @@ jobs:
         run: make IMG=${{ needs.build_image.outputs.image }} create-kind-cluster kind-load-image
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} e2e-test
+      - name: Get artefact upload directory
+        if: ${{ failure() }}
+        run: |
+          uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
+          echo 'setting uploaddir_name to' $uploaddir_name
+          echo "::set-env name=uploaddir_name::$uploaddir_name"
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: k8s-logs-${{ matrix.e2e_test }}
+          name: k8s-logs-${{ env.uploaddir_name }}
           path: ./build/test

--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -138,7 +138,7 @@ jobs:
         run: |
           uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
           echo 'setting uploaddir_name to' $uploaddir_name
-          echo "::set-env name=uploaddir_name::$uploaddir_name"
+          echo "uploaddir_name=$uploaddir_name" >> $GITHUB_ENV
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -132,9 +132,16 @@ jobs:
         run: make IMG=${{ needs.build_image.outputs.image }} create-kind-multicluster kind-load-image-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} NODETOOL_STATUS_TIMEOUT=2m e2e-test
+      - name: Get artefact upload directory
+        if: ${{ failure() }}
+        run: |
+          uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
+          echo 'setting uploaddir_name to' $uploaddir_name
+          echo "::set-env name=uploaddir_name::$uploaddir_name"
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: k8s-logs-${{ matrix.e2e_test }}
+          name: k8s-logs-${{ env.uploaddir_name }}
           path: ./build/test
+

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |
           uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
           echo 'setting uploaddir_name to' $uploaddir_name
-          echo "::set-env name=uploaddir_name::$uploaddir_name"
+          echo "uploaddir_name=$uploaddir_name" >> $GITHUB_ENV
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -2,15 +2,18 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace string, f *framework.E2eFramework) {
 	require := require.New(t)
+	assert.FailNow(t, "Deliberate failure.")
 
 	dc1Namespace := "test-1"
 	dc2Namespace := "test-2"


### PR DESCRIPTION
A demo of the way that multiDcMultiCluster can't upload artefacts when it fails. It tries to upload to a directory with a `/` in the path, due to naming it equal to the Go subtest name.