### PR TITLE
Update install guide to use server side apply [K8SSAND-1274]

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -404,7 +404,7 @@ helm search repo k8ssandra-operator
 
 ```console
 NAME                               	CHART VERSION	APP VERSION	DESCRIPTION
-k8ssandra/k8ssandra-operator       	0.32.0       	1.0.0      	Kubernetes operator which handles the provision...
+k8ssandra/k8ssandra-operator       	0.32.0       	1.0.2      	Kubernetes operator which handles the provision...
 ```
 
 ### Single Cluster 
@@ -442,7 +442,7 @@ helm ls -n k8ssandra-operator
 
 ```console
 NAME              	NAMESPACE         	REVISION	UPDATED                             	STATUS  	CHART                    	APP VERSION
-k8ssandra-operator	k8ssandra-operator	1       	2021-09-30 16:28:08.722822 -0400 EDT	deployed	k8ssandra-operator-0.32.0	1.0.0
+k8ssandra-operator	k8ssandra-operator	1       	2021-09-30 16:28:08.722822 -0400 EDT	deployed	k8ssandra-operator-0.32.0	1.0.2
 ```
 
 Verify that the following CRDs are installed:
@@ -626,7 +626,7 @@ helm ls -n k8ssandra-operator
 
 ```console
 NAME              	NAMESPACE         	REVISION	UPDATED                             	STATUS  	CHART                    	APP VERSION
-k8ssandra-operator	k8ssandra-operator	1       	2021-09-30 16:28:08.722822 -0400 EDT	deployed	k8ssandra-operator-0.32.0	1.0.0
+k8ssandra-operator	k8ssandra-operator	1       	2021-09-30 16:28:08.722822 -0400 EDT	deployed	k8ssandra-operator-0.32.0	1.0.2
 ```
 
 Verify that the following CRDs are installed:
@@ -835,7 +835,7 @@ on Docker Hub for a list of available images.
 Install with kubectl:
 
 ```console
-kustomize build github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
+kustomize build github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane\?ref\=v1.0.2 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -855,11 +855,11 @@ cat <<EOF >$K8SSANDRA_OPERATOR_HOME/kustomization.yaml
 namespace: k8ssandra-operator
 
 resources:
-- github.com/k8ssandra/k8ssandra-operator/config/deployments/default?ref=v1.0.0
+- github.com/k8ssandra/k8ssandra-operator/config/deployments/default?ref=v1.0.2
 
 images:
 - name: k8ssandra/k8ssandra-operator
-  newTag: v1.0.0
+  newTag: v1.0.2
 EOF
 ```
 
@@ -1074,7 +1074,7 @@ kubectx kind-k8ssandra-0
 Now install the operator:
 
 ```console
-kustomize build github.com/k8ssandra/config/deployments/control-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
+kustomize build github.com/k8ssandra/config/deployments/control-plane\?ref\=v1.0.2 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -1125,7 +1125,7 @@ kubectx kind-k8ssandra-1
 Now install the operator:
 
 ```console
-kustomize build github.com/k8ssandra/config/deployments/data-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
+kustomize build github.com/k8ssandra/config/deployments/data-plane\?ref\=v1.0.2 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -835,7 +835,7 @@ on Docker Hub for a list of available images.
 Install with kubectl:
 
 ```console
-kubectl apply --server-side -k github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane\?ref\=v1.0.0
+kustomize build github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -866,7 +866,7 @@ EOF
 Now install the operator:
 
 ```console
-kubectl apply --server-side -k $K8SSANDRA_OPERATOR_HOME
+kustomize build $K8SSANDRA_OPERATOR_HOME | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -835,7 +835,7 @@ on Docker Hub for a list of available images.
 Install with kubectl:
 
 ```console
-kubectl apply -k github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane
+kubectl apply --server-side -k github.com/k8ssandra/k8ssandra-operator/config/deployments/control-plane\?ref\=v1.0.0
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -855,21 +855,18 @@ cat <<EOF >$K8SSANDRA_OPERATOR_HOME/kustomization.yaml
 namespace: k8ssandra-operator
 
 resources:
-- github.com/k8ssandra/k8ssandra-operator/config/deployments/default?ref=main
-
-components:
-- github.com/k8ssandra/k8ssandra-operator/config/components/namespace
+- github.com/k8ssandra/k8ssandra-operator/config/deployments/default?ref=v1.0.0
 
 images:
 - name: k8ssandra/k8ssandra-operator
-  newTag: v1.0.0-alpha.1
+  newTag: v1.0.0
 EOF
 ```
 
 Now install the operator:
 
 ```console
-kubectl apply -k $K8SSANDRA_OPERATOR_HOME
+kubectl apply --server-side -k $K8SSANDRA_OPERATOR_HOME
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -907,7 +904,7 @@ k8ssandra-operator   1/1     1            1           2m
 Verify that the `K8SSANDRA_CONTROL_PLANE` environment variable is set to `false`:
 
 ```console
-kubectl -n k8ssandra-operator get deployment k8ssandra-operator-k8ssandra-operator -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="K8SSANDRA_CONTROL_PLANE")].value}'
+kubectl -n k8ssandra-operator get deployment k8ssandra-operator -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="K8SSANDRA_CONTROL_PLANE")].value}'
 ```
 
 #### Deploy a K8ssandraCluster
@@ -1077,7 +1074,7 @@ kubectx kind-k8ssandra-0
 Now install the operator:
 
 ```console
-kubectl apply -k github.com/k8ssandra/config/deployments/control-plane
+kubectl apply -k github.com/k8ssandra/config/deployments/control-plane\?ref\=v1.0.0 --server-side
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -1128,7 +1125,7 @@ kubectx kind-k8ssandra-1
 Now install the operator:
 
 ```console
-kubectl apply -k github.com/k8ssandra/config/deployments/data-plane
+kubectl apply -k github.com/k8ssandra/config/deployments/data-plane\?ref\=v1.0.0 --server-side
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1074,7 +1074,7 @@ kubectx kind-k8ssandra-0
 Now install the operator:
 
 ```console
-kubectl apply -k github.com/k8ssandra/config/deployments/control-plane\?ref\=v1.0.0 --server-side
+kustomize build github.com/k8ssandra/config/deployments/control-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.
@@ -1125,7 +1125,7 @@ kubectx kind-k8ssandra-1
 Now install the operator:
 
 ```console
-kubectl apply -k github.com/k8ssandra/config/deployments/data-plane\?ref\=v1.0.0 --server-side
+kustomize build github.com/k8ssandra/config/deployments/data-plane\?ref\=v1.0.0 | kubectl apply --server-side --force-conflicts -f -
 ```
 
 This installs the operator in the `k8ssandra-operator` namespace.


### PR DESCRIPTION
**What this PR does**:
Updates the install guide to use server side apply as the k8ssandracluster CRD is now too big to fit into the last-applied-configuration annotation.

**Which issue(s) this PR fixes**:
Fixes #430 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
