### PR TITLE
Fix failures in the single-dc reaper e2e test

### DIFF
--- a/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
@@ -15,7 +15,7 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 1
+        size: 2
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard


### PR DESCRIPTION
Fix failures in the `CreateSingleReaper` e2e test by adding a second replica.
It seems like we have a race condition possibly due to caches which prevent a single node to restart with the seed-node label, resulting in no seed at all being present in the cluster.