### PR TITLE
cass-operator webhook fixes

### DIFF
--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
+- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=682baeb8e643dba629c964f80516634f95556619
 
 images:
   - name: k8ssandra/cass-operator

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=682baeb8e643dba629c964f80516634f95556619
 
 images:
   - name: k8ssandra/cass-operator

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -176,7 +176,7 @@ The integration test framework installs CRDs. We have to specify the version to 
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d"
-	cassOperatorVersion       = "9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa"
+	cassOperatorVersion       = "682baeb8e643dba629c964f80516634f95556619"
 	prometheusOperatorVersion = "v0.9.0"
 )
 ```
@@ -187,7 +187,7 @@ There are a couple of places in the Kustomize manifests that need to be updated.
 ```yaml
 resources:
   - ../default
-  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa
+  - github.com/k8ssandra/cass-operator/config/deployments/default?ref=682baeb8e643dba629c964f80516634f95556619
 
 images:
   - name: k8ssandra/cass-operator

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -3,11 +3,12 @@ package test
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -38,7 +39,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d"
-	cassOperatorVersion       = "9d1c58a5dec6d113b22bb7cfdbfde5370df6ddfa"
+	cassOperatorVersion       = "682baeb8e643dba629c964f80516634f95556619"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -208,6 +208,11 @@ replacements:
       kind: ClusterRoleBinding
     fieldPaths:
       - subjects.0.namespace
+  - select:
+      name: cass-operator-validating-webhook-configuration
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+      - webhooks.0.clientConfig.service.namespace
 `
 
 	dataPlaneTmpl := `
@@ -249,42 +254,11 @@ replacements:
       kind: ClusterRoleBinding
     fieldPaths:
       - subjects.0.namespace
-replacements:
-- source: 
-    kind: Namespace
-    name: {{ .Namespace }}
-    fieldPath: metadata.name
-  targets:
   - select:
-      namespace: cass-operator
+      name: cass-operator-validating-webhook-configuration
+      kind: ValidatingWebhookConfiguration
     fieldPaths:
-      - metadata.namespace
-  - select:
-      namespace: k8ssandra-operator
-    fieldPaths:
-      - metadata.namespace
-  - select:
-      kind: ClusterRoleBinding
-    fieldPaths:
-      - subjects.0.namespace
-replacements:
-- source: 
-    kind: Namespace
-    name: {{ .Namespace }}
-    fieldPath: metadata.name
-  targets:
-  - select:
-      namespace: cass-operator
-    fieldPaths:
-      - metadata.namespace
-  - select:
-      namespace: k8ssandra-operator
-    fieldPaths:
-    - metadata.namespace
-  - select:
-      kind: ClusterRoleBinding
-    fieldPaths:
-    - subjects.0.namespace
+      - webhooks.0.clientConfig.service.namespace
 `
 
 	k := Kustomization{Namespace: config.Namespace, ImageTag: config.ImageTag}


### PR DESCRIPTION
**What this PR does**:

Bumps cass-operator version to a new version which has the right failure behaviour in the webhook (see this [PR](https://github.com/k8ssandra/cass-operator/pull/271)).

Fixes issues in the e2e tests which arise from the wrong namespace being specified for the `webhooks.0.clientConfig.service.namespace`.

**Which issue(s) this PR fixes**:

#397 originally talked about some problems with the `ValidatingWebhookConfiguration`, these do not occur in real deployments, but will occur during tests. 

It has since been repurposed to focus on the e2e test kustomizations.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
