### PR TITLE
Fix namespace removal

### DIFF
--- a/config/components/single-namespace/kustomization.yaml
+++ b/config/components/single-namespace/kustomization.yaml
@@ -22,11 +22,11 @@ replacements:
         kind: ValidatingWebhookConfiguration
       fieldPaths:
       - webhooks.0.clientConfig.service.namespace
-# patchesStrategicMerge:
-# - |-
-#   apiVersion: v1
-#   kind: Namespace
-#   metadata:
-#     name: cass-operator
-#   $patch: delete
+patchesStrategicMerge:
+- |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: cass-operator
+  $patch: delete
     

--- a/config/components/single-namespace/kustomization.yaml
+++ b/config/components/single-namespace/kustomization.yaml
@@ -22,11 +22,11 @@ replacements:
         kind: ValidatingWebhookConfiguration
       fieldPaths:
       - webhooks.0.clientConfig.service.namespace
-patchesStrategicMerge:
-- |-
-  apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: cass-operator
-  $patch: delete
+# patchesStrategicMerge:
+# - |-
+#   apiVersion: v1
+#   kind: Namespace
+#   metadata:
+#     name: cass-operator
+#   $patch: delete
     

--- a/config/deployments/control-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/control-plane/cass-operator-dev/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../default
-  - ../../cass-operator/ns-scoped
+  - ../../../cass-operator/ns-scoped
+components:
   - ../../../components/single-namespace

--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - ../../../cass-operator/ns-scoped
 components:
   - ../../../components/data-plane
-  - ../../components/single-namespace
+  - ../../../components/single-namespace

--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - ../../../cass-operator/ns-scoped
 components:
   - ../../../components/data-plane
-  - ../../../components/single-namespace

--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ../../../cass-operator/ns-scoped
 components:
   - ../../../components/data-plane
+  - ../../components/single-namespace

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 components:
   - ../../../components/cluster-scope
   - ../../../components/data-plane
-  - ../../components/single-namespace

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 components:
   - ../../../components/cluster-scope
   - ../../../components/data-plane
+  - ../../components/single-namespace

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 components:
   - ../../../components/cluster-scope
   - ../../../components/data-plane
-  - ../../../components/single-namespace

--- a/config/deployments/data-plane/kustomization.yaml
+++ b/config/deployments/data-plane/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 components:
   - ../../components/data-plane
+  - ../../components/single-namespace

--- a/config/deployments/data-plane/kustomization.yaml
+++ b/config/deployments/data-plane/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 
 components:
   - ../../components/data-plane
-  - ../../components/single-namespace


### PR DESCRIPTION
**What this PR does**:

When I merged #387 it looked like all tests were passing but the multi-cluster tests just hadn't run. They all fail!

This is because the data plane kustomizations were wrong -  they applied the same deletion patch that was already applied in the control-plane kustomizations from which data-plane is derived. Because the namespace is already deleted, this causes an error in `kustomize build`.

**Which issue(s) this PR fixes**:

Haven't raised one, this is a hotfix.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
