### PR TITLE
Async-safe `client.Get()` for all tests

### DIFF
--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -4,7 +4,7 @@ package k8ssandra
 
 import (
 	"context"
-
+	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"testing"
 
 	testlogr "github.com/go-logr/logr/testing"
@@ -12,7 +12,6 @@ import (
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/telemetry"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -227,7 +227,7 @@ func testCreateReaper(t *testing.T, ctx context.Context, k8sClient client.Client
 	}, timeout, interval, "reaper status should have been updated")
 }
 
-// The purpose of this testutils is to cover code paths where an object, e.g., the
+// The purpose of this test is to cover code paths where an object, e.g., the
 // deployment already exists. This could happen after a failed reconciliation and
 // the request gets requeued.
 func testCreateReaperWithExistingObjects(t *testing.T, ctx context.Context, k8sClient client.Client, testNamespace string) {

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -227,7 +227,7 @@ func testCreateReaper(t *testing.T, ctx context.Context, k8sClient client.Client
 	}, timeout, interval, "reaper status should have been updated")
 }
 
-// The purpose of this test is to cover code paths where an object, e.g., the
+// The purpose of this testutils is to cover code paths where an object, e.g., the
 // deployment already exists. This could happen after a failed reconciliation and
 // the request gets requeued.
 func testCreateReaperWithExistingObjects(t *testing.T, ctx context.Context, k8sClient client.Client, testNamespace string) {

--- a/controllers/stargate/stargate_telemetry_reconciler_test.go
+++ b/controllers/stargate/stargate_telemetry_reconciler_test.go
@@ -5,20 +5,20 @@ package stargate
 import (
 	"context"
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"testing"
 
 	testlogr "github.com/go-logr/logr/testing"
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/telemetry"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// new_DummyK8ssandraClusterReconciler gives us back a `K8ssandraClusterReconciler` with just the fields that we need to test `reconcileCassandraDCTelemetry()`.
+// new_DummyK8ssandraClusterReconciler gives us back a `K8ssandraClusterReconciler` with just the fields that we need to testutils `reconcileCassandraDCTelemetry()`.
 func newDummyK8ssandraClusterReconciler() StargateReconciler {
 	return StargateReconciler{ReconcilerConfig: &config.ReconcilerConfig{DefaultDelay: interval}}
 }

--- a/pkg/telemetry/prometheus_resourcer_test.go
+++ b/pkg/telemetry/prometheus_resourcer_test.go
@@ -5,10 +5,10 @@ package telemetry
 import (
 	"context"
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"testing"
 
 	testlogr "github.com/go-logr/logr/testing"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -206,7 +206,7 @@ func (e *MultiClusterTestEnv) Start(ctx context.Context, t *testing.T, initRecon
 			return err
 		}
 
-		e.Clients[clusterName] = testutils.NewTestk8sClient(t, configuredClient, DefaultTimeout, DefaultTick)
+		e.Clients[clusterName] = testutils.NewTestk8sClient(t, configuredClient, testutils.DefaultTimeout, testutils.DefaultTick)
 		cfgs[i] = cfg
 
 		c, err := cluster.New(cfg, func(o *cluster.Options) {
@@ -288,7 +288,7 @@ func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test Controlle
 		for k, v := range e.Clients {
 			remoteClients[k] = testutils.NewTestk8sClient(t, v, testutils.DefaultTimeout, testutils.DefaultTick)
 		}
-		f := framework.NewFramework(testutils.NewTestk8sClient(t, remoteClients[primaryCluster], timeout, tick), primaryCluster, remoteClients)
+		f := framework.NewFramework(testutils.NewTestk8sClient(t, remoteClients[primaryCluster], testutils.DefaultTimeout, testutils.DefaultTick), primaryCluster, remoteClients)
 
 		if err := f.CreateNamespace(namespace); err != nil {
 			t.Fatalf("failed to create namespace %s: %v", namespace, err)

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -284,7 +284,7 @@ func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test Controlle
 	namespace := framework.CleanupForKubernetes(rand.String(9))
 	return func(t *testing.T) {
 		primaryCluster := fmt.Sprintf(clusterProtoName, 0)
-		var remoteClients map[string]testutils.TestK8sClient
+		remoteClients := make(map[string]testutils.TestK8sClient)
 		for k, v := range e.Clients {
 			remoteClients[k] = testutils.NewTestk8sClient(t, v, testutils.DefaultTimeout, testutils.DefaultTick)
 		}

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -100,7 +100,7 @@ func (e *TestEnv) Start(ctx context.Context, t *testing.T, initReconcilers func(
 	}
 
 	configuredClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	e.TestClient = testutils.NewTestk8sClient(t, configuredClient, DefaultTimeout, DefaultTick)
+	e.TestClient = testutils.NewTestk8sClient(t, configuredClient, testutils.DefaultTimeout, testutils.DefaultTick)
 
 	clientCache := clientcache.New(e.TestClient, e.TestClient, scheme.Scheme)
 	err = (&api.K8ssandraCluster{}).SetupWebhookWithManager(k8sManager, clientCache)

--- a/pkg/testutils/constants.go
+++ b/pkg/testutils/constants.go
@@ -4,5 +4,5 @@ import "time"
 
 const (
 	DefaultTick    = time.Second
-	DefaultTimeout = time.Second*500
+	DefaultTimeout = time.Second * 500
 )

--- a/pkg/testutils/constants.go
+++ b/pkg/testutils/constants.go
@@ -1,0 +1,8 @@
+package testutils
+
+import "time"
+
+const (
+	DefaultTick    = time.Second
+	DefaultTimeout = time.Second*500
+)

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -20,7 +20,7 @@ type TestK8sClient struct {
 	TestState     *testing.T
 	UnsafeGetSync func(ctx context.Context, key client.ObjectKey, obj client.Object) error
 	timeout       time.Duration
-	tick         time.Duration
+	tick          time.Duration
 }
 
 func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -1,0 +1,53 @@
+package testutils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
+	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
+	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestK8sClient struct {
+	client.Client
+	TestState     *testing.T
+	UnsafeGetSync func(ctx context.Context, key client.ObjectKey, obj client.Object) error
+	timeout       time.Duration
+	tick         time.Duration
+}
+
+func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	var err error
+	assert.Eventually(my.TestState, func() bool {
+		if err := my.UnsafeGetSync(ctx, key, obj); err != nil {
+			return false
+		}
+		return true
+	}, my.timeout, my.tick)
+	return err
+}
+
+// NewTestk8sClient takes a configured client and returns a client which overrides certain methods to ensure their safety in testing.
+func NewTestk8sClient(t *testing.T, configuredClient client.Client, timeout time.Duration, tick time.Duration) TestK8sClient {
+	testScheme := configuredClient.Scheme()
+	utilruntime.Must(promapi.AddToScheme(testScheme))
+	utilruntime.Must(cassdcapi.AddToScheme(testScheme))
+	utilruntime.Must(k8ssandraapi.AddToScheme(testScheme))
+	utilruntime.Must(reaperapi.AddToScheme(testScheme))
+	utilruntime.Must(stargateapi.AddToScheme(testScheme))
+	testClient := TestK8sClient{
+		Client:        configuredClient,
+		TestState:     t,
+		UnsafeGetSync: configuredClient.Get,
+		timeout:       timeout,
+		tick:          tick,
+	}
+	return testClient
+}

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,49 +18,33 @@ import (
 
 type TestK8sClient struct {
 	client.Client
-	TestState     *testing.T
-	UnsafeGetSync func(ctx context.Context, key client.ObjectKey, obj client.Object) error
+	TestState      *testing.T
+	UnsafeGetSync  func(ctx context.Context, key client.ObjectKey, obj client.Object) error
 	UnsafeListSync func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
-	timeout       time.Duration
-	tick          time.Duration
+	timeout        time.Duration
+	tick           time.Duration
 }
 
-// SleepWithContext thanks to [this](https://stackoverflow.com/a/69291047) SO answer.
-func SleepWithContext(ctx context.Context, d time.Duration) {
-	timer := time.NewTimer(d)
-	select {
-	case <-ctx.Done():
-		if !timer.Stop() {
-			<-timer.C
-		}
-	case <-timer.C:
-	}
-}
-
-// Get IS AN ASYNC SAFE client.Get(), it is not the normal `Get)`! Use UnsafeListSync() if you want regular Get()'s behaviour.
+// Get IS AN ASYNC SAFE client.Get(), it is not the normal `Get()`! Use UnsafeListSync() if you want regular Get()'s behaviour.
 func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 	var err error
-	ticker := time.NewTicker(my.tick)
-	sleepCtx, sleepCancel := context.WithCancel(context.Background())
-	done := make(chan bool)
-	defer sleepCancel()
-	go func(){
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() error {
+		defer wg.Done()
 		for {
 			select {
-			case <-done:
-				return
-			case <-ticker.C:
+			case <-time.After(my.tick): // Poll
 				err = my.UnsafeGetSync(ctx, key, obj)
 				if err == nil {
-					sleepCancel()
-					return
+					return nil
+				}
+			case <-time.After(my.timeout): // Timeout
+				return err
 			}
 		}
-		}
 	}()
-	SleepWithContext(sleepCtx, my.timeout)
-	ticker.Stop()
-	done <- true
+	wg.Wait()
 	return err
 }
 
@@ -84,12 +69,12 @@ func NewTestk8sClient(t *testing.T, configuredClient client.Client, timeout time
 	utilruntime.Must(reaperapi.AddToScheme(testScheme))
 	utilruntime.Must(stargateapi.AddToScheme(testScheme))
 	testClient := TestK8sClient{
-		Client:        configuredClient,
-		TestState:     t,
-		UnsafeGetSync: configuredClient.Get,
+		Client:         configuredClient,
+		TestState:      t,
+		UnsafeGetSync:  configuredClient.Get,
 		UnsafeListSync: configuredClient.List,
-		timeout:       timeout,
-		tick:          tick,
+		timeout:        timeout,
+		tick:           tick,
 	}
 	return testClient
 }

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -19,6 +19,7 @@ type TestK8sClient struct {
 	client.Client
 	TestState     *testing.T
 	UnsafeGetSync func(ctx context.Context, key client.ObjectKey, obj client.Object) error
+	UnsafeListSync func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
 	timeout       time.Duration
 	tick          time.Duration
 }
@@ -27,6 +28,17 @@ func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 	var err error
 	assert.Eventually(my.TestState, func() bool {
 		if err := my.UnsafeGetSync(ctx, key, obj); err != nil {
+			return false
+		}
+		return true
+	}, my.timeout, my.tick)
+	return err
+}
+
+func (my TestK8sClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	var err error
+	assert.Eventually(my.TestState, func() bool {
+		if err := my.UnsafeListSync(ctx, list, opts...); err != nil {
 			return false
 		}
 		return true
@@ -46,6 +58,7 @@ func NewTestk8sClient(t *testing.T, configuredClient client.Client, timeout time
 		Client:        configuredClient,
 		TestState:     t,
 		UnsafeGetSync: configuredClient.Get,
+		UnsafeListSync: configuredClient.List,
 		timeout:       timeout,
 		tick:          tick,
 	}

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -24,6 +24,7 @@ type TestK8sClient struct {
 	tick          time.Duration
 }
 
+// Get IS AN ASYNC SAFE client.Get(), it is not the normal `Get)`! Use UnsafeListSync() if you want regular Get()'s behaviour.
 func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 	var err error
 	assert.Eventually(my.TestState, func() bool {
@@ -35,6 +36,7 @@ func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 	return err
 }
 
+// List IS AN ASYNC SAFE client.List(), it is not the normal `List()`! Use UnsafeListSync() if you want regular List()'s behaviour.
 func (my TestK8sClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	var err error
 	assert.Eventually(my.TestState, func() bool {

--- a/pkg/testutils/testk8sclient.go
+++ b/pkg/testutils/testk8sclient.go
@@ -11,7 +11,6 @@ import (
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,12 +52,24 @@ func (my TestK8sClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 // List IS AN ASYNC SAFE client.List(), it is not the normal `List()`! Use UnsafeListSync() if you want regular List()'s behaviour.
 func (my TestK8sClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	var err error
-	assert.Eventually(my.TestState, func() bool {
-		if err := my.UnsafeListSync(ctx, list, opts...); err != nil {
-			return false
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-time.After(my.tick): // Poll
+				err = my.UnsafeListSync(ctx, list, opts...)
+				if err == nil {
+					return
+				}
+			case <-time.After(my.timeout): // Timeout
+				err = errors.NewTimeoutError("timed out trying to get resource", 0)
+				return
+			}
 		}
-		return true
-	}, my.timeout, my.tick)
+	}()
+	wg.Wait()
 	return err
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -543,12 +543,12 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("check Stargate deleted")
 	require.Eventually(func() bool {
 		stargate := &stargateapi.Stargate{}
-		err := f.Client.Get(ctx, stargateKey.NamespacedName, stargate)
+		err := f.Client.UnsafeGetSync(ctx, stargateKey.NamespacedName, stargate)
 		if err == nil || !errors.IsNotFound(err) {
 			return false
 		}
 		k8ssandra := &api.K8ssandraCluster{}
-		if err := f.Client.Get(ctx, kcKey, k8ssandra); err != nil {
+		if err := f.Client.UnsafeGetSync(ctx, kcKey, k8ssandra); err != nil {
 			return false
 		} else if kdcStatus, found := k8ssandra.Status.Datacenters[dcKey.Name]; !found {
 			return false
@@ -596,7 +596,7 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	t.Log("check k8ssandra cluster status updated for CassandraDatacenter")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, kcKey, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, kcKey, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -645,7 +645,7 @@ func createSingleDatacenterClusterReaperEncryption(t *testing.T, ctx context.Con
 	t.Log("check k8ssandra cluster status updated for CassandraDatacenter")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, kcKey, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, kcKey, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -707,7 +707,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -725,7 +725,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1018,7 +1018,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1036,7 +1036,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1062,7 +1062,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	t.Log("check k8ssandra cluster status updated for Stargate test-dc1-stargate")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1091,7 +1091,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	t.Log("check k8ssandra cluster status updated for Stargate test-dc2-stargate")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1160,7 +1160,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1178,7 +1178,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1204,7 +1204,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	t.Log("check k8ssandra cluster status updated for Stargate test-dc1-stargate")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1233,7 +1233,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	t.Log("check k8ssandra cluster status updated for Stargate test-dc2-stargate")
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
+		err := f.Client.UnsafeGetSync(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
 		if err != nil {
 			return false
 		}
@@ -1332,7 +1332,7 @@ func checkStargateK8cStatusReady(
 	t.Log("check k8ssandra cluster status updated for Stargate")
 	assert.Eventually(t, func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
-		if err := f.Client.Get(ctx, kcKey, k8ssandra); err != nil {
+		if err := f.Client.UnsafeGetSync(ctx, kcKey, k8ssandra); err != nil {
 			return false
 		}
 		kdcStatus, found := k8ssandra.Status.Datacenters[dcKey.Name]

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -461,7 +461,7 @@ func (f *Framework) withDatacenter(ctx context.Context, key ClusterKey, conditio
 		}
 
 		dc := &cassdcapi.CassandraDatacenter{}
-		if err := remoteClient.Get(ctx, key.NamespacedName, dc); err == nil {
+		if err := remoteClient.UnsafeGetSync(ctx, key.NamespacedName, dc); err == nil {
 			return condition(dc)
 		} else {
 			if !errors.IsNotFound(err) {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k8ssandra/k8ssandra-operator/pkg/testutils"
+
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -36,7 +38,7 @@ import (
 )
 
 var (
-	Client client.Client
+	Client testutils.TestK8sClient
 )
 
 // TODO Add a Framework type and make functions method on that type
@@ -83,13 +85,13 @@ type Framework struct {
 	// Client is the client for the control plane cluster, i.e., the cluster in which the
 	// K8ssandraCluster controller is deployed. Note that this may also be one of the
 	// remote clusters.
-	Client client.Client
+	Client testutils.TestK8sClient
 
 	// The Kubernetes context in which the K8ssandraCluser controller is running.
 	ControlPlaneContext string
 
 	// RemoteClients is mapping of Kubernetes context names to clients.
-	remoteClients map[string]client.Client
+	remoteClients map[string]testutils.TestK8sClient
 
 	logger logr.Logger
 }
@@ -113,7 +115,8 @@ func NewClusterKey(context, namespace, name string) ClusterKey {
 		},
 	}
 }
-func NewFramework(client client.Client, controlPlanContext string, remoteClients map[string]client.Client) *Framework {
+
+func NewFramework(client testutils.TestK8sClient, controlPlanContext string, remoteClients map[string]testutils.TestK8sClient) *Framework {
 	var log logr.Logger
 	log = logrusr.NewLogger(logrus.New())
 	terratestlogger.Default = terratestlogger.New(&terratestLoggerBridge{logger: log})


### PR DESCRIPTION
**What this PR does**:

Many of the test flakes we currently see relate to fairly simple problems where calls to `Get()` and other methods of `client` expect to operate synchronously. 

In fact, envtests and e2e tests both use "real" k8s clusters and are asynchronous systems. It would be more reasonable to expect async behaviour by default, which this PR does by creating a new k8s test client and overriding its `Get()` method with a `Get()` wrapped in an `Eventually()`. 

Test PR to see whether my idea of replacing all `Get()` calls with a new asyc-safe `Get()` works.

We see similar issues with the HTTP client, so this PR might form a basis for fixing both.

**Which issue(s) this PR fixes**:
Fixes #337 and others

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
