### PR TITLE
Make data plane deployments consistent and fix test `ClusterScoped/MultiDcMultiCluster`

### DIFF
--- a/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
+++ b/config/deployments/data-plane/cass-operator-dev/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../default
-  - ../../../cass-operator/ns-scoped
+  - ../../control-plane
 components:
   - ../../../components/data-plane

--- a/config/deployments/data-plane/cluster-scope/kustomization.yaml
+++ b/config/deployments/data-plane/cluster-scope/kustomization.yaml
@@ -2,9 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../default
-  - ../../../cass-operator/cluster-scoped
+  - ../../control-plane/cluster-scope
 
 components:
-  - ../../../components/cluster-scope
   - ../../../components/data-plane


### PR DESCRIPTION
**What this PR does**:

The three data-plane kustomizations were not consistent when I updated them to remove the single-namespace component. 

The `deployments/data-plane` kustomization draws from  `../control-plane` as a base which already has `../../../components/single-namespace` applied. Trying to apply it again would break things, so I removed it from all data-plane kustomizations.

But it turns out that both `data-plane/cluster-scoped` and `data-plane/cass-operator-dev` take `../../default` as their base, not control-plane. So they never receive the single-namespace component.

This breaks the test `ClusterScoped/MultiDcMultiCluster` because it results in cass-operator being deployed into the cass-operator NS for cluster scoped deployments.

This PR makes `data-plane/cluster-scoped` and `data-plane/cass-operator-dev`  consistent with `deployments/data-plane` so that they pick up the `single-namespace` component and the test passes.

**Which issue(s) this PR fixes**:
Trying to iron out test flakes.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
