### PR TITLE
configure watches for control plane cluster/cache [K8SSAND-1240]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -17,6 +17,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [FEATURE] [#296](https://github.com/k8ssandra/k8ssandra-operator/issues/296) Expose the stopped property from the
   CassandraDatacenter spec
+* [BUGFIX] [#389](https://github.com/k8ssandra/k8ssandra-operator/issues/389) Configure watches for control plane client
 * [TESTING] [#332](https://github.com/k8ssandra/k8ssandra-operator/issues/332) Configure mocks to avoid panics
 
 ## v0.4.0 2022-02-04

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -184,6 +184,13 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 		return requests
 	}
 
+	cb = cb.Watches(&source.Kind{Type: &cassdcapi.CassandraDatacenter{}},
+		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
+	cb = cb.Watches(&source.Kind{Type: &stargateapi.Stargate{}},
+		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
+	cb = cb.Watches(&source.Kind{Type: &reaperapi.Reaper{}},
+		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
+
 	for _, c := range clusters {
 		cb = cb.Watches(source.NewKindWithCache(&cassdcapi.CassandraDatacenter{}, c.GetCache()),
 			handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Configures watches for CassandraDatacenter, Stargate, and Reaper objects in the control plane client, or more precisely, in the control plane client's cache.

**Which issue(s) this PR fixes**:
Fixes #389

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
