### PR TITLE
Single ns component [K8SSAND-1208]

### DIFF
--- a/config/components/single-namespace/kustomization.yaml
+++ b/config/components/single-namespace/kustomization.yaml
@@ -1,0 +1,26 @@
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+replacements:
+  - source: 
+      kind: Namespace
+      name: k8ssandra-operator
+      fieldPath: metadata.name
+    targets:
+    - select:
+        namespace: cass-operator
+      fieldPaths:
+      - metadata.namespace
+    - select:
+        name: cass-operator-manager-rolebinding
+        kind: ClusterRoleBinding
+      fieldPaths:
+      - subjects.0.namespace
+    - select:
+        name: cass-operator-validating-webhook-configuration
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+      - webhooks.0.clientConfig.service.namespace
+  
+    

--- a/config/deployments/control-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/control-plane/cass-operator-dev/kustomization.yaml
@@ -4,13 +4,4 @@ kind: Kustomization
 resources:
   - ../../default
   - ../../cass-operator/ns-scoped
-replacements:
-  - source: 
-      kind: Namespace
-      name: k8ssandra-operator
-      fieldPath: metadata.name
-    targets:
-    - select:
-        namespace: cass-operator
-      fieldPaths:
-      - metadata.namespace
+  - ../../../components/single-namespace

--- a/config/deployments/control-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/control-plane/cluster-scope/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ../../../cass-operator/cluster-scoped
 components:
   - ../../../components/cluster-scope
+  - ../../../components/single-namespace

--- a/config/deployments/control-plane/kustomization.yaml
+++ b/config/deployments/control-plane/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - ../default
   - ../../cass-operator/ns-scoped
 components:
-  - ../../../components/single-namespace
+  - ../../components/single-namespace

--- a/config/deployments/control-plane/kustomization.yaml
+++ b/config/deployments/control-plane/kustomization.yaml
@@ -4,13 +4,5 @@ kind: Kustomization
 resources:
   - ../default
   - ../../cass-operator/ns-scoped
-replacements:
-  - source: 
-      kind: Namespace
-      name: k8ssandra-operator
-      fieldPath: metadata.name
-    targets:
-    - select:
-        namespace: cass-operator
-      fieldPaths:
-      - metadata.namespace
+components:
+  - ../../../components/single-namespace

--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -6,13 +6,4 @@ resources:
   - ../../../cass-operator/ns-scoped
 components:
   - ../../../components/data-plane
-replacements:
-  - source: 
-      kind: Namespace
-      name: k8ssandra-operator
-      fieldPath: metadata.name
-    targets:
-    - select:
-        namespace: cass-operator
-      fieldPaths:
-      - metadata.namespace
+  - ../../../components/single-namespace

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 components:
   - ../../../components/cluster-scope
   - ../../../components/data-plane
+  - ../../../components/single-namespace

--- a/config/deployments/data-plane/kustomization.yaml
+++ b/config/deployments/data-plane/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 
 components:
   - ../../components/data-plane
-  - ../../../components/single-namespace
+  - ../../components/single-namespace

--- a/config/deployments/data-plane/kustomization.yaml
+++ b/config/deployments/data-plane/kustomization.yaml
@@ -6,13 +6,4 @@ resources:
 
 components:
   - ../../components/data-plane
-replacements:
-  - source: 
-      kind: Namespace
-      name: k8ssandra-operator
-      fieldPath: metadata.name
-    targets:
-    - select:
-        namespace: cass-operator
-      fieldPaths:
-      - metadata.namespace
+  - ../../../components/single-namespace

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -342,7 +342,7 @@ func beforeTest(t *testing.T, f *framework.E2eFramework, fixtureDir string, opts
 		return err
 	}
 
