### PR TITLE
configure mocks with testing.T instance to avoid panics [K8SSAND-1197]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -15,10 +15,9 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-## v0.5.0 2022-02-10
-
-* [CHANGE] [#120](https://github.com/k8ssandra/k8ssandra-operator/issues/120) Remove `systemLoggerResources` from K8ssandraCluster spec
-* [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the CassandraDatacenter spec
+* [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the
+  CassandraDatacenter spec
+* [TESTING] [#332](https://github.com/k8ssandra/k8ssandra-operator/issues/332) Configure mocks to avoid panics
 
 ## v0.4.0 2022-02-04
 

--- a/controllers/k8ssandra/add_dc_test.go
+++ b/controllers/k8ssandra/add_dc_test.go
@@ -183,6 +183,9 @@ func addDcSetupForMultiDc(ctx context.Context, t *testing.T, f *framework.Framew
 
 func addDcTest(ctx context.Context, f *framework.Framework, test addDcTestFunc, single bool) func(*testing.T) {
 	return func(t *testing.T) {
+		managementApiFactory.SetT(t)
+		managementApiFactory.UseDefaultAdapter()
+
 		namespace := framework.CleanupForKubernetes(rand.String(9))
 		if err := f.CreateNamespace(namespace); err != nil {
 			t.Fatalf("failed to create namespace %s: %v", namespace, err)
@@ -193,7 +196,7 @@ func addDcTest(ctx context.Context, f *framework.Framework, test addDcTestFunc, 
 		} else {
 			kc = addDcSetupForMultiDc(ctx, t, f, namespace)
 		}
-		managementApiFactory.Reset()
+
 		test(ctx, t, f, kc)
 
 		if err := f.DeleteK8ssandraCluster(ctx, utils.GetKey(kc)); err != nil {

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -65,8 +65,9 @@ func TestK8ssandraCluster(t *testing.T) {
 	ctx := testutils.TestSetup(t)
 	ctx, cancel := context.WithCancel(ctx)
 	testEnv = &testutils.MultiClusterTestEnv{
-		BeforeTest: func() {
-			managementApiFactory.Reset()
+		BeforeTest: func(t *testing.T) {
+			managementApiFactory.SetT(t)
+			managementApiFactory.UseDefaultAdapter()
 		},
 	}
 

--- a/controllers/k8ssandra/stop_dc_test.go
+++ b/controllers/k8ssandra/stop_dc_test.go
@@ -35,7 +35,8 @@ func stopDcTest(f *framework.Framework, ctx context.Context, test stopDcTestFunc
 		if err := f.CreateNamespace(namespace); err != nil {
 			t.Fatalf("failed to create namespace %s: %v", namespace, err)
 		}
-		managementApiFactory.Reset()
+		managementApiFactory.SetT(t)
+		managementApiFactory.UseDefaultAdapter()
 		kc := stopDcTestSetup(t, f, ctx, namespace)
 		test(t, f, ctx, kc)
 		err := f.DeleteK8ssandraCluster(ctx, utils.GetKey(kc))
@@ -143,7 +144,6 @@ func stopDcTestSetup(t *testing.T, f *framework.Framework, ctx context.Context, 
 // EnsureKeyspaceReplication that have the desired replication. Other calls with undesired replications would then
 // panic. This ensures that stopping a DC does not modify the desired replication of keyspaces in the cluster.
 func stopDcManagementApiReset(replication map[string]int) {
-	managementApiFactory.Reset()
 	mockMgmtApi := testutils.NewFakeManagementApiFacade()
 	// Only accept calls to EnsureKeyspaceReplication with the desired replication for system keyspaces:
 	for _, keyspace := range api.SystemKeyspaces {

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -34,6 +34,8 @@ const (
 	interval = time.Millisecond * 250
 )
 
+var currentTest *testing.T
+
 func TestReaper(t *testing.T) {
 	ctx := testutils.TestSetup(t)
 	ctx, cancel := context.WithCancel(ctx)
@@ -65,6 +67,7 @@ func newMockManager() reaper.Manager {
 	m.On("Connect", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	m.On("AddClusterToReaper", mock.Anything, mock.Anything).Return(nil)
 	m.On("VerifyClusterIsConfigured", mock.Anything, mock.Anything).Return(true, nil)
+	m.Test(currentTest)
 	return m
 }
 
@@ -77,7 +80,7 @@ func reaperControllerTest(ctx context.Context, env *testutils.TestEnv, test func
 }
 
 func beforeTest(t *testing.T, ctx context.Context, k8sClient client.Client, testNamespace string) {
-
+	currentTest = t
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
 	err := k8sClient.Create(ctx, ns)
 	require.NoError(t, err)

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -114,7 +114,7 @@ type MultiClusterTestEnv struct {
 
 	clustersToCreate int
 
-	BeforeTest func()
+	BeforeTest func(t *testing.T)
 }
 
 func (e *MultiClusterTestEnv) Start(ctx context.Context, t *testing.T, initReconcilers func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error) error {
@@ -230,7 +230,7 @@ func (e *MultiClusterTestEnv) ControllerTest(ctx context.Context, test Controlle
 		}
 
 		if e.BeforeTest != nil {
-			e.BeforeTest()
+			e.BeforeTest(t)
 		}
 
 		test(t, ctx, f, namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
There is some indirection involved for setting the `testing.T` instance on the mocks because the factory objects for producing the mocks are configure as member variables of the Reconciler.

**Which issue(s) this PR fixes**:
Fixes #332

The scope of this PR has been reduced to handling panics with mocks. I created #376 to address handling panics in subtests.

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
