### PR TITLE
Add ConfigBuilderContainerImage and SystemLoggerContainerImage APIs [K8SSAND-1233] 

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -17,6 +17,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [CHANGE] [#120](https://github.com/k8ssandra/k8ssandra-operator/issues/120) Remove `systemLoggerResources` from K8ssandraCluster spec
 * [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the CassandraDatacenter spec
+* [FEATURE] [#378](https://github.com/k8ssandra/k8ssandra-operator/issues/378) Expose `ConfigBuilderContainerImage` and `SystemLoggerContainerImage` properties to allow control over which images will be used for those containers within the Cassandra pods.
 
 ## v0.4.0 2022-02-04
 

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -200,6 +200,18 @@ type CassandraClusterTemplate struct {
 	// +kubebuilder:validation:Pattern=(3\.11\.\d+)|(4\.0\.\d+)
 	ServerVersion string `json:"serverVersion,omitempty"`
 
+	// The image to use in each Cassandra pod for the container that runs the system logger.
+	// Defaults back to cass-operator's defaults if undefined.
+	// +optional
+	// +kubebuilder:default={repository:"k8ssandra",name:"system-logger",tag:"latest"}
+	SystemLoggerContainerImage *images.Image `json:"systemLoggerContainerImage,omitempty"`
+
+	// The image to use in each Cassandra pod for the init container that runs cass-config-builder.
+	// Defaults back to cass-operator's defaults if undefined.
+	// +optional
+	// +kubebuilder:default={repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
+	ConfigBuilderContainerImage *images.Image `json:"configBuilderContainerImage,omitempty"`
+
 	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote
 	// authentication on Cassandra pods. This is only useful when authentication is enabled in the cluster.
 	// The default is "busybox:1.34.1".
@@ -285,6 +297,16 @@ type CassandraDatacenterTemplate struct {
 	// +kubebuilder:validation:Pattern=(3\.11\.\d+)|(4\.0\.\d+)
 	// +optional
 	ServerVersion string `json:"serverVersion,omitempty"`
+
+	// The image to use in each Cassandra pod for the container that runs the system logger.
+	// Defaults back to cass-operator's defaults if undefined.
+	// +optional
+	SystemLoggerContainerImage *images.Image `json:"systemLoggerContainerImage,omitempty"`
+
+	// The image to use in each Cassandra pod for the init container that runs cass-config-builder.
+	// Defaults back to cass-operator's defaults if undefined.
+	// +optional
+	ConfigBuilderContainerImage *images.Image `json:"configBuilderContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote
 	// authentication on Cassandra pods. This is only useful when authentication is enabled in the cluster.

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -203,13 +203,13 @@ type CassandraClusterTemplate struct {
 	// The image to use in each Cassandra pod for the container that runs the system logger.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
-	// +kubebuilder:default={repository:"k8ssandra",name:"system-logger",tag:"latest"}
+	// +kubebuilder:default={registry:"docker.io",repository:"k8ssandra",name:"system-logger",tag:"latest"}
 	SystemLoggerContainerImage *images.Image `json:"systemLoggerContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the init container that runs cass-config-builder.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
-	// +kubebuilder:default={repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
+	// +kubebuilder:default={registry:"docker.io",repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
 	ConfigBuilderContainerImage *images.Image `json:"configBuilderContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote
@@ -301,13 +301,13 @@ type CassandraDatacenterTemplate struct {
 	// The image to use in each Cassandra pod for the container that runs the system logger.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
-	// +kubebuilder:default={repository:"k8ssandra",name:"system-logger",tag:"latest"}
+	// +kubebuilder:default={registry:"docker.io",repository:"k8ssandra",name:"system-logger",tag:"latest"}
 	SystemLoggerContainerImage *images.Image `json:"systemLoggerContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the init container that runs cass-config-builder.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
-	// +kubebuilder:default={repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
+	// +kubebuilder:default={registry:"docker.io",repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
 	ConfigBuilderContainerImage *images.Image `json:"configBuilderContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -301,11 +301,13 @@ type CassandraDatacenterTemplate struct {
 	// The image to use in each Cassandra pod for the container that runs the system logger.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
+	// +kubebuilder:default={repository:"k8ssandra",name:"system-logger",tag:"latest"}
 	SystemLoggerContainerImage *images.Image `json:"systemLoggerContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the init container that runs cass-config-builder.
 	// Defaults back to cass-operator's defaults if undefined.
 	// +optional
+	// +kubebuilder:default={repository:"datastax",name:"cass-config-builder",tag:"1.0.4-ubi7"}
 	ConfigBuilderContainerImage *images.Image `json:"configBuilderContainerImage,omitempty"`
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote

--- a/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
@@ -106,6 +106,16 @@ func (in *AuditLogOptions) DeepCopy() *AuditLogOptions {
 func (in *CassandraClusterTemplate) DeepCopyInto(out *CassandraClusterTemplate) {
 	*out = *in
 	out.SuperuserSecretRef = in.SuperuserSecretRef
+	if in.SystemLoggerContainerImage != nil {
+		in, out := &in.SystemLoggerContainerImage, &out.SystemLoggerContainerImage
+		*out = new(images.Image)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ConfigBuilderContainerImage != nil {
+		in, out := &in.ConfigBuilderContainerImage, &out.ConfigBuilderContainerImage
+		*out = new(images.Image)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.JmxInitContainerImage != nil {
 		in, out := &in.JmxInitContainerImage, &out.JmxInitContainerImage
 		*out = new(images.Image)
@@ -203,6 +213,16 @@ func (in *CassandraConfig) DeepCopy() *CassandraConfig {
 func (in *CassandraDatacenterTemplate) DeepCopyInto(out *CassandraDatacenterTemplate) {
 	*out = *in
 	in.Meta.DeepCopyInto(&out.Meta)
+	if in.SystemLoggerContainerImage != nil {
+		in, out := &in.SystemLoggerContainerImage, &out.SystemLoggerContainerImage
+		*out = new(images.Image)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ConfigBuilderContainerImage != nil {
+		in, out := &in.ConfigBuilderContainerImage, &out.ConfigBuilderContainerImage
+		*out = new(images.Image)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.JmxInitContainerImage != nil {
 		in, out := &in.JmxInitContainerImage, &out.JmxInitContainerImage
 		*out = new(images.Image)

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -1116,6 +1116,51 @@ spec:
                             x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  configBuilderContainerImage:
+                    default:
+                      name: cass-config-builder
+                      repository: datastax
+                      tag: 1.0.4-ubi7
+                    description: The image to use in each Cassandra pod for the init
+                      container that runs cass-config-builder. Defaults back to cass-operator's
+                      defaults if undefined.
+                    properties:
+                      name:
+                        description: The image name to use.
+                        type: string
+                      pullPolicy:
+                        description: The image pull policy to use. Defaults to "Always"
+                          if the tag is "latest", otherwise to "IfNotPresent".
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      pullSecretRef:
+                        description: 'The secret to use when pulling the image from
+                          private repositories. If specified, this secret will be
+                          passed to individual puller implementations for them to
+                          use. For example, in the case of Docker, only DockerConfig
+                          type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      registry:
+                        default: docker.io
+                        description: The Docker registry to use. Defaults to "docker.io",
+                          the official Docker Hub.
+                        type: string
+                      repository:
+                        description: The Docker repository to use.
+                        type: string
+                      tag:
+                        default: latest
+                        description: The image tag to use. Defaults to "latest".
+                        type: string
+                    type: object
                   datacenters:
                     description: Datacenters a list of the DCs in the cluster.
                     items:
@@ -2152,6 +2197,49 @@ spec:
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
+                          type: object
+                        configBuilderContainerImage:
+                          description: The image to use in each Cassandra pod for
+                            the init container that runs cass-config-builder. Defaults
+                            back to cass-operator's defaults if undefined.
+                          properties:
+                            name:
+                              description: The image name to use.
+                              type: string
+                            pullPolicy:
+                              description: The image pull policy to use. Defaults
+                                to "Always" if the tag is "latest", otherwise to "IfNotPresent".
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              - Never
+                              type: string
+                            pullSecretRef:
+                              description: 'The secret to use when pulling the image
+                                from private repositories. If specified, this secret
+                                will be passed to individual puller implementations
+                                for them to use. For example, in the case of Docker,
+                                only DockerConfig type secrets are honored. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                              type: object
+                            registry:
+                              default: docker.io
+                              description: The Docker registry to use. Defaults to
+                                "docker.io", the official Docker Hub.
+                              type: string
+                            repository:
+                              description: The Docker repository to use.
+                              type: string
+                            tag:
+                              default: latest
+                              description: The image tag to use. Defaults to "latest".
+                              type: string
                           type: object
                         jmxInitContainerImage:
                           default:
@@ -5853,6 +5941,49 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        systemLoggerContainerImage:
+                          description: The image to use in each Cassandra pod for
+                            the container that runs the system logger. Defaults back
+                            to cass-operator's defaults if undefined.
+                          properties:
+                            name:
+                              description: The image name to use.
+                              type: string
+                            pullPolicy:
+                              description: The image pull policy to use. Defaults
+                                to "Always" if the tag is "latest", otherwise to "IfNotPresent".
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              - Never
+                              type: string
+                            pullSecretRef:
+                              description: 'The secret to use when pulling the image
+                                from private repositories. If specified, this secret
+                                will be passed to individual puller implementations
+                                for them to use. For example, in the case of Docker,
+                                only DockerConfig type secrets are honored. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                              type: object
+                            registry:
+                              default: docker.io
+                              description: The Docker registry to use. Defaults to
+                                "docker.io", the official Docker Hub.
+                              type: string
+                            repository:
+                              description: The Docker repository to use.
+                              type: string
+                            tag:
+                              default: latest
+                              description: The image tag to use. Defaults to "latest".
+                              type: string
+                          type: object
                       required:
                       - size
                       type: object
@@ -6397,6 +6528,51 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  systemLoggerContainerImage:
+                    default:
+                      name: system-logger
+                      repository: k8ssandra
+                      tag: latest
+                    description: The image to use in each Cassandra pod for the container
+                      that runs the system logger. Defaults back to cass-operator's
+                      defaults if undefined.
+                    properties:
+                      name:
+                        description: The image name to use.
+                        type: string
+                      pullPolicy:
+                        description: The image pull policy to use. Defaults to "Always"
+                          if the tag is "latest", otherwise to "IfNotPresent".
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      pullSecretRef:
+                        description: 'The secret to use when pulling the image from
+                          private repositories. If specified, this secret will be
+                          passed to individual puller implementations for them to
+                          use. For example, in the case of Docker, only DockerConfig
+                          type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      registry:
+                        default: docker.io
+                        description: The Docker registry to use. Defaults to "docker.io",
+                          the official Docker Hub.
+                        type: string
+                      repository:
+                        description: The Docker repository to use.
+                        type: string
+                      tag:
+                        default: latest
+                        description: The image tag to use. Defaults to "latest".
                         type: string
                     type: object
                 type: object

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -191,7 +191,7 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 	}
 
 	if template.SystemLoggerContainerImage != nil {
-		dc.Spec.ConfigBuilderImage = template.SystemLoggerContainerImage.String()
+		dc.Spec.SystemLoggerImage = template.SystemLoggerContainerImage.String()
 	}
 
 	return dc, nil
@@ -304,7 +304,7 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 		dcConfig.ConfigBuilderContainerImage = clusterTemplate.ConfigBuilderContainerImage
 	}
 
-	if dcTemplate.ConfigBuilderContainerImage != nil {
+	if dcTemplate.SystemLoggerContainerImage != nil {
 		dcConfig.SystemLoggerContainerImage = dcTemplate.SystemLoggerContainerImage
 	} else {
 		dcConfig.SystemLoggerContainerImage = clusterTemplate.SystemLoggerContainerImage

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -89,31 +89,33 @@ func (r *Replication) ReplicationFactor(dc, ks string) int {
 // to be specified at the DC-level. Using a DatacenterConfig allows to keep the api types
 // clean such that cluster-level settings won't leak into the dc-level settings.
 type DatacenterConfig struct {
-	Meta                     api.EmbeddedObjectMeta
-	Cluster                  string
-	SuperuserSecretRef       corev1.LocalObjectReference
-	ServerImage              string
-	ServerVersion            string
-	JmxInitContainerImage    *images.Image
-	Size                     int32
-	Stopped                  bool
-	Resources                *corev1.ResourceRequirements
-	SystemReplication        SystemReplication
-	StorageConfig            *cassdcapi.StorageConfig
-	Racks                    []cassdcapi.Rack
-	CassandraConfig          api.CassandraConfig
-	AdditionalSeeds          []string
-	Networking               *cassdcapi.NetworkingConfig
-	Users                    []cassdcapi.CassandraUser
-	PodTemplateSpec          *corev1.PodTemplateSpec
-	MgmtAPIHeap              *resource.Quantity
-	SoftPodAntiAffinity      *bool
-	ServerEncryptionStores   *encryption.Stores
-	ClientEncryptionStores   *encryption.Stores
-	ClientKeystorePassword   string
-	ClientTruststorePassword string
-	ServerKeystorePassword   string
-	ServerTruststorePassword string
+	Meta                        api.EmbeddedObjectMeta
+	Cluster                     string
+	SuperuserSecretRef          corev1.LocalObjectReference
+	ServerImage                 string
+	ServerVersion               string
+	SystemLoggerContainerImage  *images.Image
+	ConfigBuilderContainerImage *images.Image
+	JmxInitContainerImage       *images.Image
+	Size                        int32
+	Stopped                     bool
+	Resources                   *corev1.ResourceRequirements
+	SystemReplication           SystemReplication
+	StorageConfig               *cassdcapi.StorageConfig
+	Racks                       []cassdcapi.Rack
+	CassandraConfig             api.CassandraConfig
+	AdditionalSeeds             []string
+	Networking                  *cassdcapi.NetworkingConfig
+	Users                       []cassdcapi.CassandraUser
+	PodTemplateSpec             *corev1.PodTemplateSpec
+	MgmtAPIHeap                 *resource.Quantity
+	SoftPodAntiAffinity         *bool
+	ServerEncryptionStores      *encryption.Stores
+	ClientEncryptionStores      *encryption.Stores
+	ClientKeystorePassword      string
+	ClientTruststorePassword    string
+	ServerKeystorePassword      string
+	ServerTruststorePassword    string
 }
 
 const (
@@ -182,6 +184,14 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 
 	if template.SoftPodAntiAffinity != nil {
 		dc.Spec.AllowMultipleNodesPerWorker = *template.SoftPodAntiAffinity
+	}
+
+	if template.ConfigBuilderContainerImage != nil {
+		dc.Spec.ConfigBuilderImage = template.ConfigBuilderContainerImage.String()
+	}
+
+	if template.SystemLoggerContainerImage != nil {
+		dc.Spec.ConfigBuilderImage = template.SystemLoggerContainerImage.String()
 	}
 
 	return dc, nil
@@ -286,6 +296,18 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 		dcConfig.JmxInitContainerImage = dcTemplate.JmxInitContainerImage
 	} else {
 		dcConfig.JmxInitContainerImage = clusterTemplate.JmxInitContainerImage
+	}
+
+	if dcTemplate.ConfigBuilderContainerImage != nil {
+		dcConfig.ConfigBuilderContainerImage = dcTemplate.ConfigBuilderContainerImage
+	} else {
+		dcConfig.ConfigBuilderContainerImage = clusterTemplate.ConfigBuilderContainerImage
+	}
+
+	if dcTemplate.ConfigBuilderContainerImage != nil {
+		dcConfig.SystemLoggerContainerImage = dcTemplate.SystemLoggerContainerImage
+	} else {
+		dcConfig.SystemLoggerContainerImage = clusterTemplate.SystemLoggerContainerImage
 	}
 
 	if len(dcTemplate.Racks) == 0 {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
+
 	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
@@ -517,6 +519,22 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 		}
 		return cassandraDatacenterReady(kdcStatus.Cassandra)
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
+
+	// Confirm default images are being applied as expected.
+	expectedSystemLoggerContainerImage := &images.Image{
+		Registry:   "docker.io",
+		Repository: "k8ssandra",
+		Name:       "system-logger",
+		Tag:        "latest",
+	}
+	expectedConfigBuilderContainerImage := &images.Image{
+		Registry:   "docker.io",
+		Repository: "datastax",
+		Name:       "cass-config-builder",
+		Tag:        "1.0.4-ubi7",
+	}
+	require.Equal(t, k8ssandra.Spec.Cassandra.SystemLoggerContainerImage, expectedSystemLoggerContainerImage)
+	require.Equal(t, k8ssandra.Spec.Cassandra.ConfigBuilderContainerImage, expectedConfigBuilderContainerImage)
 
 	stargateKey := framework.ClusterKey{K8sContext: "kind-k8ssandra-0", NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)


### PR DESCRIPTION
**What this PR does**:

Adds two new fields to the Cassandra portions of the APIs to control which images are used for each container.

**Which issue(s) this PR fixes**:
Fixes #378 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