-	if err := f.WaitForCassOperatorToBeReady(opts.sutNamespace, polling.operatorDeploymentReady.timeout, polling.operatorDeploymentReady.interval); err != nil {
+	if err := f.WaitForCassOperatorToBeReady(opts.operatorNamespace, polling.operatorDeploymentReady.timeout, polling.operatorDeploymentReady.interval); err != nil {
 		t.Log("failed waiting for cass-operator to be ready")
 		return err
 	}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -283,11 +283,9 @@ func getTestFixtureDir(fixture TestFixture) (string, error) {
 // required by both operators.
 func beforeTest(t *testing.T, f *framework.E2eFramework, fixtureDir string, opts *e2eTestOpts) error {
 	namespaces := make([]string, 0)
-	cassOperatorNS := opts.sutNamespace
 
 	if opts.clusterScoped {
 		namespaces = append(namespaces, opts.sutNamespace)
-		cassOperatorNS = "cass-operator"
 	}
 
 	namespaces = append(namespaces, opts.operatorNamespace)
@@ -344,7 +342,7 @@ func beforeTest(t *testing.T, f *framework.E2eFramework, fixtureDir string, opts
 		return err
 	}
 
-	if err := f.WaitForCassOperatorToBeReady(cassOperatorNS, polling.operatorDeploymentReady.timeout, polling.operatorDeploymentReady.interval); err != nil {
+	if err := f.WaitForCassOperatorToBeReady(opts.sutNamespace, polling.operatorDeploymentReady.timeout, polling.operatorDeploymentReady.interval); err != nil {
 		t.Log("failed waiting for cass-operator to be ready")
 		return err
 	}

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -229,24 +229,6 @@ patches:
     - op: replace
       path: /metadata/name
       value: {{ .Namespace }}
-replacements:
-- source: 
-    kind: Namespace
-    name: {{ .Namespace }}
-    fieldPath: metadata.name
-  targets:
-  - select:
-      namespace: cass-operator
-    fieldPaths:
-    - metadata.namespace
-  - select:
-      namespace: k8ssandra-operator
-    fieldPaths:
-    - metadata.namespace
-  - select:
-      kind: ClusterRoleBinding
-    fieldPaths:
-    - subjects.0.namespace
 `
 
 		dataPlaneTmpl = `
@@ -269,24 +251,6 @@ patches:
     - op: replace
       path: /metadata/name
       value: {{ .Namespace }}
-replacements:
-- source: 
-    kind: Namespace
-    name: {{ .Namespace }}
-    fieldPath: metadata.name
-  targets:
-  - select:
-      namespace: cass-operator
-    fieldPaths:
-    - metadata.namespace
-  - select:
-      namespace: k8ssandra-operator
-    fieldPaths:
-    - metadata.namespace
-  - select:
-      kind: ClusterRoleBinding
-    fieldPaths:
-    - subjects.0.namespace
 `
 	}
 

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -229,6 +229,24 @@ patches:
     - op: replace
       path: /metadata/name
       value: {{ .Namespace }}
+replacements:
+- source: 
+    kind: Namespace
+    name: {{ .Namespace }}
+    fieldPath: metadata.name
+  targets:
+  - select:
+      namespace: cass-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      namespace: k8ssandra-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+    fieldPaths:
+      - subjects.0.namespace
 `
 
 		dataPlaneTmpl = `
@@ -251,6 +269,60 @@ patches:
     - op: replace
       path: /metadata/name
       value: {{ .Namespace }}
+replacements:
+- source: 
+    kind: Namespace
+    name: {{ .Namespace }}
+    fieldPath: metadata.name
+  targets:
+  - select:
+      namespace: cass-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      namespace: k8ssandra-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+    fieldPaths:
+      - subjects.0.namespace
+replacements:
+- source: 
+    kind: Namespace
+    name: {{ .Namespace }}
+    fieldPath: metadata.name
+  targets:
+  - select:
+      namespace: cass-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      namespace: k8ssandra-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+    fieldPaths:
+      - subjects.0.namespace
+replacements:
+- source: 
+    kind: Namespace
+    name: {{ .Namespace }}
+    fieldPath: metadata.name
+  targets:
+  - select:
+      namespace: cass-operator
+    fieldPaths:
+      - metadata.namespace
+  - select:
+      namespace: k8ssandra-operator
+    fieldPaths:
+    - metadata.namespace
+  - select:
+      kind: ClusterRoleBinding
+    fieldPaths:
+    - subjects.0.namespace
 `
 	}
 


### PR DESCRIPTION
**What this PR does**:

Creates a new component that installs all k8ssandra dependancies (except cert-manager) into a single namespace.

**Which issue(s) this PR fixes**:
Fixes #345

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
