### PR TITLE
Adds a test to check that all deployments build successfully.

### DIFF
--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -115,3 +115,4 @@ jobs:
         kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
         make IMG="k8ssandra/k8ssandra-operator:latest" kind-load-image
         ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-config-control-plane
+        ./bin/kubectl-kuttl test --start-kind=false --test test-all-deployments

--- a/test/kuttl/test-all-deployments/00-buildall.yaml
+++ b/test/kuttl/test-all-deployments/00-buildall.yaml
@@ -1,0 +1,16 @@
+# Build all kustomize deployments to ensure all are valid.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands: 
+- command: ../../../bin/kustomize build ../../../config/deployments/control-plane
+  ignoreFailure: false 
+- command: ../../../bin/kustomize build ../../../config/deployments/control-plane/cluster-scope
+  ignoreFailure: false 
+- command: ../../../bin/kustomize build ../../../config/deployments/control-plane/cass-operator-dev 
+  ignoreFailure: false 
+- command: ../../../bin/kustomize build ../../../config/deployments/data-plane
+  ignoreFailure: false 
+- command: ../../../bin/kustomize build ../../../config/deployments/data-plane/cluster-scope
+  ignoreFailure: false 
+- command: ../../../bin/kustomize build ../../../config/deployments/data-plane/cass-operator-dev
+  ignoreFailure: false 


### PR DESCRIPTION
**What this PR does**:

What is says on the tin. Make sure all 6(!) of our kustomize deployments successfully build.

Doesn't need to be in 1.0, getting it into `main` later is fine.

**Which issue(s) this PR fixes**:
No issue raised.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
