### PR TITLE
make sure to use build/kubeconfig and not ~/.kube/config in e2e tests

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -13,6 +13,9 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+* [TESTING] [#420](https://github.com/k8ssandra/k8ssandra-operator/issues/420) Default to `build/kubeconfig` instead of `~/.kube/config` for `kubectl` commands in tests
+
 ## v1.0.0  2022-02-17
 
 * [CHANGE] [#423](https://github.com/k8ssandra/k8ssandra-operator/pull/423) Update to cass-operator v1.10.0

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -510,8 +510,14 @@ func (f *E2eFramework) DeleteNamespace(name string, timeout, interval time.Durat
 func (f *E2eFramework) WaitForCrdsToBecomeActive() error {
 	// TODO Add multi-cluster support.
 	// By default this should wait for all clusters including the control plane cluster.
-
-	return kubectl.WaitForCondition("established", "--timeout=60s", "--all", "crd")
+	for _, k8sContext := range f.getClusterContexts() {
+		opts := kubectl.Options{Context: k8sContext}
+		err := kubectl.WaitForCondition(opts,"established", "--timeout=60s", "--all", "crd")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // WaitForK8ssandraOperatorToBeReady blocks until the k8ssandra-operator deployment is

--- a/test/kubectl/kubectl.go
+++ b/test/kubectl/kubectl.go
@@ -14,6 +14,13 @@ type Options struct {
 	Namespace  string
 	Context    string
 	ServerSide bool
+	KubeConfig string
+}
+
+func applyDefaults(opts *Options) {
+	if opts.KubeConfig == "" {
+		opts.KubeConfig = filepath.Join("..", "..", "build", "kubeconfig")
+	}
 }
 
 var logOutput = false
@@ -23,7 +30,12 @@ func LogOutput(enabled bool) {
 }
 
 func Apply(opts Options, arg interface{}) error {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
 
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
@@ -62,7 +74,12 @@ func Apply(opts Options, arg interface{}) error {
 }
 
 func Delete(opts Options, arg interface{}) error {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
 
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
@@ -95,7 +112,12 @@ func Delete(opts Options, arg interface{}) error {
 }
 
 func DeleteByName(opts Options, kind, name string, ignoreNotFound bool) error {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
@@ -115,7 +137,12 @@ func DeleteByName(opts Options, kind, name string, ignoreNotFound bool) error {
 }
 
 func DeleteAllOf(opts Options, kind string) error {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
@@ -133,11 +160,20 @@ func DeleteAllOf(opts Options, kind string) error {
 	return err
 }
 
-func WaitForCondition(condition string, args ...string) error {
+func WaitForCondition(opts Options, condition string, args ...string) error {
+	applyDefaults(&opts)
 	kargs := []string{"wait", "--for", "condition=" + condition}
 	kargs = append(kargs, args...)
 
 	cmd := exec.Command("kubectl", kargs...)
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
+
+	if len(opts.Context) > 0 {
+		cmd.Args = append(cmd.Args, "--context", opts.Context)
+	}
 
 	output, err := cmd.CombinedOutput()
 
@@ -151,7 +187,13 @@ func WaitForCondition(condition string, args ...string) error {
 // Exec executes a command against a Cassandra pod and the cassandra container in
 // particular. This does not currently handle pipes.
 func Exec(opts Options, pod string, args ...string) (string, error) {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
+
 
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
@@ -192,7 +234,13 @@ type ClusterInfoOptions struct {
 }
 
 func DumpClusterInfo(opts ClusterInfoOptions) error {
+	applyDefaults(&opts.Options)
 	cmd := exec.Command("kubectl", "cluster-info", "dump")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
+
 
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
@@ -225,10 +273,17 @@ func DumpClusterInfo(opts ClusterInfoOptions) error {
 }
 
 func Get(opts Options, args ...string) (string, error) {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl", "get")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
+
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
+
 	if len(opts.Namespace) > 0 {
 		cmd.Args = append(cmd.Args, "-n", opts.Namespace)
 	}
@@ -255,10 +310,17 @@ func Get(opts Options, args ...string) (string, error) {
 }
 
 func RolloutStatus(opts Options, kind, name string) error {
+	applyDefaults(&opts)
 	cmd := exec.Command("kubectl", "rollout", "status")
+
+	if len(opts.KubeConfig) > 0 {
+		cmd.Args = append(cmd.Args, "--kubeconfig", opts.KubeConfig)
+	}
+
 	if len(opts.Context) > 0 {
 		cmd.Args = append(cmd.Args, "--context", opts.Context)
 	}
+
 	if len(opts.Namespace) > 0 {
 		cmd.Args = append(cmd.Args, "-n", opts.Namespace)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the functions in `kubectl.go` to use the `--kubeconfig` option with a default value of `build/kubeconfig`. The latter is generated by the `scripts/setup-kind-multicluster.sh` script. 

This PR does not make the tests configurable such that they easily clusters other than the kind ones generated by `scripts/setup-kind-multicluster.sh`. That's outside the scope of this PR.

**Which issue(s) this PR fixes**:
Fixes #420

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
