### PR TITLE
rename property cassandraTelemetry property [K8SSAND-1252]

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [CHANGE] [#411](https://github.com/k8ssandra/k8ssandra-operator/issues/411) Rename `cassandraTelemetry` to just `telemetry`
 * [FEATURE] [#402](https://github.com/k8ssandra/k8ssandra-operator/issues/402) Expose CassandraDatacenter Tolerations property
 * [BUGFIX] [#381](https://github.com/k8ssandra/k8ssandra-operator/issues/381) Add additionalSeeds property to support migrations
 * [TESTING] [#332](https://github.com/k8ssandra/k8ssandra-operator/issues/332) Configure mocks to avoid panics

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -234,11 +234,11 @@ type CassandraClusterTemplate struct {
 	// +optional
 	Datacenters []CassandraDatacenterTemplate `json:"datacenters,omitempty"`
 
-	// CassandraTelemetry defines the desired state for telemetry resources in this K8ssandraCluster.
+	// Telemetry defines the desired state for telemetry resources in this K8ssandraCluster.
 	// If telemetry configurations are defined, telemetry resources will be deployed to integrate with
 	// a user-provided monitoring solution (at present, only support for Prometheus is available).
 	// +optional
-	CassandraTelemetry *telemetryapi.TelemetrySpec `json:"cassandraTelemetry,omitempty"`
+	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 
 	// MgmtAPIHeap defines the amount of memory devoted to the management
 	// api heap.
@@ -341,7 +341,7 @@ type CassandraDatacenterTemplate struct {
 	// If telemetry configurations are defined, telemetry resources will be deployed to integrate with
 	// a user-provided monitoring solution (at present, only support for Prometheus is available).
 	// +optional
-	CassandraTelemetry *telemetryapi.TelemetrySpec `json:"cassandraTelemetry,omitempty"`
+	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 
 	// SoftPodAntiAffinity sets whether multiple Cassandra instances can be scheduled on the same node.
 	// This should normally be false to ensure cluster resilience but may be set true for test/dev scenarios to minimise

--- a/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
@@ -146,8 +146,8 @@ func (in *CassandraClusterTemplate) DeepCopyInto(out *CassandraClusterTemplate) 
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.CassandraTelemetry != nil {
-		in, out := &in.CassandraTelemetry, &out.CassandraTelemetry
+	if in.Telemetry != nil {
+		in, out := &in.Telemetry, &out.Telemetry
 		*out = new(telemetryv1alpha1.TelemetrySpec)
 		(*in).DeepCopyInto(*out)
 	}
@@ -258,8 +258,8 @@ func (in *CassandraDatacenterTemplate) DeepCopyInto(out *CassandraDatacenterTemp
 		x := (*in).DeepCopy()
 		*out = &x
 	}
-	if in.CassandraTelemetry != nil {
-		in, out := &in.CassandraTelemetry, &out.CassandraTelemetry
+	if in.Telemetry != nil {
+		in, out := &in.Telemetry, &out.Telemetry
 		*out = new(telemetryv1alpha1.TelemetrySpec)
 		(*in).DeepCopyInto(*out)
 	}

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -68,27 +68,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  cassandraTelemetry:
-                    description: CassandraTelemetry defines the desired state for
-                      telemetry resources in this K8ssandraCluster. If telemetry configurations
-                      are defined, telemetry resources will be deployed to integrate
-                      with a user-provided monitoring solution (at present, only support
-                      for Prometheus is available).
-                    properties:
-                      prometheus:
-                        properties:
-                          commonLabels:
-                            additionalProperties:
-                              type: string
-                            description: CommonLabels are applied to all serviceMonitors
-                              created.
-                            type: object
-                          enabled:
-                            description: Enable the creation of Prometheus serviceMonitors
-                              for this resource (Cassandra or Stargate).
-                            type: boolean
-                        type: object
-                    type: object
                   clientEncryptionStores:
                     description: Client encryption stores which are used by Cassandra
                       and Reaper.
@@ -1133,27 +1112,6 @@ spec:
                     description: Datacenters a list of the DCs in the cluster.
                     items:
                       properties:
-                        cassandraTelemetry:
-                          description: Telemetry defines the desired state for telemetry
-                            resources in this datacenter. If telemetry configurations
-                            are defined, telemetry resources will be deployed to integrate
-                            with a user-provided monitoring solution (at present,
-                            only support for Prometheus is available).
-                          properties:
-                            prometheus:
-                              properties:
-                                commonLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: CommonLabels are applied to all serviceMonitors
-                                    created.
-                                  type: object
-                                enabled:
-                                  description: Enable the creation of Prometheus serviceMonitors
-                                    for this resource (Cassandra or Stargate).
-                                  type: boolean
-                              type: object
-                          type: object
                         config:
                           description: CassandraConfig is configuration settings that
                             are applied to cassandra.yaml and jvm-options for 3.11.x
@@ -5866,6 +5824,27 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        telemetry:
+                          description: Telemetry defines the desired state for telemetry
+                            resources in this datacenter. If telemetry configurations
+                            are defined, telemetry resources will be deployed to integrate
+                            with a user-provided monitoring solution (at present,
+                            only support for Prometheus is available).
+                          properties:
+                            prometheus:
+                              properties:
+                                commonLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonLabels are applied to all serviceMonitors
+                                    created.
+                                  type: object
+                                enabled:
+                                  description: Enable the creation of Prometheus serviceMonitors
+                                    for this resource (Cassandra or Stargate).
+                                  type: boolean
+                              type: object
+                          type: object
                         tolerations:
                           description: Tolerations applied to every Cassandra pod.
                           items:
@@ -6454,6 +6433,27 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    type: object
+                  telemetry:
+                    description: Telemetry defines the desired state for telemetry
+                      resources in this K8ssandraCluster. If telemetry configurations
+                      are defined, telemetry resources will be deployed to integrate
+                      with a user-provided monitoring solution (at present, only support
+                      for Prometheus is available).
+                    properties:
+                      prometheus:
+                        properties:
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels are applied to all serviceMonitors
+                              created.
+                            type: object
+                          enabled:
+                            description: Enable the creation of Prometheus serviceMonitors
+                              for this resource (Cassandra or Stargate).
+                            type: boolean
+                        type: object
                     type: object
                   tolerations:
                     description: Tolerations applied to every Cassandra pod.

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -24,7 +24,7 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 	remoteClient client.Client,
 ) result.ReconcileResult {
 	logger.Info("reconciling telemetry")
-	mergedSpec := kc.Spec.Cassandra.CassandraTelemetry.Merge(dcTemplate.CassandraTelemetry)
+	mergedSpec := kc.Spec.Cassandra.Telemetry.Merge(dcTemplate.Telemetry)
 	cfg := telemetry.PrometheusResourcer{
 		MonitoringTargetNS:   actualDc.Namespace,
 		MonitoringTargetName: actualDc.Name,

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -48,7 +48,7 @@ func Test_reconcileCassandraDCTelemetry_TracksNamespaces(t *testing.T) {
 				Namespace: cassDC.Namespace,
 				Name:      cassDC.Name,
 			},
-			CassandraTelemetry: &telemetryapi.TelemetrySpec{
+			Telemetry: &telemetryapi.TelemetrySpec{
 				Prometheus: &telemetryapi.PrometheusTelemetrySpec{
 					Enabled: true,
 				},

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -247,7 +247,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 
 	// Test that prometheus servicemonitor comes up when it is requested in the CassandraDatacenter.
 	kcPatch := client.MergeFrom(kc.DeepCopy())
-	kc.Spec.Cassandra.Datacenters[0].CassandraTelemetry = &telemetryapi.TelemetrySpec{
+	kc.Spec.Cassandra.Datacenters[0].Telemetry = &telemetryapi.TelemetrySpec{
 		Prometheus: &telemetryapi.PrometheusTelemetrySpec{
 			Enabled: true,
 		},
@@ -282,7 +282,7 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 	assert.NotNil(t, sm.Spec.Endpoints)
 	// Ensure that removing the telemetry spec does delete the ServiceMonitor
 	kcPatch = client.MergeFrom(kc.DeepCopy())
-	kc.Spec.Cassandra.Datacenters[0].CassandraTelemetry = nil
+	kc.Spec.Cassandra.Datacenters[0].Telemetry = nil
 	if err := f.Client.Patch(ctx, kc, kcPatch); err != nil {
 		assert.Fail(t, "failed to patch stargate", "error", err)
 	}

--- a/test/kuttl/test-servicemonitors/config/single-node-k8ssandra/kustomization.yaml
+++ b/test/kuttl/test-servicemonitors/config/single-node-k8ssandra/kustomization.yaml
@@ -15,7 +15,7 @@ patches:
             enabled: true
         allowStargateOnDataNodes: true
     - op: add
-      path: /spec/cassandra/cassandraTelemetry
+      path: /spec/cassandra/telemetry
       value:
         prometheus:
             enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Renames the property to just `telemetry`

**Which issue(s) this PR fixes**:
Fixes #411 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
