### PR TITLE
Fix artefact upload failues on e2e test ClusterScoped/MultiDcMultiCluster

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -133,9 +133,15 @@ jobs:
         run: make IMG=${{ needs.build_image.outputs.image }} create-kind-cluster kind-load-image
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} e2e-test
+      - name: Get artefact upload directory
+        if: ${{ failure() }}
+        run: |
+          uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
+          echo 'setting uploaddir_name to' $uploaddir_name
+          echo "uploaddir_name=$uploaddir_name" >> $GITHUB_ENV
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: k8s-logs-${{ matrix.e2e_test }}
+          name: k8s-logs-${{ env.uploaddir_name }}
           path: ./build/test

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -132,9 +132,16 @@ jobs:
         run: make IMG=${{ needs.build_image.outputs.image }} create-kind-multicluster kind-load-image-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: make E2E_TEST=TestOperator/${{ matrix.e2e_test }} NODETOOL_STATUS_TIMEOUT=2m e2e-test
+      - name: Get artefact upload directory
+        if: ${{ failure() }}
+        run: |
+          uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
+          echo 'setting uploaddir_name to' $uploaddir_name
+          echo "uploaddir_name=$uploaddir_name" >> $GITHUB_ENV
       - name: Archive k8s logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: k8s-logs-${{ matrix.e2e_test }}
+          name: k8s-logs-${{ env.uploaddir_name }}
           path: ./build/test
+


### PR DESCRIPTION
**What this PR does**:

When a GHA e2e test workflow fails it tries to upload artefacts to a directory named after the test.

Go's subtests separate test names using `/` which GHA's `actions/upload-artifact@v2` action does not like. 

This PR runs a simple sed script to replace `/` characters with `__` in the test name and uses the output as the upload directory. 

**Which issue(s) this PR fixes**:
#339 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
