### PR TITLE
Expose AllowMultipleNodesPerWorker [K8SSAND-1203]

### DIFF
--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -238,6 +238,11 @@ type CassandraClusterTemplate struct {
 	// api heap.
 	// +optional
 	MgmtAPIHeap *resource.Quantity `json:"mgmtAPIHeap,omitempty"`
+
+	// AllowMultipleCassPerNode sets whether multiple Cassandra instances can be scheduled on the same node.
+	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise
+	// the number of nodes required.
+	AllowMultipleCassPerNode *bool `json:"allowMultipleCassPerNode,omitempty"`
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields
@@ -307,6 +312,11 @@ type CassandraDatacenterTemplate struct {
 	// a user-provided monitoring solution (at present, only support for Prometheus is available).
 	// +optional
 	CassandraTelemetry *telemetryapi.TelemetrySpec `json:"cassandraTelemetry,omitempty"`
+
+	// AllowMultipleCassPerNode sets whether multiple Cassandra instances can be scheduled on the same node.
+	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise
+	// the number of nodes required.
+	AllowMultipleCassPerNode *bool `json:"allowMultipleCassPerNode,omitempty"`
 }
 
 type EmbeddedObjectMeta struct {

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -239,10 +239,10 @@ type CassandraClusterTemplate struct {
 	// +optional
 	MgmtAPIHeap *resource.Quantity `json:"mgmtAPIHeap,omitempty"`
 
-	// AllowMultipleCassPerNode sets whether multiple Cassandra instances can be scheduled on the same node.
+	// SoftPodAntiAffinity sets whether multiple Cassandra instances can be scheduled on the same node.
 	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise
 	// the number of nodes required.
-	AllowMultipleCassPerNode *bool `json:"allowMultipleCassPerNode,omitempty"`
+	SoftPodAntiAffinity *bool `json:"softPodAntiAffinity,omitempty"`
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields
@@ -313,10 +313,10 @@ type CassandraDatacenterTemplate struct {
 	// +optional
 	CassandraTelemetry *telemetryapi.TelemetrySpec `json:"cassandraTelemetry,omitempty"`
 
-	// AllowMultipleCassPerNode sets whether multiple Cassandra instances can be scheduled on the same node.
+	// SoftPodAntiAffinity sets whether multiple Cassandra instances can be scheduled on the same node.
 	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise
 	// the number of nodes required.
-	AllowMultipleCassPerNode *bool `json:"allowMultipleCassPerNode,omitempty"`
+	SoftPodAntiAffinity *bool `json:"softPodAntiAffinity,omitempty"`
 }
 
 type EmbeddedObjectMeta struct {

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -87,24 +87,24 @@ func (r *Replication) ReplicationFactor(dc, ks string) int {
 // to be specified at the DC-level. Using a DatacenterConfig allows to keep the api types
 // clean such that cluster-level settings won't leak into the dc-level settings.
 type DatacenterConfig struct {
-	Meta                     api.EmbeddedObjectMeta
-	Cluster                  string
-	SuperuserSecretRef       corev1.LocalObjectReference
-	ServerImage              string
-	ServerVersion            string
-	JmxInitContainerImage    *images.Image
-	Size                     int32
-	Resources                *corev1.ResourceRequirements
-	SystemReplication        SystemReplication
-	StorageConfig            *cassdcapi.StorageConfig
-	Racks                    []cassdcapi.Rack
-	CassandraConfig          api.CassandraConfig
-	AdditionalSeeds          []string
-	Networking               *cassdcapi.NetworkingConfig
-	Users                    []cassdcapi.CassandraUser
-	PodTemplateSpec          *corev1.PodTemplateSpec
-	MgmtAPIHeap              *resource.Quantity
-	AllowMultipleCassPerNode *bool
+	Meta                  api.EmbeddedObjectMeta
+	Cluster               string
+	SuperuserSecretRef    corev1.LocalObjectReference
+	ServerImage           string
+	ServerVersion         string
+	JmxInitContainerImage *images.Image
+	Size                  int32
+	Resources             *corev1.ResourceRequirements
+	SystemReplication     SystemReplication
+	StorageConfig         *cassdcapi.StorageConfig
+	Racks                 []cassdcapi.Rack
+	CassandraConfig       api.CassandraConfig
+	AdditionalSeeds       []string
+	Networking            *cassdcapi.NetworkingConfig
+	Users                 []cassdcapi.CassandraUser
+	PodTemplateSpec       *corev1.PodTemplateSpec
+	MgmtAPIHeap           *resource.Quantity
+	SoftPodAntiAffinity   *bool
 }
 
 const (
@@ -165,8 +165,8 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 		setMgmtAPIHeap(dc, template.MgmtAPIHeap)
 	}
 
-	if template.AllowMultipleCassPerNode != nil {
-		dc.Spec.AllowMultipleNodesPerWorker = *template.AllowMultipleCassPerNode
+	if template.SoftPodAntiAffinity != nil {
+		dc.Spec.AllowMultipleNodesPerWorker = *template.SoftPodAntiAffinity
 	}
 
 	return dc, nil
@@ -310,10 +310,10 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 		dcConfig.MgmtAPIHeap = dcTemplate.MgmtAPIHeap
 	}
 
-	if dcTemplate.AllowMultipleCassPerNode == nil {
-		dcConfig.AllowMultipleCassPerNode = clusterTemplate.AllowMultipleCassPerNode
+	if dcTemplate.SoftPodAntiAffinity == nil {
+		dcConfig.SoftPodAntiAffinity = clusterTemplate.SoftPodAntiAffinity
 	} else {
-		dcConfig.AllowMultipleCassPerNode = dcTemplate.AllowMultipleCassPerNode
+		dcConfig.SoftPodAntiAffinity = dcTemplate.SoftPodAntiAffinity
 	}
 
 	return dcConfig

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -346,7 +346,7 @@ func TestNewDatacenter_MgmtAPIHeapSize_Unset(t *testing.T) {
 
 func TestNewDatacenter_AllowMultipleCassPerNodeSet(t *testing.T) {
 	template := GetDatacenterConfig()
-	template.AllowMultipleCassPerNode = pointer.Bool(true)
+	template.SoftPodAntiAffinity = pointer.Bool(true)
 	dc, err := NewDatacenter(
 		types.NamespacedName{Name: "testdc", Namespace: "test-namespace"},
 		&template,

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -344,6 +344,17 @@ func TestNewDatacenter_MgmtAPIHeapSize_Unset(t *testing.T) {
 	assert.Equal(t, (*corev1.PodTemplateSpec)(nil), dc.Spec.PodTemplateSpec)
 }
 
+func TestNewDatacenter_AllowMultipleCassPerNodeSet(t *testing.T) {
+	template := GetDatacenterConfig()
+	template.AllowMultipleCassPerNode = pointer.Bool(true)
+	dc, err := NewDatacenter(
+		types.NamespacedName{Name: "testdc", Namespace: "test-namespace"},
+		&template,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, true, dc.Spec.AllowMultipleNodesPerWorker)
+}
+
 // TestNewDatacenter_Fail_NoStorageConfig tests that NewDatacenter fails when no storage config is provided.
 func TestNewDatacenter_Fail_NoStorageConfig(t *testing.T) {
 	template := GetDatacenterConfig()


### PR DESCRIPTION
**What this PR does**:

Expose AllowMultipleNodesPerWorker property from the CassandraDatacenter CRD.

**Which issue(s) this PR fixes**:
Fixes #342

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
