### PR TITLE
Reduce nodes per DC to 2 in multi-dc test fixture [K8SSANDRA-1241]

### DIFF
--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../default
-  - ../../../cass-operator/ns-scoped
+  - ../../control-plane
 components:
   - ../../../components/data-plane

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../default
-  - ../../../cass-operator/cluster-scoped
+  - ../../control-plane
 
 components:
   - ../../../components/cluster-scope

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -2,11 +2,12 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace string, f *framework.E2eFramework) {
@@ -70,7 +71,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
 	pod := "test-dc1-rack1-sts-0"
-	count := 6
+	count := 4
 	checkNodeToolStatus(t, f, "kind-k8ssandra-0", dc1Namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	t.Log("check nodes in dc2 see nodes in dc1")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -751,7 +751,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
 	pod := "test-dc1-rack1-sts-0"
-	count := 6
+	count := 4
 	checkNodeToolStatus(t, f, "kind-k8ssandra-0", namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -213,11 +213,6 @@ replacements:
       kind: ValidatingWebhookConfiguration
     fieldPaths:
       - webhooks.0.clientConfig.service.namespace
-  - select:
-      name: k8ssandra-operator-validating-webhook-configuration
-      kind: ValidatingWebhookConfiguration
-    fieldPaths:
-      - webhooks.0.clientConfig.service.namespace
 `
 
 	dataPlaneTmpl := `
@@ -261,11 +256,6 @@ replacements:
       - subjects.0.namespace
   - select:
       name: cass-operator-validating-webhook-configuration
-      kind: ValidatingWebhookConfiguration
-    fieldPaths:
-      - webhooks.0.clientConfig.service.namespace
-  - select:
-      name: k8ssandra-operator-validating-webhook-configuration
       kind: ValidatingWebhookConfiguration
     fieldPaths:
       - webhooks.0.clientConfig.service.namespace

--- a/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
@@ -21,9 +21,6 @@ spec:
       - name: rack2
         nodeAffinityLabels:
           "topology.kubernetes.io/zone": rack2
-      - name: rack3
-        nodeAffinityLabels:
-          "topology.kubernetes.io/zone": rack3
     config:
       cassandraYaml:
         auto_snapshot: false
@@ -52,10 +49,10 @@ spec:
           name: dc1
           namespace: test-1
         k8sContext: kind-k8ssandra-0
-        size: 3
+        size: 2
       - metadata:
           name: dc2
           namespace: test-2
         k8sContext: kind-k8ssandra-1
-        size: 3
+        size: 2
     mgmtAPIHeap: 64Mi

--- a/test/testdata/fixtures/multi-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc/k8ssandra.yaml
@@ -51,8 +51,8 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 3
+        size: 2
       - metadata:
           name: dc2
         k8sContext: kind-k8ssandra-1
-        size: 3
+        size: 2


### PR DESCRIPTION
**What this PR does**:

Reduce nodes in multi-DC fixture to 2 in order to avoid memory pressure issues.

**Which issue(s) this PR fixes**:
Fixes #392 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
