### PR TITLE
Make kuttl tests run in parallel

### DIFF
--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -59,6 +59,10 @@ jobs:
     strategy:
       matrix:
         k8s_version: ["1.21"]
+        kuttl-test:
+        - test-servicemonitors
+        - test-config-control-plane
+        - test-user-defined-ns
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -106,12 +110,9 @@ jobs:
         # release process. The following changes have been made to stay as close as possible
         # to the existing behavior with kuttl tests while supporting the ability to use a release
         # image tag of the operator.
-
+        
         make install-kuttl
         kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
         make IMG="k8ssandra/k8ssandra-operator:latest" kind-load-image
-        ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-servicemonitors
+        ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test ${{ matrix.kuttl-test }}
         kind delete cluster --name k8ssandra-0
-        kind create cluster --name k8ssandra-0 --config ./test/kuttl/config/kind/w3k${{ matrix.k8s_version }}.yaml
-        make IMG="k8ssandra/k8ssandra-operator:latest" kind-load-image
-        ./bin/kubectl-kuttl test --kind-context=k8ssandra-0 --start-kind=false --test test-config-control-plane


### PR DESCRIPTION
**What this PR does**:

Kuttl tests currently run in serial and intermingle their outputs. This PR uses the matrix strategy to run them in parallel and provide more granular output from the GHA summary screens.

**Which issue(s) this PR fixes**:
No issue raised.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
