### PR TITLE
add AdditionalSeeds property [K8SSAND-1235]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#381](https://github.com/k8ssandra/k8ssandra-operator/issues/381) Add additionalSeeds property to support migrations
 * [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the
   CassandraDatacenter spec
 * [BUGFIX] [#389](https://github.com/k8ssandra/k8ssandra-operator/issues/389) Configure watches for control plane client

--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -16,6 +16,11 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [BUGFIX] [#381](https://github.com/k8ssandra/k8ssandra-operator/issues/381) Add additionalSeeds property to support migrations
+* [TESTING] [#332](https://github.com/k8ssandra/k8ssandra-operator/issues/332) Configure mocks to avoid panics
+
+## v0.5.0 2022-02-10
+
+* [CHANGE] [#120](https://github.com/k8ssandra/k8ssandra-operator/issues/120) Remove `systemLoggerResources` from K8ssandraCluster spec
 * [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the
   CassandraDatacenter spec
 * [BUGFIX] [#389](https://github.com/k8ssandra/k8ssandra-operator/issues/389) Configure watches for control plane client

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -245,6 +245,15 @@ type CassandraClusterTemplate struct {
 	// +optional
 	MgmtAPIHeap *resource.Quantity `json:"mgmtAPIHeap,omitempty"`
 
+	// AdditionalSeeds specifies Cassandra node IPs for an existing datacenter. This is
+	// primarily intended for migrations from an existing Cassandra cluster that is not
+	// managed by k8ssandra-operator. Note that this property should NOT be used to set
+	// seeds for a DC that is or will be managed by k8ssandra-operator. k8ssandra-operator
+	// already manages seeds for DCs that it manages. If you have DNS set up such that you
+	// can resolve hostnames for the remote Cassandra cluster, then you can specify hostnames
+	// here; otherwise, use IP addresses.
+	AdditionalSeeds []string `json:"additionalSeeds,omitempty"`
+
 	// SoftPodAntiAffinity sets whether multiple Cassandra instances can be scheduled on the same node.
 	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise
 	// the number of nodes required.

--- a/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *CassandraClusterTemplate) DeepCopyInto(out *CassandraClusterTemplate) 
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.AdditionalSeeds != nil {
+		in, out := &in.AdditionalSeeds, &out.AdditionalSeeds
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SoftPodAntiAffinity != nil {
 		in, out := &in.SoftPodAntiAffinity, &out.SoftPodAntiAffinity
 		*out = new(bool)

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -55,6 +55,19 @@ spec:
                   cluster where each DC should be deployed, node affinity (via racks),
                   individual C* node settings, JVM settings, and more.
                 properties:
+                  additionalSeeds:
+                    description: AdditionalSeeds specifies Cassandra node IPs for
+                      an existing datacenter. This is primarily intended for migrations
+                      from an existing Cassandra cluster that is not managed by k8ssandra-operator.
+                      Note that this property should NOT be used to set seeds for
+                      a DC that is or will be managed by k8ssandra-operator. k8ssandra-operator
+                      already manages seeds for DCs that it manages. If you have DNS
+                      set up such that you can resolve hostnames for the remote Cassandra
+                      cluster, then you can specify hostnames here; otherwise, use
+                      IP addresses.
+                    items:
+                      type: string
+                    type: array
                   cassandraTelemetry:
                     description: CassandraTelemetry defines the desired state for
                       telemetry resources in this K8ssandraCluster. If telemetry configurations

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -105,7 +105,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 		actualDc := &cassdcapi.CassandraDatacenter{}
 
-		if recResult := r.reconcileSeedsEndpoints(ctx, desiredDc, seeds, remoteClient, logger); recResult.Completed() {
+		if recResult := r.reconcileSeedsEndpoints(ctx, desiredDc, seeds, dcConfig.AdditionalSeeds, remoteClient, logger); recResult.Completed() {
 			return recResult, actualDcs
 		}
 

--- a/controllers/k8ssandra/seeds.go
+++ b/controllers/k8ssandra/seeds.go
@@ -71,23 +71,34 @@ func (r *K8ssandraClusterReconciler) reconcileSeedsEndpoints(
 		// If we already have an Endpoints object but no seeds then it probably means all
 		// Cassandra pods are down or not ready for some reason. In this case we will
 		// delete the Endpoints and let it get recreated once we have seed nodes.
-		if len(seeds) == 0 {
-			logger.Info("Deleting endpoints")
-			if err := remoteClient.Delete(ctx, actualEndpoints); err != nil {
-				logger.Error(err, "Failed to delete endpoints")
+		//if len(seeds) == 0 {
+		//	logger.Info("Deleting endpoints")
+		//	if err := remoteClient.Delete(ctx, actualEndpoints); err != nil {
+		//		logger.Error(err, "Failed to delete endpoints")
+		//		return result.Error(err)
+		//	}
+		//} else {
+		//	if !annotations.CompareHashAnnotations(actualEndpoints, desiredEndpoints) {
+		//		logger.Info("Updating endpoints", "Endpoints", endpointsKey)
+		//		actualEndpoints := actualEndpoints.DeepCopy()
+		//		resourceVersion := actualEndpoints.GetResourceVersion()
+		//		desiredEndpoints.DeepCopyInto(actualEndpoints)
+		//		actualEndpoints.SetResourceVersion(resourceVersion)
+		//		if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
+		//			logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
+		//			return result.Error(err)
+		//		}
+		//	}
+		//}
+		if !annotations.CompareHashAnnotations(actualEndpoints, desiredEndpoints) {
+			logger.Info("Updating endpoints", "Endpoints", endpointsKey)
+			actualEndpoints := actualEndpoints.DeepCopy()
+			resourceVersion := actualEndpoints.GetResourceVersion()
+			desiredEndpoints.DeepCopyInto(actualEndpoints)
+			actualEndpoints.SetResourceVersion(resourceVersion)
+			if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
+				logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
 				return result.Error(err)
-			}
-		} else {
-			if !annotations.CompareHashAnnotations(actualEndpoints, desiredEndpoints) {
-				logger.Info("Updating endpoints", "Endpoints", endpointsKey)
-				actualEndpoints := actualEndpoints.DeepCopy()
-				resourceVersion := actualEndpoints.GetResourceVersion()
-				desiredEndpoints.DeepCopyInto(actualEndpoints)
-				actualEndpoints.SetResourceVersion(resourceVersion)
-				if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
-					logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
-					return result.Error(err)
-				}
 			}
 		}
 	} else {
@@ -99,7 +110,7 @@ func (r *K8ssandraClusterReconciler) reconcileSeedsEndpoints(
 			// first created and no pods have reached the ready state. Secondly, you
 			// cannot create an Endpoints object that has both empty Addresses and
 			// empty NotReadyAddresses.
-			if len(seeds) > 0 {
+			if len(seeds) > 0 || len(additionalSeeds) > 0 {
 				logger.Info("Creating endpoints", "Endpoints", endpointsKey)
 				if err = remoteClient.Create(ctx, desiredEndpoints); err != nil {
 					logger.Error(err, "Failed to create endpoints", "Endpoints", endpointsKey)

--- a/controllers/k8ssandra/seeds.go
+++ b/controllers/k8ssandra/seeds.go
@@ -68,28 +68,6 @@ func (r *K8ssandraClusterReconciler) reconcileSeedsEndpoints(
 	endpointsKey := client.ObjectKey{Namespace: desiredEndpoints.Namespace, Name: desiredEndpoints.Name}
 
 	if err := remoteClient.Get(ctx, endpointsKey, actualEndpoints); err == nil {
-		// If we already have an Endpoints object but no seeds then it probably means all
-		// Cassandra pods are down or not ready for some reason. In this case we will
-		// delete the Endpoints and let it get recreated once we have seed nodes.
-		//if len(seeds) == 0 {
-		//	logger.Info("Deleting endpoints")
-		//	if err := remoteClient.Delete(ctx, actualEndpoints); err != nil {
-		//		logger.Error(err, "Failed to delete endpoints")
-		//		return result.Error(err)
-		//	}
-		//} else {
-		//	if !annotations.CompareHashAnnotations(actualEndpoints, desiredEndpoints) {
-		//		logger.Info("Updating endpoints", "Endpoints", endpointsKey)
-		//		actualEndpoints := actualEndpoints.DeepCopy()
-		//		resourceVersion := actualEndpoints.GetResourceVersion()
-		//		desiredEndpoints.DeepCopyInto(actualEndpoints)
-		//		actualEndpoints.SetResourceVersion(resourceVersion)
-		//		if err = remoteClient.Update(ctx, actualEndpoints); err != nil {
-		//			logger.Error(err, "Failed to update endpoints", "Endpoints", endpointsKey)
-		//			return result.Error(err)
-		//		}
-		//	}
-		//}
 		if !annotations.CompareHashAnnotations(actualEndpoints, desiredEndpoints) {
 			logger.Info("Updating endpoints", "Endpoints", endpointsKey)
 			actualEndpoints := actualEndpoints.DeepCopy()

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -167,7 +167,6 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 			SuperuserSecretName: template.SuperuserSecretRef.Name,
 			Users:               template.Users,
 			Networking:          template.Networking,
-			AdditionalSeeds:     template.AdditionalSeeds,
 			PodTemplateSpec:     template.PodTemplateSpec,
 		},
 	}
@@ -334,6 +333,7 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 	// Client/Server Encryption stores are only defined at the cluster level
 	dcConfig.ServerEncryptionStores = clusterTemplate.ServerEncryptionStores
 	dcConfig.ClientEncryptionStores = clusterTemplate.ClientEncryptionStores
+	dcConfig.AdditionalSeeds = clusterTemplate.AdditionalSeeds
 
 	return dcConfig
 }

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -37,6 +37,7 @@ func TestCoalesce(t *testing.T) {
 			clusterName: "k8ssandra",
 			clusterTemplate: &api.CassandraClusterTemplate{
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
+				AdditionalSeeds:    []string{"172.18.0.8", "172.18.0.14"},
 			},
 			dcTemplate: &api.CassandraDatacenterTemplate{
 				Meta: api.EmbeddedObjectMeta{
@@ -59,6 +60,7 @@ func TestCoalesce(t *testing.T) {
 				},
 				SuperuserSecretRef: corev1.LocalObjectReference{Name: "test-superuser"},
 				Size:               3,
+				AdditionalSeeds:    []string{"172.18.0.8", "172.18.0.14"},
 			},
 		},
 		{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an AdditionalSeeds property that can be used when migrating from an existing cluster not created or managed by k8ssandra-operator.

TODO:
* Update integration tests

**Which issue(s) this PR fixes**:
Fixes #381

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
