### PR TITLE
Update install guide example manifests [K8SSAND-1242]

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -107,7 +107,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     datacenters:
       - metadata:
@@ -264,7 +263,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     storageConfig:
       cassandraDataVolumeClaimSpec:
@@ -479,7 +477,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     datacenters:
       - metadata:
@@ -764,7 +761,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "3.11.11"
     storageConfig:
       cassandraDataVolumeClaimSpec:
@@ -926,7 +922,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     datacenters:
       - metadata:
@@ -1223,7 +1218,6 @@ metadata:
   name: demo
 spec:
   cassandra:
-    cluster: demo
     serverVersion: "4.0.1"
     storageConfig:
       cassandraDataVolumeClaimSpec:


### PR DESCRIPTION
There are likely other things in the guide that are a bit dated given that this was written before a bunch of recent work and this guide is destined to be deprecated entirely once the docs site is up and fully fleshed out - but, since this particular problem was stumbled upon by a few folks in recent days I figured it prudent to go ahead and fix it real quick.

**What this PR does**:
Updates the example manifests used in the install guide to remove the no longer valid `cluster` name from the spec.

**Which issue(s) this PR fixes**:
Fixes #394 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
