### PR TITLE
Remove cass-operator namespace [K8SSAND-1239]

### DIFF
--- a/config/components/single-namespace/kustomization.yaml
+++ b/config/components/single-namespace/kustomization.yaml
@@ -22,5 +22,11 @@ replacements:
         kind: ValidatingWebhookConfiguration
       fieldPaths:
       - webhooks.0.clientConfig.service.namespace
-  
+patchesStrategicMerge:
+- |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: cass-operator
+  $patch: delete
     

--- a/test/kuttl/test-user-defined-ns/01-assert.yaml
+++ b/test/kuttl/test-user-defined-ns/01-assert.yaml
@@ -15,3 +15,19 @@ status:
     status: "True"
     type: Progressing
   readyReplicas: 1
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: k8ssandra-operator/cass-operator-serving-cert
+  name: cass-operator-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: cass-operator-webhook-service
+        namespace: k8ssandra-operator
+        path: /validate-cassandra-datastax-com-v1beta1-cassandradatacenter

--- a/test/kuttl/test-user-defined-ns/01-k8ssandra-operator.yaml
+++ b/test/kuttl/test-user-defined-ns/01-k8ssandra-operator.yaml
@@ -1,3 +1,5 @@
+# We are deploying a cluster scoped version of cass-operator and k8ssandra-operator into the namespace k8ssandra-operator.
+# This sets us up to ensure the cluster-scope component is successful, and immediately demonstrates that the single-namespace component is sucessful.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 

--- a/test/kuttl/test-user-defined-ns/02-k8ssandra-cluster.yaml
+++ b/test/kuttl/test-user-defined-ns/02-k8ssandra-cluster.yaml
@@ -1,3 +1,4 @@
+# While all operators are in k8ssandra-operator ns, the K8ssandraCluster is in test-ns. This demonstrates that cluster scoping is successful.
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 


### PR DESCRIPTION
**What this PR does**:

All components now install into the namespace k8ssandra-operator. But the cass-operator namespace is still created. 

This PR adds a patch to delete it.

**Which issue(s) this PR fixes**:
Fixes #385 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
