### PR TITLE
Pin kube-prometheus version to v0.10.0 rather than tracking `master`.

### DIFF
--- a/test/kuttl/test-servicemonitors/config/prometheus/kustomization.yaml
+++ b/test/kuttl/test-servicemonitors/config/prometheus/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/prometheus-operator/kube-prometheus
+- https://github.com/prometheus-operator/kube-prometheus?ref=v0.10.0


### PR DESCRIPTION
**What this PR does**:

kube-prometheus is set up from its `master` branch in the kuttl tests. This is bad practice and we should pin to v0.10.0 to ensure test stability.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
