### PR TITLE
Distinguish control plane from data planes in tests

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -70,7 +70,7 @@ jobs:
       CGO_ENABLED: 0
       KUBECONFIG_FILE: "./build/kind-kubeconfig"
       CONTROL_PLANE: kind-k8ssandra-0
-      DATA_PLANES: ""
+      DATA_PLANES: kind-k8ssandra-0
     steps:
       - name: Free diskspace by removing unused packages
         run: |

--- a/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
@@ -1,5 +1,4 @@
-# This workflow is for tests that require multiple clusters.
-name: Run multi-cluster e2e tests
+name: Run e2e tests with isolated control plane
 on:
   push:
     branches:
@@ -57,26 +56,14 @@ jobs:
     strategy:
       matrix:
         e2e_test:
-          - CreateMultiDatacenterCluster
-          - CreateMixedMultiDataCenterCluster
-          - AddDcToCluster
-          - RemoveDcFromCluster
-          - CheckStargateApisWithMultiDcCluster
-          - CreateMultiStargateAndDatacenter
           - CreateMultiReaper
-          - ClusterScoped/MultiDcMultiCluster
-          - CreateMultiMedusa
-          - MultiDcAuthOnOff
-          - MultiDcEncryptionWithStargate
-          - MultiDcEncryptionWithReaper
-          - StopAndRestartDc
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:
       CGO_ENABLED: 0
       KUBECONFIG_FILE: "./build/kind-kubeconfig"
       CONTROL_PLANE: kind-k8ssandra-0
-      DATA_PLANES: kind-k8ssandra-0,kind-k8ssandra-1
+      DATA_PLANES: kind-k8ssandra-1,kind-k8ssandra-2
     steps:
       - name: Free diskspace by removing unused packages
         run: |
@@ -122,7 +109,7 @@ jobs:
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
       - name: Setup kind clusters
-        run: make IMG="k8ssandra/k8ssandra-operator:latest" create-kind-multicluster kind-load-image-multi
+        run: make IMG="k8ssandra/k8ssandra-operator:latest" NUM_CLUSTERS=3 NUM_WORKER_NODES=1,2,2 create-kind-multicluster kind-load-image-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: |
           e2e_test="TestOperator/${{ matrix.e2e_test }}"

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ DEPLOYMENT =
 # be created with scripts/setup-kind-multicluster.sh.
 NUM_CLUSTERS = 2
 
+# Indicates the number of worker nodes per cluster created with scripts/setup-kind-multicluster.sh.
+# It can either be a single number or a comma-separated list of numbers, one per cluster.
+NUM_WORKER_NODES = 4
+
 ifeq ($(DEPLOYMENT), )
 	DEPLOY_TARGET =
 else
@@ -235,10 +239,10 @@ cleanup:
 	done
 
 create-kind-cluster:
-	scripts/setup-kind-multicluster.sh --clusters 1 --kind-worker-nodes 4 --output-file $(KIND_KUBECONFIG)
+	scripts/setup-kind-multicluster.sh --clusters 1 --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
 
 create-kind-multicluster:
-	scripts/setup-kind-multicluster.sh --clusters $(NUM_CLUSTERS) --kind-worker-nodes 4 --output-file $(KIND_KUBECONFIG)
+	scripts/setup-kind-multicluster.sh --clusters $(NUM_CLUSTERS) --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
 
 kind-load-image-multi:
 	for ((i = 0; i < $(NUM_CLUSTERS); ++i)); do \

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -33,7 +33,7 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 			Cassandra: &api.CassandraClusterTemplate{
 				Datacenters: []api.CassandraDatacenterTemplate{{
 					Meta:          api.EmbeddedObjectMeta{Name: "dc1"},
-					K8sContext:    f.K8sContext(1),
+					K8sContext:    f.DataPlaneContexts[1],
 					Size:          1,
 					ServerVersion: "3.11.10",
 					StorageConfig: &cassdcapi.StorageConfig{
@@ -51,10 +51,10 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 	err := f.Client.Create(ctx, kc)
 	require.NoError(t, err, "failed to create K8ssandraCluster")
 
-	kcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: kc.Name}}
-	dcKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
-	stargateKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
+	kcKey := framework.ClusterKey{K8sContext: f.ControlPlaneContext, NamespacedName: types.NamespacedName{Namespace: namespace, Name: kc.Name}}
+	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
 
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
@@ -131,7 +131,7 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 	}), timeout, interval)
 
 	t.Log("deleting K8ssandraCluster")
-	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name})
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
 	require.NoError(t, err, "failed to delete K8ssandraCluster")
 	f.AssertObjectDoesNotExist(ctx, t, dcKey, &cassdcapi.CassandraDatacenter{}, timeout, interval)
 	f.AssertObjectDoesNotExist(ctx, t, stargateKey, &stargateapi.Stargate{}, timeout, interval)
@@ -151,7 +151,7 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 			Cassandra: &api.CassandraClusterTemplate{
 				Datacenters: []api.CassandraDatacenterTemplate{{
 					Meta:          api.EmbeddedObjectMeta{Name: "dc1"},
-					K8sContext:    f.K8sContext(1),
+					K8sContext:    f.DataPlaneContexts[1],
 					Size:          1,
 					ServerVersion: "3.11.10",
 					StorageConfig: &cassdcapi.StorageConfig{
@@ -169,10 +169,10 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 	err := f.Client.Create(ctx, kc)
 	require.NoError(t, err, "failed to create K8ssandraCluster")
 
-	kcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: kc.Name}}
-	dcKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
-	stargateKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
+	kcKey := framework.ClusterKey{K8sContext: f.ControlPlaneContext, NamespacedName: types.NamespacedName{Namespace: namespace, Name: kc.Name}}
+	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
 
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
@@ -258,7 +258,7 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 	}), timeout, interval)
 
 	t.Log("deleting K8ssandraCluster")
-	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name})
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
 	require.NoError(t, err, "failed to delete K8ssandraCluster")
 	f.AssertObjectDoesNotExist(ctx, t, dcKey, &cassdcapi.CassandraDatacenter{}, timeout, interval)
 	f.AssertObjectDoesNotExist(ctx, t, stargateKey, &stargateapi.Stargate{}, timeout, interval)

--- a/controllers/k8ssandra/medusa_reconciler_test.go
+++ b/controllers/k8ssandra/medusa_reconciler_test.go
@@ -40,7 +40,7 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 						Meta: api.EmbeddedObjectMeta{
 							Name: "dc1",
 						},
-						K8sContext:    f.K8sContext(0),
+						K8sContext:    f.DataPlaneContexts[0],
 						Size:          3,
 						ServerVersion: "3.11.10",
 						StorageConfig: &cassdcapi.StorageConfig{
@@ -53,7 +53,7 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 						Meta: api.EmbeddedObjectMeta{
 							Name: "dc2",
 						},
-						K8sContext:    f.K8sContext(1),
+						K8sContext:    f.DataPlaneContexts[1],
 						Size:          3,
 						ServerVersion: "3.11.10",
 						StorageConfig: &cassdcapi.StorageConfig{
@@ -86,7 +86,7 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
 	t.Log("check that dc1 was created")
-	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.K8sContext(0)}
+	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
 
 	t.Log("update datacenter status to scaling up")
@@ -99,7 +99,7 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	})
 	require.NoError(err, "failed to patch datacenter status")
 
-	kcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
+	kcKey := framework.ClusterKey{K8sContext: f.ControlPlaneContext, NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test"}}
 
 	t.Log("check that the K8ssandraCluster status is updated")
 	require.Eventually(func() bool {
@@ -130,7 +130,7 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	checkMedusaObjectsCompliance(t, f, dc1, kc)
 
 	t.Log("check that dc2 has not been created yet")
-	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: f.K8sContext(1)}
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: f.DataPlaneContexts[1]}
 	dc2 := &cassdcapi.CassandraDatacenter{}
 	err = f.Get(ctx, dc2Key, dc2)
 	require.True(err != nil && errors.IsNotFound(err), "dc2 should not be created until dc1 is ready")

--- a/controllers/k8ssandra/remove_dc_test.go
+++ b/controllers/k8ssandra/remove_dc_test.go
@@ -58,7 +58,7 @@ func deleteDcWithUserKeyspaces(ctx context.Context, t *testing.T, f *framework.F
 	}
 	managementApiFactory.SetAdapter(adapter)
 
-	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: kc.Namespace, Name: "dc2"}, K8sContext: f.K8sContext(1)}
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: kc.Namespace, Name: "dc2"}, K8sContext: f.DataPlaneContexts[1]}
 
 	addDatacenterFinalizer(ctx, t, f, dc2Key)
 
@@ -135,7 +135,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	addStargateAndReaperToCluster(ctx, t, f, kc)
 
 	sg1Key := framework.ClusterKey{
-		K8sContext: f.K8sContext(0),
+		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: kc.Namespace,
 			Name:      kc.Name + "-dc1-stargate",
@@ -150,7 +150,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	require.NoError(err, "failed to patch stargate status")
 
 	reaper1Key := framework.ClusterKey{
-		K8sContext: f.K8sContext(0),
+		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: kc.Namespace,
 			Name:      kc.Name + "-dc1-reaper",
@@ -165,7 +165,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	require.NoError(err, "failed to patch reaper status")
 
 	sg2Key := framework.ClusterKey{
-		K8sContext: f.K8sContext(1),
+		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: kc.Namespace,
 			Name:      kc.Name + "-dc2-stargate",
@@ -180,7 +180,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	require.NoError(err, "failed to patch stargate status")
 
 	reaper2Key := framework.ClusterKey{
-		K8sContext: f.K8sContext(1),
+		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: kc.Namespace,
 			Name:      kc.Name + "-dc2-reaper",
@@ -194,7 +194,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	err = f.SetReaperStatusReady(ctx, reaper1Key)
 	require.NoError(err, "failed to patch reaper status")
 
-	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: kc.Namespace, Name: "dc2"}, K8sContext: f.K8sContext(1)}
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: kc.Namespace, Name: "dc2"}, K8sContext: f.DataPlaneContexts[1]}
 
 	addDatacenterFinalizer(ctx, t, f, dc2Key)
 

--- a/controllers/k8ssandra/stop_dc_test.go
+++ b/controllers/k8ssandra/stop_dc_test.go
@@ -39,7 +39,7 @@ func stopDcTest(f *framework.Framework, ctx context.Context, test stopDcTestFunc
 		managementApiFactory.UseDefaultAdapter()
 		kc := stopDcTestSetup(t, f, ctx, namespace)
 		test(t, f, ctx, kc)
-		err := f.DeleteK8ssandraCluster(ctx, utils.GetKey(kc))
+		err := f.DeleteK8ssandraCluster(ctx, utils.GetKey(kc), timeout, interval)
 		require.NoError(t, err, "failed to delete K8ssandraCluster")
 	}
 }
@@ -58,8 +58,8 @@ func stopDcTestSetup(t *testing.T, f *framework.Framework, ctx context.Context, 
 					CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{StorageClassName: &defaultStorageClass},
 				},
 				Datacenters: []api.CassandraDatacenterTemplate{
-					{Meta: api.EmbeddedObjectMeta{Name: "dc1"}, K8sContext: f.K8sContext(0), Size: 3},
-					{Meta: api.EmbeddedObjectMeta{Name: "dc2"}, K8sContext: f.K8sContext(1), Size: 3},
+					{Meta: api.EmbeddedObjectMeta{Name: "dc1"}, K8sContext: f.DataPlaneContexts[0], Size: 3},
+					{Meta: api.EmbeddedObjectMeta{Name: "dc2"}, K8sContext: f.DataPlaneContexts[1], Size: 3},
 				},
 			},
 			Stargate: &stargateapi.StargateClusterTemplate{Size: 3},
@@ -75,8 +75,8 @@ func stopDcTestSetup(t *testing.T, f *framework.Framework, ctx context.Context, 
 	verifySuperuserSecretCreated(ctx, t, f, kc)
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
-	dc1Key := framework.NewClusterKey(f.K8sContext(0), namespace, "dc1")
-	dc2Key := framework.NewClusterKey(f.K8sContext(1), namespace, "dc2")
+	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc1")
+	dc2Key := framework.NewClusterKey(f.DataPlaneContexts[1], namespace, "dc2")
 
 	t.Log("check that dc1 was created")
 	require.Eventually(t, f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -102,10 +102,10 @@ func stopDcTestSetup(t *testing.T, f *framework.Framework, ctx context.Context, 
 		return assert.NoError(t, err) && assert.Equal(t, corev1.ConditionTrue, kc.Status.GetConditionStatus(api.CassandraInitialized))
 	}, timeout, interval, "timed out waiting for CassandraInitialized condition check")
 
-	sg1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-stargate")
-	sg2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-stargate")
-	reaper1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-reaper")
-	reaper2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-reaper")
+	sg1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-stargate")
+	sg2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-stargate")
+	reaper1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-reaper")
+	reaper2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-reaper")
 
 	t.Log("check that stargate sg1 was created")
 	require.Eventually(t, f.StargateExists(ctx, sg1Key), timeout, interval)
@@ -168,25 +168,31 @@ func stopDcManagementApiReset(replication map[string]int) {
 func stopExistingDc(t *testing.T, f *framework.Framework, ctx context.Context, kc *api.K8ssandraCluster) {
 
 	kcKey := utils.GetKey(kc)
-	dc1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, "dc1")
-	sg1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-stargate")
-	sg2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-stargate")
-	reaper1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-reaper")
-	reaper2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-reaper")
+	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, "dc1")
+	sg1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-stargate")
+	sg2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-stargate")
+	reaper1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-reaper")
+	reaper2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-reaper")
 
 	replication := map[string]int{"dc1": 3, "dc2": 3}
 	stopDcManagementApiReset(replication)
 
 	t.Log("stop dc1")
-	patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
-	kc.Spec.Cassandra.Datacenters[0].Stopped = true
-	err := f.Client.Patch(ctx, kc, patch)
-	require.NoError(t, err, "failed to patch kc")
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		kc.Spec.Cassandra.Datacenters[0].Stopped = true
+		err = f.Client.Patch(ctx, kc, patch)
+		return err == nil
+	}, timeout, interval, "timeout waiting for kc patch")
 	withDc1 := f.NewWithDatacenter(ctx, dc1Key)
 	require.Eventually(t, withDc1(func(dc1 *cassdcapi.CassandraDatacenter) bool {
 		return assert.True(t, dc1.Spec.Stopped)
 	}), timeout, interval, "timeout waiting for dc1 to be stopped")
-	err = f.SetDatacenterStatusStopped(ctx, dc1Key)
+	err := f.SetDatacenterStatusStopped(ctx, dc1Key)
 	require.NoError(t, err, "failed to set dc1 status stopped")
 
 	t.Log("wait for the dc conditions to be met")
@@ -211,10 +217,16 @@ func stopExistingDc(t *testing.T, f *framework.Framework, ctx context.Context, k
 	require.Eventually(t, f.ReaperExists(ctx, reaper2Key), timeout, interval, "failed to verify reaper reaper2 created")
 
 	t.Log("start dc1")
-	patch = client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
-	kc.Spec.Cassandra.Datacenters[0].Stopped = false
-	err = f.Client.Patch(ctx, kc, patch)
-	require.NoError(t, err, "failed to patch kc")
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		kc.Spec.Cassandra.Datacenters[0].Stopped = false
+		err = f.Client.Patch(ctx, kc, patch)
+		return err == nil
+	}, timeout, interval, "timeout waiting for kc patch")
 	require.Eventually(t, withDc1(func(dc1 *cassdcapi.CassandraDatacenter) bool {
 		return assert.False(t, dc1.Spec.Stopped)
 	}), timeout, interval, "timeout waiting for dc1 to be started")
@@ -254,34 +266,40 @@ func stopExistingDc(t *testing.T, f *framework.Framework, ctx context.Context, k
 func addAndStopDc(t *testing.T, f *framework.Framework, ctx context.Context, kc *api.K8ssandraCluster) {
 
 	kcKey := utils.GetKey(kc)
-	dc1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, "dc1")
-	dc3Key := framework.NewClusterKey(f.K8sContext(2), kc.Namespace, "dc3")
-	sg1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-stargate")
-	sg2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-stargate")
-	sg3Key := framework.NewClusterKey(f.K8sContext(2), kc.Namespace, kc.Name+"-dc3-stargate")
-	reaper1Key := framework.NewClusterKey(f.K8sContext(0), kc.Namespace, kc.Name+"-dc1-reaper")
-	reaper2Key := framework.NewClusterKey(f.K8sContext(1), kc.Namespace, kc.Name+"-dc2-reaper")
-	reaper3Key := framework.NewClusterKey(f.K8sContext(2), kc.Namespace, kc.Name+"-dc3-reaper")
+	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, "dc1")
+	dc3Key := framework.NewClusterKey(f.DataPlaneContexts[2], kc.Namespace, "dc3")
+	sg1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-stargate")
+	sg2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-stargate")
+	sg3Key := framework.NewClusterKey(f.DataPlaneContexts[2], kc.Namespace, kc.Name+"-dc3-stargate")
+	reaper1Key := framework.NewClusterKey(f.DataPlaneContexts[0], kc.Namespace, kc.Name+"-dc1-reaper")
+	reaper2Key := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, kc.Name+"-dc2-reaper")
+	reaper3Key := framework.NewClusterKey(f.DataPlaneContexts[2], kc.Namespace, kc.Name+"-dc3-reaper")
 
 	t.Log("add dc3")
-	patch := client.MergeFromWithOptions(kc.DeepCopy())
-	kc.Spec.Cassandra.Datacenters = append(
-		kc.Spec.Cassandra.Datacenters,
-		api.CassandraDatacenterTemplate{Meta: api.EmbeddedObjectMeta{Name: "dc3"}, K8sContext: f.K8sContext(2), Size: 3},
-	)
-	err := f.Client.Patch(ctx, kc, patch)
-	require.NoError(t, err, "failed to patch kc")
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		patch := client.MergeFromWithOptions(kc.DeepCopy())
+		kc.Spec.Cassandra.Datacenters = append(
+			kc.Spec.Cassandra.Datacenters,
+			api.CassandraDatacenterTemplate{Meta: api.EmbeddedObjectMeta{Name: "dc3"}, K8sContext: f.DataPlaneContexts[2], Size: 3},
+		)
+		err = f.Client.Patch(ctx, kc, patch)
+		return err == nil
+	}, timeout, interval, "timeout waiting for kc patch")
 
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
 	t.Log("check that dc3 was created")
 	require.Eventually(t, f.DatacenterExists(ctx, dc3Key), timeout, interval, "failed to verify dc3 was created")
-	err = f.SetDatacenterStatusReady(ctx, dc3Key)
+	err := f.SetDatacenterStatusReady(ctx, dc3Key)
 	require.NoError(t, err, "failed to set dc3 status ready")
 
 	t.Log("check that dc3 was rebuilt")
 	verifyRebuildTaskCreated(ctx, t, f, dc3Key, dc1Key)
-	rebuildTaskKey := framework.NewClusterKey(f.K8sContext(2), kc.Namespace, "dc3-rebuild")
+	rebuildTaskKey := framework.NewClusterKey(f.DataPlaneContexts[2], kc.Namespace, "dc3-rebuild")
 	setRebuildTaskFinished(ctx, t, f, rebuildTaskKey, dc3Key)
 
 	t.Log("check that stargate sg3 was created")
@@ -319,13 +337,16 @@ func addAndStopDc(t *testing.T, f *framework.Framework, ctx context.Context, kc 
 	stopDcManagementApiReset(replication)
 
 	t.Log("stop dc3")
-	err = f.Client.Get(ctx, kcKey, kc)
-	require.NoError(t, err)
-	patch = client.MergeFromWithOptions(kc.DeepCopy())
-	kc.Spec.Cassandra.Datacenters[2].Stopped = true
-	err = f.Client.Patch(ctx, kc, patch)
-	require.NoError(t, err, "failed to patch kc")
-
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		patch := client.MergeFromWithOptions(kc.DeepCopy())
+		kc.Spec.Cassandra.Datacenters[2].Stopped = true
+		err = f.Client.Patch(ctx, kc, patch)
+		return err == nil
+	}, timeout, interval, "timeout waiting for kc patch")
 	withDc3 := f.NewWithDatacenter(ctx, dc3Key)
 	require.Eventually(t, withDc3(func(dc3 *cassdcapi.CassandraDatacenter) bool {
 		return assert.True(t, dc3.Spec.Stopped)
@@ -362,16 +383,19 @@ func addAndStopDc(t *testing.T, f *framework.Framework, ctx context.Context, kc 
 	f.AssertObjectDoesNotExist(ctx, t, reaper3Key, &reaperapi.Reaper{}, timeout, interval)
 
 	t.Log("start dc3")
-	err = f.Client.Get(ctx, kcKey, kc)
-	require.NoError(t, err)
-	patch = client.MergeFromWithOptions(kc.DeepCopy())
-	kc.Spec.Cassandra.Datacenters[2].Stopped = false
-	err = f.Client.Patch(ctx, kc, patch)
-	require.NoError(t, err, "failed to patch kc")
-
+	require.Eventually(t, func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		patch := client.MergeFromWithOptions(kc.DeepCopy())
+		kc.Spec.Cassandra.Datacenters[2].Stopped = false
+		err = f.Client.Patch(ctx, kc, patch)
+		return err == nil
+	}, timeout, interval, "timeout waiting for kc patch")
 	require.Eventually(t, withDc3(func(dc3 *cassdcapi.CassandraDatacenter) bool {
 		return assert.False(t, dc3.Spec.Stopped)
-	}), timeout, interval, "timeout waiting for dc3 to be started")
+	}), timeout, interval, "timeout waiting for dc3 to be stopped")
 	err = f.SetDatacenterStatusReady(ctx, dc3Key)
 	require.NoError(t, err, "failed to set dc3 status ready")
 

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -2,15 +2,14 @@ package medusa
 
 import (
 	"context"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
 	"time"
 
-	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
-	ctrl "github.com/k8ssandra/k8ssandra-operator/controllers/k8ssandra"
+	k8ssandractrl "github.com/k8ssandra/k8ssandra-operator/controllers/k8ssandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -23,109 +22,76 @@ const (
 )
 
 var (
-	defaultStorageClass = "default"
-	testEnv             *testutils.MultiClusterTestEnv
-	seedsResolver       = &fakeSeedsResolver{}
-	managementApi       = &testutils.FakeManagementApiFactory{}
-	medusaClientFactory *fakeMedusaClientFactory
+	defaultStorageClass  = "default"
+	medusaClientFactory  = NewMedusaClientFactory()
+	managementApiFactory = &testutils.FakeManagementApiFactory{}
 )
 
 func TestMedusaBackupRestore(t *testing.T) {
-	ctx := testutils.TestSetup(t)
-	ctx, cancel := context.WithCancel(ctx)
-	testEnv1 := setupBackupTestEnv(t, ctx)
-	defer testEnv1.Stop(t)
-	defer cancel()
 
-	t.Run("TestBackupDatacenter", testEnv1.ControllerTest(ctx, testBackupDatacenter))
-
-	testEnv2 := setupRestoreTestEnv(t, ctx)
-	defer testEnv2.Stop(t)
-	defer cancel()
-	t.Run("TestRestoreDatacenter", testEnv2.ControllerTest(ctx, testInPlaceRestore))
-
-}
-
-func setupBackupTestEnv(t *testing.T, ctx context.Context) *testutils.MultiClusterTestEnv {
-	testEnv = &testutils.MultiClusterTestEnv{}
-	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
-		return []string{}, nil
+	ctx, cancel := context.WithCancel(testutils.TestSetup(t))
+	testEnv := &testutils.MultiClusterTestEnv{
+		NumDataPlanes: 1,
+		BeforeTest: func(t *testing.T) {
+			managementApiFactory.SetT(t)
+			managementApiFactory.UseDefaultAdapter()
+		},
 	}
 
 	reconcilerConfig := config.InitConfig()
-
 	reconcilerConfig.DefaultDelay = 100 * time.Millisecond
 	reconcilerConfig.LongDelay = 300 * time.Millisecond
 
-	medusaClientFactory = NewMedusaClientFactory()
-
-	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
-		err := (&ctrl.K8ssandraClusterReconciler{
+	err := testEnv.Start(ctx, t, func(controlPlaneMgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
+		err := (&k8ssandractrl.K8ssandraClusterReconciler{
 			ReconcilerConfig: reconcilerConfig,
-			Client:           mgr.GetClient(),
+			Client:           controlPlaneMgr.GetClient(),
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
-			ManagementApi:    managementApi,
-		}).SetupWithManager(mgr, clusters)
+			ManagementApi:    managementApiFactory,
+		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err
 		}
-		err = (&CassandraBackupReconciler{
-			ReconcilerConfig: reconcilerConfig,
-			Client:           mgr.GetClient(),
-			Scheme:           scheme.Scheme,
-			ClientFactory:    medusaClientFactory,
-		}).SetupWithManager(mgr)
-		return err
+		for _, env := range testEnv.GetDataPlaneEnvTests() {
+			dataPlaneMgr, err := ctrl.NewManager(env.Config, ctrl.Options{Scheme: scheme.Scheme})
+			if err != nil {
+				return err
+			}
+			err = (&CassandraBackupReconciler{
+				ReconcilerConfig: reconcilerConfig,
+				Client:           dataPlaneMgr.GetClient(),
+				Scheme:           scheme.Scheme,
+				ClientFactory:    medusaClientFactory,
+			}).SetupWithManager(dataPlaneMgr)
+			if err != nil {
+				return err
+			}
+			err = (&CassandraRestoreReconciler{
+				ReconcilerConfig: reconcilerConfig,
+				Client:           dataPlaneMgr.GetClient(),
+				Scheme:           scheme.Scheme,
+			}).SetupWithManager(dataPlaneMgr)
+			if err != nil {
+				return err
+			}
+			go func() {
+				err := dataPlaneMgr.Start(ctx)
+				if err != nil {
+					t.Errorf("failed to start manager: %s", err)
+				}
+			}()
+		}
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("failed to start test environment: %s", err)
 	}
-	return testEnv
-}
 
-func setupRestoreTestEnv(t *testing.T, ctx context.Context) *testutils.MultiClusterTestEnv {
-	testEnv = &testutils.MultiClusterTestEnv{}
-	seedsResolver.callback = func(dc *cassdcapi.CassandraDatacenter) ([]string, error) {
-		return []string{}, nil
-	}
+	defer testEnv.Stop(t)
+	defer cancel()
 
-	reconcilerConfig := config.InitConfig()
+	t.Run("TestBackupDatacenter", testEnv.ControllerTest(ctx, testBackupDatacenter))
+	t.Run("TestRestoreDatacenter", testEnv.ControllerTest(ctx, testInPlaceRestore))
 
-	reconcilerConfig.DefaultDelay = 100 * time.Millisecond
-	reconcilerConfig.LongDelay = 300 * time.Millisecond
-
-	medusaClientFactory = NewMedusaClientFactory()
-
-	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
-		err := (&ctrl.K8ssandraClusterReconciler{
-			ReconcilerConfig: reconcilerConfig,
-			Client:           mgr.GetClient(),
-			Scheme:           scheme.Scheme,
-			ClientCache:      clientCache,
-			ManagementApi:    managementApi,
-		}).SetupWithManager(mgr, clusters)
-		if err != nil {
-			return err
-		}
-
-		err = (&CassandraRestoreReconciler{
-			ReconcilerConfig: reconcilerConfig,
-			Client:           mgr.GetClient(),
-			Scheme:           scheme.Scheme,
-		}).SetupWithManager(mgr)
-		return err
-	})
-	if err != nil {
-		t.Fatalf("failed to start test environment: %s", err)
-	}
-	return testEnv
-}
-
-type fakeSeedsResolver struct {
-	callback func(dc *cassdcapi.CassandraDatacenter) ([]string, error)
-}
-
-func (r *fakeSeedsResolver) ResolveSeedEndpoints(ctx context.Context, dc *cassdcapi.CassandraDatacenter, remoteClient client.Client) ([]string, error) {
-	return r.callback(dc)
 }

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -43,7 +43,7 @@ var (
 func TestSecretController(t *testing.T) {
 	ctx := testutils.TestSetup(t)
 	ctx, cancel := context.WithCancel(ctx)
-	testEnv = &testutils.MultiClusterTestEnv{}
+	testEnv = &testutils.MultiClusterTestEnv{NumDataPlanes: 2}
 	err := testEnv.Start(ctx, t, func(mgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
 		scheme = mgr.GetScheme()
 		logger = mgr.GetLogger()
@@ -75,7 +75,7 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 	// assert := assert.New(t)
 	var empty struct{}
 
-	rsec := generateReplicatedSecret(f.K8sContext(1), namespace)
+	rsec := generateReplicatedSecret(f.DataPlaneContexts[1], namespace)
 	rsec.Name = "broke"
 	err := f.Client.Create(ctx, rsec)
 	require.NoError(err, "failed to create replicated secret to main cluster")
@@ -91,21 +91,21 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 
 	t.Log("check that the secrets were copied to other cluster(s)")
 	require.Eventually(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetCopyToCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetCopyToCluster]}, map[string]struct{}{
 			generatedSecrets[0].Name: empty,
 		}, generatedSecrets[0].Namespace)
 	}, timeout, interval)
 
 	t.Log("check that secret not match by replicated secret was not copied")
 	require.Never(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetCopyToCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetCopyToCluster]}, map[string]struct{}{
 			generatedSecrets[1].Name: empty,
 		}, generatedSecrets[0].Namespace)
 	}, 3, interval)
 
 	t.Log("check that nothing was copied to cluster not match by replicated secret")
 	require.Never(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetNoCopyCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetNoCopyCluster]}, map[string]struct{}{
 			generatedSecrets[0].Name: empty,
 			generatedSecrets[1].Name: empty,
 		}, generatedSecrets[0].Namespace)
@@ -121,13 +121,13 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 
 	t.Log("verify it was modified in the target cluster also")
 	require.Eventually(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetCopyToCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetCopyToCluster]}, map[string]struct{}{
 			generatedSecrets[0].Name: empty,
 		}, generatedSecrets[0].Namespace)
 	}, timeout, interval)
 
 	t.Log("modify the secret in target cluster")
-	modifierClient := testEnv.Clients[f.K8sContext(targetCopyToCluster)]
+	modifierClient := testEnv.Clients[f.DataPlaneContexts[targetCopyToCluster]]
 	targetSecrets := &corev1.SecretList{}
 	err = modifierClient.List(ctx, targetSecrets, client.InNamespace(generatedSecrets[0].Namespace))
 	require.NoError(err)
@@ -144,7 +144,7 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 
 	t.Log("verify it was returned to original form")
 	require.Eventually(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetCopyToCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetCopyToCluster]}, map[string]struct{}{
 			generatedSecrets[0].Name: empty,
 		}, generatedSecrets[0].Namespace)
 	}, timeout, interval)
@@ -179,7 +179,7 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 	require.NoError(err, "failed to delete replicated secret from main cluster")
 
 	t.Log("verify the replicated secrets are gone from the remote cluster")
-	remoteClient := testEnv.Clients[f.K8sContext(targetCopyToCluster)]
+	remoteClient := testEnv.Clients[f.DataPlaneContexts[targetCopyToCluster]]
 	require.Eventually(func() bool {
 		t.Logf("checking for secret deletion: %v", types.NamespacedName{Name: generatedSecrets[0].Name, Namespace: rsec.Namespace})
 		remoteSecret := &corev1.Secret{}
@@ -203,7 +203,7 @@ func verifySecretIsDeleted(t *testing.T, ctx context.Context, f *framework.Frame
 	require := require.New(t)
 	var empty struct{}
 
-	rsec := generateReplicatedSecret(f.K8sContext(1), namespace)
+	rsec := generateReplicatedSecret(f.DataPlaneContexts[1], namespace)
 	err := f.Client.Create(ctx, rsec)
 	require.NoError(err, "failed to create replicated secret to main cluster")
 
@@ -215,7 +215,7 @@ func verifySecretIsDeleted(t *testing.T, ctx context.Context, f *framework.Frame
 
 	t.Log("check that the secret was copied to other cluster(s)")
 	require.Eventually(func() bool {
-		return verifySecretsMatch(t, ctx, f.Client, []string{f.K8sContext(targetCopyToCluster)}, map[string]struct{}{
+		return verifySecretsMatch(t, ctx, f.Client, []string{f.DataPlaneContexts[targetCopyToCluster]}, map[string]struct{}{
 			generatedSecrets[0].Name: empty,
 		}, generatedSecrets[0].Namespace)
 	}, timeout, interval)
@@ -225,7 +225,7 @@ func verifySecretIsDeleted(t *testing.T, ctx context.Context, f *framework.Frame
 	require.NoError(err, "failed to delete replicated secret from main cluster")
 
 	t.Log("verify the replicated secrets are gone from the remote cluster")
-	remoteClient := testEnv.Clients[f.K8sContext(targetCopyToCluster)]
+	remoteClient := testEnv.Clients[f.DataPlaneContexts[targetCopyToCluster]]
 	require.Eventually(func() bool {
 		remoteSecret := &corev1.Secret{}
 		err := remoteClient.Get(context.TODO(), types.NamespacedName{Name: generatedSecrets[0].Name, Namespace: rsec.Namespace}, remoteSecret)
@@ -240,20 +240,20 @@ func verifySecretIsDeleted(t *testing.T, ctx context.Context, f *framework.Frame
 func wrongClusterIgnoreCopy(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
 
-	err := f.Client.Create(ctx, generateReplicatedSecret(f.K8sContext(1), namespace))
+	err := f.Client.Create(ctx, generateReplicatedSecret(f.DataPlaneContexts[1], namespace))
 	require.NoError(err, "failed to create replicated secret to main cluster")
 
 	generatedSecrets := generateSecrets(namespace)
 
 	for _, s := range generatedSecrets {
-		err := testEnv.Clients[f.K8sContext(targetCopyToCluster)].Create(ctx, s)
+		err := testEnv.Clients[f.DataPlaneContexts[targetCopyToCluster]].Create(ctx, s)
 		require.NoError(err, "failed to create secret to main cluster")
 	}
 
 	t.Log("check that the secrets were not copied to other cluster(s)")
 	for _, s := range generatedSecrets {
 		require.Never(func() bool {
-			return verifySecretCopied(t, ctx, f.K8sContext(targetCopyToCluster), s, nil)
+			return verifySecretCopied(t, ctx, f.DataPlaneContexts[targetCopyToCluster], s, nil)
 		}, timeout, interval)
 	}
 }

--- a/controllers/stargate/stargate_controller_test.go
+++ b/controllers/stargate/stargate_controller_test.go
@@ -59,24 +59,23 @@ func TestStargate(t *testing.T) {
 	t.Run("CreateStargateSingleRack", func(t *testing.T) {
 		managementApiFactory.SetT(t)
 		managementApiFactory.UseDefaultAdapter()
-		testCreateStargateSingleRack(t, testEnv.TestClient)
+		testCreateStargateSingleRack(t, ctx, testEnv.TestClient)
 	})
 	t.Run("TestCreateStargateEncryption", func(t *testing.T) {
 		managementApiFactory.SetT(t)
 		managementApiFactory.UseDefaultAdapter()
-		testCreateStargateEncryption(t, testEnv.TestClient)
+		testCreateStargateEncryption(t, ctx, testEnv.TestClient)
 	})
 	t.Run("CreateStargateMultiRack", func(t *testing.T) {
 		managementApiFactory.SetT(t)
 		managementApiFactory.UseDefaultAdapter()
-		testCreateStargateMultiRack(t, testEnv.TestClient)
+		testCreateStargateMultiRack(t, ctx, testEnv.TestClient)
 	})
 }
 
-func testCreateStargateSingleRack(t *testing.T, testClient client.Client) {
+func testCreateStargateSingleRack(t *testing.T, ctx context.Context, testClient client.Client) {
 
 	namespace := "default"
-	ctx := context.Background()
 
 	dc := &cassdcapi.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
@@ -255,10 +254,9 @@ func testCreateStargateSingleRack(t *testing.T, testClient client.Client) {
 	}, timeout, interval, "stargate was never deleted")
 }
 
-func testCreateStargateMultiRack(t *testing.T, testClient client.Client) {
+func testCreateStargateMultiRack(t *testing.T, ctx context.Context, testClient client.Client) {
 
 	namespace := "default"
-	ctx := context.Background()
 
 	dc := &cassdcapi.CassandraDatacenter{
 		ObjectMeta: metav1.ObjectMeta{
@@ -460,10 +458,9 @@ func testCreateStargateMultiRack(t *testing.T, testClient client.Client) {
 	}, timeout, interval, "stargate was never deleted")
 }
 
-func testCreateStargateEncryption(t *testing.T, testClient client.Client) {
+func testCreateStargateEncryption(t *testing.T, ctx context.Context, testClient client.Client) {
 
 	namespace := "default"
-	ctx := context.Background()
 
 	// Create the client keystore and truststore secrets
 	clientKeystore := &corev1.Secret{

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -27,14 +27,14 @@ func multiDcAuthOnOff(t *testing.T, ctx context.Context, namespace string, f *fr
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "cluster1"}
 
-	dc1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	dc2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
+	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
 
-	reaper1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc2-reaper"}}
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc2-reaper"}}
 
-	stargate1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
-	stargate2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc2-stargate"}}
+	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc1-stargate"}}
+	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "cluster1-dc2-stargate"}}
 
 	superuserSecretKey := types.NamespacedName{Namespace: namespace, Name: secret.DefaultSuperuserSecretName("cluster1")}
 	reaperCqlSecretKey := types.NamespacedName{Namespace: namespace, Name: reaper.DefaultUserSecretName("cluster1")}
@@ -46,12 +46,12 @@ func multiDcAuthOnOff(t *testing.T, ctx context.Context, namespace string, f *fr
 	waitForAllComponentsReady(t, f, ctx, kcKey, dc1Key, dc2Key, stargate1Key, stargate2Key, reaper1Key, reaper2Key)
 
 	t.Log("deploying Stargate and Reaper ingress routes in both clusters")
-	f.DeployStargateIngresses(t, 0, namespace, "cluster1-dc1-stargate-service", "", "")
-	f.DeployStargateIngresses(t, 1, namespace, "cluster1-dc2-stargate-service", "", "")
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "cluster1-dc1-reaper-service")
-	f.DeployReaperIngresses(t, ctx, 1, namespace, "cluster1-dc2-reaper-service")
-	defer f.UndeployAllIngresses(t, 0, namespace)
-	defer f.UndeployAllIngresses(t, 1, namespace)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "cluster1-dc1-stargate-service", "", "")
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, "cluster1-dc2-stargate-service", "", "")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "cluster1-dc1-reaper-service")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, "cluster1-dc2-reaper-service")
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
 
 	pod1Name := "cluster1-dc1-default-sts-0"
 	pod2Name := "cluster1-dc2-default-sts-0"
@@ -78,28 +78,28 @@ func checkSecrets(
 	expectReaperSecretsCreated bool,
 ) {
 	t.Log("check that superuser secret exists in both contexts")
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: superuserSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: superuserSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: superuserSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: superuserSecretKey})
 	if expectReaperSecretsCreated {
 		t.Log("check that reaper CQL secret exists in both contexts")
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperCqlSecretKey})
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperCqlSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperCqlSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperCqlSecretKey})
 		t.Log("check that reaper JMX secret exists in both contexts")
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperJmxSecretKey})
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperJmxSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperJmxSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperJmxSecretKey})
 		t.Log("check that reaper UI secret exists in both contexts")
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperUiSecretKey})
-		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperUiSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperUiSecretKey})
+		checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperUiSecretKey})
 	} else {
 		t.Log("check that reaper CQL secret wasn't created in neither context")
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperCqlSecretKey})
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperCqlSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperCqlSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperCqlSecretKey})
 		t.Log("check that reaper JMX secret wasn't created in neither context")
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperJmxSecretKey})
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperJmxSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperJmxSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperJmxSecretKey})
 		t.Log("check that reaper UI secret wasn't created in neither context")
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperUiSecretKey})
-		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: reaperUiSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperUiSecretKey})
+		checkSecretDoesNotExist(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: reaperUiSecretKey})
 	}
 }
 
@@ -124,15 +124,15 @@ func waitForAllComponentsReady(
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dc2Key)
 	// we need to wait until the deployments are fully rolled out before continuing, to avoid hitting an old
 	// pod that has authentication enabled while we just turned it off.
-	options1 := kubectl.Options{Namespace: kcKey.Namespace, Context: f.K8sContext(0)}
-	options2 := kubectl.Options{Namespace: kcKey.Namespace, Context: f.K8sContext(1)}
-	err := kubectl.RolloutStatus(options1, "deployment", "cluster1-dc1-default-stargate-deployment")
+	options1 := kubectl.Options{Namespace: kcKey.Namespace, Context: f.DataPlaneContexts[0]}
+	options2 := kubectl.Options{Namespace: kcKey.Namespace, Context: f.DataPlaneContexts[1]}
+	err := kubectl.RolloutStatus(ctx, options1, "deployment", "cluster1-dc1-default-stargate-deployment")
 	assert.NoError(t, err)
-	err = kubectl.RolloutStatus(options1, "deployment", "cluster1-dc1-reaper")
+	err = kubectl.RolloutStatus(ctx, options1, "deployment", "cluster1-dc1-reaper")
 	assert.NoError(t, err)
-	err = kubectl.RolloutStatus(options2, "deployment", "cluster1-dc2-default-stargate-deployment")
+	err = kubectl.RolloutStatus(ctx, options2, "deployment", "cluster1-dc2-default-stargate-deployment")
 	assert.NoError(t, err)
-	err = kubectl.RolloutStatus(options2, "deployment", "cluster1-dc2-reaper")
+	err = kubectl.RolloutStatus(ctx, options2, "deployment", "cluster1-dc2-reaper")
 	assert.NoError(t, err)
 }
 
@@ -158,14 +158,14 @@ func testAuthenticationDisabled(
 	t.Run("TestJmxAccessAuthDisabled", func(t *testing.T) {
 		t.Run("Local", func(t *testing.T) {
 			t.Log("check that nodes in different dcs can see each other (auth disabled, local JMX)")
-			checkNodeToolStatus(t, f, f.K8sContext(0), namespace, pod1Name, 2, 0)
-			checkNodeToolStatus(t, f, f.K8sContext(1), namespace, pod2Name, 2, 0)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod1Name, 2, 0)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod2Name, 2, 0)
 		})
 		t.Run("Remote", func(t *testing.T) {
 			t.Log("check that nodes in different dcs can see each other (auth disabled, remote JMX)")
 			pod1IP, pod2IP := getPodIPs(t, f, namespace, pod1Name, pod2Name)
-			checkNodeToolStatus(t, f, f.K8sContext(0), namespace, pod1Name, 2, 0, "-h", pod2IP)
-			checkNodeToolStatus(t, f, f.K8sContext(1), namespace, pod2Name, 2, 0, "-h", pod1IP)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod1Name, 2, 0, "-h", pod2IP)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod2Name, 2, 0, "-h", pod1IP)
 		})
 	})
 	t.Run("TestApisAuthDisabled", func(t *testing.T) {
@@ -174,12 +174,12 @@ func testAuthenticationDisabled(
 			// token, the username will be checked against the system_auth.roles table directly.
 			// Therefore, we only test the CQL API here.
 			// See https://github.com/stargate/stargate/issues/792
-			testStargateNativeApi(t, ctx, 0, "", "", replication)
-			testStargateNativeApi(t, ctx, 1, "", "", replication)
+			testStargateNativeApi(t, ctx, f.DataPlaneContexts[0], "", "", replication)
+			testStargateNativeApi(t, ctx, f.DataPlaneContexts[1], "", "", replication)
 		})
 		t.Run("Reaper", func(t *testing.T) {
-			testReaperApi(t, ctx, 0, "cluster1", reaperapi.DefaultKeyspace, "", "")
-			testReaperApi(t, ctx, 1, "cluster1", reaperapi.DefaultKeyspace, "", "")
+			testReaperApi(t, ctx, f.DataPlaneContexts[0], "cluster1", reaperapi.DefaultKeyspace, "", "")
+			testReaperApi(t, ctx, f.DataPlaneContexts[1], "cluster1", reaperapi.DefaultKeyspace, "", "")
 		})
 	})
 }
@@ -194,33 +194,33 @@ func testAuthenticationEnabled(
 	pod1Name, pod2Name string,
 ) {
 	t.Log("retrieve superuser credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, kcKey.Namespace, "cluster1")
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], kcKey.Namespace, "cluster1")
 	require.NoError(t, err, "failed to retrieve superuser credentials")
 	t.Run("TestJmxAccessAuthEnabled", func(t *testing.T) {
 		t.Run("Local", func(t *testing.T) {
 			t.Log("check that nodes in different dcs can see each other (auth enabled, local JMX)")
-			checkNodeToolStatus(t, f, f.K8sContext(0), namespace, pod1Name, 2, 0, "-u", username, "-pw", password)
-			checkNodeToolStatus(t, f, f.K8sContext(1), namespace, pod2Name, 2, 0, "-u", username, "-pw", password)
-			checkLocalJmxFailsWithNoCredentials(t, f, f.K8sContext(0), namespace, pod1Name)
-			checkLocalJmxFailsWithNoCredentials(t, f, f.K8sContext(1), namespace, pod2Name)
-			checkLocalJmxFailsWithWrongCredentials(t, f, f.K8sContext(0), namespace, pod1Name)
-			checkLocalJmxFailsWithWrongCredentials(t, f, f.K8sContext(1), namespace, pod2Name)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod1Name, 2, 0, "-u", username, "-pw", password)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod2Name, 2, 0, "-u", username, "-pw", password)
+			checkLocalJmxFailsWithNoCredentials(t, f, f.DataPlaneContexts[0], namespace, pod1Name)
+			checkLocalJmxFailsWithNoCredentials(t, f, f.DataPlaneContexts[1], namespace, pod2Name)
+			checkLocalJmxFailsWithWrongCredentials(t, f, f.DataPlaneContexts[0], namespace, pod1Name)
+			checkLocalJmxFailsWithWrongCredentials(t, f, f.DataPlaneContexts[1], namespace, pod2Name)
 		})
 		t.Run("Remote", func(t *testing.T) {
 			t.Log("check that nodes in different dcs can see each other (auth enabled, remote JMX)")
 			pod1IP, pod2IP := getPodIPs(t, f, namespace, pod1Name, pod2Name)
-			checkNodeToolStatus(t, f, f.K8sContext(0), namespace, pod1Name, 2, 0, "-h", pod2IP, "-u", username, "-pw", password)
-			checkNodeToolStatus(t, f, f.K8sContext(1), namespace, pod2Name, 2, 0, "-h", pod1IP, "-u", username, "-pw", password)
-			checkRemoteJmxFailsWithNoCredentials(t, f, f.K8sContext(0), namespace, pod1Name, pod2IP)
-			checkRemoteJmxFailsWithNoCredentials(t, f, f.K8sContext(1), namespace, pod2Name, pod1IP)
-			checkRemoteJmxFailsWithWrongCredentials(t, f, f.K8sContext(0), namespace, pod1Name, pod2IP)
-			checkRemoteJmxFailsWithWrongCredentials(t, f, f.K8sContext(1), namespace, pod2Name, pod1IP)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod1Name, 2, 0, "-h", pod2IP, "-u", username, "-pw", password)
+			checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod2Name, 2, 0, "-h", pod1IP, "-u", username, "-pw", password)
+			checkRemoteJmxFailsWithNoCredentials(t, f, f.DataPlaneContexts[0], namespace, pod1Name, pod2IP)
+			checkRemoteJmxFailsWithNoCredentials(t, f, f.DataPlaneContexts[1], namespace, pod2Name, pod1IP)
+			checkRemoteJmxFailsWithWrongCredentials(t, f, f.DataPlaneContexts[0], namespace, pod1Name, pod2IP)
+			checkRemoteJmxFailsWithWrongCredentials(t, f, f.DataPlaneContexts[1], namespace, pod2Name, pod1IP)
 		})
 	})
 	t.Run("TestApisAuthEnabled", func(t *testing.T) {
 		t.Run("Stargate", func(t *testing.T) {
-			testStargateApis(t, ctx, f.K8sContext(0), 0, username, password, replication)
-			testStargateApis(t, ctx, f.K8sContext(1), 1, username, password, replication)
+			testStargateApis(t, ctx, f.DataPlaneContexts[0], username, password, replication)
+			testStargateApis(t, ctx, f.DataPlaneContexts[1], username, password, replication)
 			checkStargateCqlConnectionFailsWithNoCredentials(t, ctx, 0)
 			checkStargateCqlConnectionFailsWithNoCredentials(t, ctx, 1)
 			checkStargateCqlConnectionFailsWithWrongCredentials(t, ctx, 0)
@@ -232,9 +232,9 @@ func testAuthenticationEnabled(
 			checkStargateTokenAuthFailsWithWrongCredentials(t, restClient, 1)
 		})
 		t.Run("Reaper", func(t *testing.T) {
-			username, password := retrieveCredentials(t, f, ctx, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: reaperUiSecretKey})
-			testReaperApi(t, ctx, 0, "cluster1", reaperapi.DefaultKeyspace, username, password)
-			testReaperApi(t, ctx, 1, "cluster1", reaperapi.DefaultKeyspace, username, password)
+			username, password := retrieveCredentials(t, f, ctx, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: reaperUiSecretKey})
+			testReaperApi(t, ctx, f.DataPlaneContexts[0], "cluster1", reaperapi.DefaultKeyspace, username, password)
+			testReaperApi(t, ctx, f.DataPlaneContexts[1], "cluster1", reaperapi.DefaultKeyspace, username, password)
 		})
 	})
 }
@@ -305,9 +305,9 @@ func checkStargateTokenAuthFailsWithWrongCredentials(t *testing.T, restClient *r
 }
 
 func getPodIPs(t *testing.T, f *framework.E2eFramework, namespace, pod1Name, pod2Name string) (string, string) {
-	pod1IP, err := f.GetPodIP(f.K8sContext(0), namespace, pod1Name)
-	require.NoError(t, err, "failed to get pod %s IP in context %s", pod1Name, f.K8sContext(0))
-	pod2IP, err := f.GetPodIP(f.K8sContext(1), namespace, pod2Name)
-	require.NoError(t, err, "failed to get pod %s IP in context %s", pod2Name, f.K8sContext(1))
+	pod1IP, err := f.GetPodIP(f.DataPlaneContexts[0], namespace, pod1Name)
+	require.NoError(t, err, "failed to get pod %s IP in context %s", pod1Name, f.DataPlaneContexts[0])
+	pod2IP, err := f.GetPodIP(f.DataPlaneContexts[1], namespace, pod2Name)
+	require.NoError(t, err, "failed to get pod %s IP in context %s", pod2Name, f.DataPlaneContexts[1])
 	return pod1IP, pod2IP
 }

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -77,17 +77,8 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	require := require.New(t)
 	require.NoError(f.CreateCassandraEncryptionStoresSecret(namespace), "Failed to create the encryption secrets")
 
-	cqlSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-cql-secret"}
-	jmxSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-jmx-secret"}
 	uiSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
-
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey})
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
@@ -163,17 +154,8 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 	require := require.New(t)
 	require.NoError(f.CreateCassandraEncryptionStoresSecret(namespace), "Failed to create the encryption secrets")
 
-	cqlSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-cql-secret"}
-	jmxSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-jmx-secret"}
 	uiSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
-
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey})
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -24,28 +24,28 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 	require.NoError(f.CreateCassandraEncryptionStoresSecret(namespace), "Failed to create the encryption secrets")
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
-	dcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(0), namespace, "test", "test-dc1-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", "reaper_db")
 
 	testDeleteReaperManually(t, f, ctx, kcKey, dcKey, reaperKey)
 	testRemoveReaperFromK8ssandraCluster(t, f, ctx, kcKey, dcKey, reaperKey)
 
-	t.Log("deploying Reaper ingress routes in", f.K8sContext(0))
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "test-dc1-reaper-service")
-	defer f.UndeployAllIngresses(t, 0, namespace)
+	t.Log("deploying Reaper ingress routes in", f.DataPlaneContexts[0])
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service")
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
-		t.Log("test Reaper API in context", f.K8sContext(0))
-		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
+		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
+		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
 		username, password := retrieveCredentials(t, f, ctx, reaperUiSecretKey)
-		testReaperApi(t, ctx, 0, "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
 	})
 }
 
@@ -54,22 +54,22 @@ func createSingleReaperWithEncryption(t *testing.T, ctx context.Context, namespa
 	require.NoError(f.CreateCassandraEncryptionStoresSecret(namespace), "Failed to create the encryption secrets")
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
-	dcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
-	t.Log("deploying Reaper ingress routes in context", f.K8sContext(0))
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "test-dc1-reaper-service")
-	defer f.UndeployAllIngresses(t, 0, namespace)
+	t.Log("deploying Reaper ingress routes in context", f.DataPlaneContexts[0])
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service")
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
-		t.Log("test Reaper API in context", f.K8sContext(0))
-		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
+		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
+		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
 		username, password := retrieveCredentials(t, f, ctx, reaperUiSecretKey)
-		testReaperApi(t, ctx, 0, "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
 	})
 }
 
@@ -82,30 +82,30 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	uiSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: uiSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: uiSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: cqlSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: cqlSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: jmxSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: jmxSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey})
 
-	dc1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	dc2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
-	reaper1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
-	stargate1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
-	stargate2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-stargate"}}
+	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
+	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-stargate"}}
 
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
 	t.Log("check Stargate auth keyspace created in both clusters")
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(0), namespace, "test", "test-dc1-default-sts-0", stargate.AuthKeyspace)
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(1), namespace, "test", "test-dc2-default-sts-0", stargate.AuthKeyspace)
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", stargate.AuthKeyspace)
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", "test-dc2-default-sts-0", stargate.AuthKeyspace)
 
 	t.Log("check Reaper custom keyspace created in both clusters")
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(0), namespace, "test", "test-dc1-default-sts-0", "reaper_ks")
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(1), namespace, "test", "test-dc2-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", "test-dc2-default-sts-0", "reaper_ks")
 
 	checkStargateReady(t, f, ctx, stargate1Key)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dc1Key)
@@ -120,42 +120,42 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dc2Key)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, "test")
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, "test")
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	checkNodeToolStatus(t, f, f.K8sContext(0), namespace, "test-dc1-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, "test-dc1-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	checkNodeToolStatus(t, f, f.K8sContext(1), namespace, "test-dc2-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, "test-dc2-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
-	t.Log("deploying Stargate and Reaper ingress routes in both clusters")
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "test-dc1-reaper-service")
-	f.DeployReaperIngresses(t, ctx, 1, namespace, "test-dc2-reaper-service")
-	f.DeployStargateIngresses(t, 0, namespace, "test-dc1-stargate-service", username, password)
-	f.DeployStargateIngresses(t, 1, namespace, "test-dc2-stargate-service", username, password)
+	t.Log("deploying Stargate and Reaper ingress routes in all data plane clusters")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, "test-dc2-reaper-service")
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, "test-dc2-stargate-service", username, password)
 
-	defer f.UndeployAllIngresses(t, 0, namespace)
-	defer f.UndeployAllIngresses(t, 1, namespace)
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
-		secretKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: uiSecretKey}
+		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, 0, "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_ks", username, password)
 	})
 	t.Run("TestReaperApi[1]", func(t *testing.T) {
-		secretKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: uiSecretKey}
+		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, 1, "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[1], "test", "reaper_ks", username, password)
 	})
 
 	replication := map[string]int{"dc1": 1, "dc2": 1}
 
 	t.Run("TestStargateApi[0]", func(t *testing.T) {
-		testStargateApis(t, ctx, f.K8sContext(0), 0, username, password, replication)
+		testStargateApis(t, ctx, f.DataPlaneContexts[0], username, password, replication)
 	})
 	t.Run("TestStargateApi[1]", func(t *testing.T) {
-		testStargateApis(t, ctx, f.K8sContext(1), 1, username, password, replication)
+		testStargateApis(t, ctx, f.DataPlaneContexts[1], username, password, replication)
 	})
 }
 
@@ -168,17 +168,17 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 	uiSecretKey := types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: cqlSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: jmxSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: uiSecretKey})
-	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: uiSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: cqlSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: cqlSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: jmxSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: jmxSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey})
+	checkSecretExists(t, f, ctx, kcKey, framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey})
 
-	dc1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	dc2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
-	reaper1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
+	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
 
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
@@ -190,49 +190,49 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dc2Key)
 
 	t.Log("deploying Stargate and Reaper ingress routes in both clusters")
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "test-dc1-reaper-service")
-	f.DeployReaperIngresses(t, ctx, 1, namespace, "test-dc2-reaper-service")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service")
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, "test-dc2-reaper-service")
 
-	defer f.UndeployAllIngresses(t, 0, namespace)
-	defer f.UndeployAllIngresses(t, 1, namespace)
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
-		secretKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: uiSecretKey}
+		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, 0, "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_ks", username, password)
 	})
 	t.Run("TestReaperApi[1]", func(t *testing.T) {
-		secretKey := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: uiSecretKey}
+		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, 1, "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[1], "test", "reaper_ks", username, password)
 	})
 }
 
 func createReaperAndDatacenter(t *testing.T, ctx context.Context, namespace string, f *framework.E2eFramework) {
 
-	dcKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper1"}}
+	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper1"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
 
 	t.Log("create Reaper keyspace")
-	_, err := f.ExecuteCql(ctx, f.K8sContext(0), namespace, "test", "test-dc1-rack1-sts-0",
+	_, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-rack1-sts-0",
 		"CREATE KEYSPACE reaper_db WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : 3} ")
 	require.NoError(t, err, "failed to create Reaper keyspace")
 
-	checkKeyspaceExists(t, f, ctx, f.K8sContext(0), namespace, "test", "test-dc1-rack1-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-rack1-sts-0", "reaper_db")
 
 	checkReaperReady(t, f, ctx, reaperKey)
 
-	t.Log("deploying Reaper ingress routes in context", f.K8sContext(0))
-	f.DeployReaperIngresses(t, ctx, 0, namespace, "reaper1-service")
-	defer f.UndeployAllIngresses(t, 0, namespace)
+	t.Log("deploying Reaper ingress routes in context", f.DataPlaneContexts[0])
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "reaper1-service")
+	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
-		t.Log("test Reaper API in context", f.K8sContext(0))
-		secretKey := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}}
+		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
+		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, 0, "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
 	})
 }
 
@@ -342,12 +342,12 @@ func testRemoveReaperFromK8ssandraCluster(
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 }
 
-func connectReaperApi(t *testing.T, ctx context.Context, k8sContextIdx int, clusterName string, username string, password string) reaperclient.Client {
-	t.Logf("Testing Reaper API in context %v...", k8sContextIdx)
-	var reaperURL, _ = url.Parse(fmt.Sprintf("http://reaper.127.0.0.1.nip.io:3%d080", k8sContextIdx))
+func connectReaperApi(t *testing.T, ctx context.Context, k8sContext, clusterName, username, password string) reaperclient.Client {
+	t.Logf("Testing Reaper API in context %v...", k8sContext)
+	var reaperURL, _ = url.Parse(fmt.Sprintf("http://%s", ingresses[k8sContext]["reaper_rest"]))
 	var reaperClient = reaperclient.NewClient(reaperURL)
 	if username != "" {
-		t.Logf("Logging into Reaper API in context %v...", k8sContextIdx)
+		t.Logf("Logging into Reaper API in context %v...", k8sContext)
 		err := reaperClient.Login(ctx, username, password)
 		require.NoError(t, err, "failed to login into Reaper")
 	}
@@ -355,8 +355,8 @@ func connectReaperApi(t *testing.T, ctx context.Context, k8sContextIdx int, clus
 	return reaperClient
 }
 
-func testReaperApi(t *testing.T, ctx context.Context, k8sContextIdx int, clusterName, keyspace, username, password string) {
-	reaperClient := connectReaperApi(t, ctx, k8sContextIdx, clusterName, username, password)
+func testReaperApi(t *testing.T, ctx context.Context, k8sContext, clusterName, keyspace, username, password string) {
+	reaperClient := connectReaperApi(t, ctx, k8sContext, clusterName, username, password)
 	repairId := triggerRepair(t, ctx, clusterName, keyspace, reaperClient)
 	t.Log("Waiting for one segment to be repaired and canceling run")
 	waitForOneSegmentToBeDone(t, ctx, repairId, reaperClient)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -141,7 +141,7 @@ func TestOperator(t *testing.T) {
 	}))
 	t.Run("CreateMixedMultiDataCenterCluster", e2eTest(ctx, &e2eTestOpts{
 		testFunc: createMultiDatacenterClusterDifferentTopologies,
-		fixture:  framework.NewTestFixture("multi-dc-mixed"),
+		fixture:  framework.NewTestFixture("multi-dc-mixed", controlPlane),
 	}))
 	t.Run("AddDcToCluster", e2eTest(ctx, &e2eTestOpts{
 		testFunc: addDcToCluster,
@@ -742,33 +742,33 @@ func createMultiDatacenterClusterDifferentTopologies(t *testing.T, ctx context.C
 	err := f.Client.Get(ctx, kcKey, kc)
 	require.NoError(err, "failed to get K8ssandraCluster in namespace %s", namespace)
 
-	dc1Key := framework.ClusterKey{K8sContext: f.K8sContext(0), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
+	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name)
 
-	dc2Key := framework.ClusterKey{K8sContext: f.K8sContext(1), NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
+	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
 	checkDatacenterReady(t, ctx, dc2Key, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, kc.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.Name)
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
 	pod := "test-dc1-default-sts-0"
 	count := 3
-	checkNodeToolStatus(t, f, f.K8sContext(0), namespace, pod, count, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
 	pod = "test-dc2-default-sts-0"
-	checkNodeToolStatus(t, f, f.K8sContext(1), namespace, pod, count, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	replication := map[string]int{"dc1": 2, "dc2": 1}
-	checkKeyspaceReplication(t, f, ctx, f.K8sContext(0), namespace, kc.Name, "test-dc1-default-sts-0",
+	checkKeyspaceReplication(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.Name, "test-dc1-default-sts-0",
 		"system_auth", replication)
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 
 	"github.com/k8ssandra/k8ssandra-operator/test/kustomize"
@@ -1313,11 +1312,6 @@ func checkNodeToolStatus(
 	)
 }
 
-func checkSecretExists(t *testing.T, f *framework.E2eFramework, ctx context.Context, kcKey client.ObjectKey, secretKey framework.ClusterKey) {
-	secret := getSecret(t, f, ctx, secretKey)
-	require.True(t, labels.IsManagedBy(secret, kcKey), "secret %s/%s is not managed by %s", secretKey.Namespace, secretKey.Name, kcKey.Name)
-}
-
 // FIXME there is some overlap with E2eFramework.RetrieveDatabaseCredentials()
 func retrieveCredentials(t *testing.T, f *framework.E2eFramework, ctx context.Context, secretKey framework.ClusterKey) (string, string) {
 	secret := getSecret(t, f, ctx, secretKey)
@@ -1337,20 +1331,6 @@ func getSecret(t *testing.T, f *framework.E2eFramework, ctx context.Context, sec
 		secretKey,
 	)
 	return secret
-}
-
-func checkSecretDoesNotExist(t *testing.T, f *framework.E2eFramework, ctx context.Context, secretKey framework.ClusterKey) {
-	secret := &corev1.Secret{}
-	require.Never(
-		t,
-		func() bool {
-			return f.Get(ctx, secretKey, secret) == nil
-		},
-		15*time.Second,
-		time.Second,
-		"secret %s exists",
-		secretKey,
-	)
 }
 
 func checkKeyspaceExists(

--- a/test/framework/cqlsh.go
+++ b/test/framework/cqlsh.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (f *E2eFramework) RetrieveSuperuserSecret(ctx context.Context, namespace, clusterName string) (*corev1.Secret, error) {
+func (f *E2eFramework) RetrieveSuperuserSecret(ctx context.Context, k8sContext, namespace, clusterName string) (*corev1.Secret, error) {
 	var superUserSecret *corev1.Secret
 	superUserSecret = &corev1.Secret{}
 	superUserSecretKey := ClusterKey{
@@ -16,14 +16,14 @@ func (f *E2eFramework) RetrieveSuperuserSecret(ctx context.Context, namespace, c
 			Namespace: namespace,
 			Name:      secret.DefaultSuperuserSecretName(clusterName),
 		},
-		K8sContext: f.ControlPlaneContext,
+		K8sContext: k8sContext,
 	}
 	err := f.Get(ctx, superUserSecretKey, superUserSecret)
 	return superUserSecret, err
 }
 
-func (f *E2eFramework) RetrieveDatabaseCredentials(ctx context.Context, namespace, clusterName string) (string, string, error) {
-	superUserSecret, err := f.RetrieveSuperuserSecret(ctx, namespace, clusterName)
+func (f *E2eFramework) RetrieveDatabaseCredentials(ctx context.Context, k8sContext, namespace, clusterName string) (string, string, error) {
+	superUserSecret, err := f.RetrieveSuperuserSecret(ctx, k8sContext, namespace, clusterName)
 	var username, password string
 	if err == nil {
 		username = string(superUserSecret.Data["username"])
@@ -33,7 +33,7 @@ func (f *E2eFramework) RetrieveDatabaseCredentials(ctx context.Context, namespac
 }
 
 func (f *E2eFramework) ExecuteCql(ctx context.Context, k8sContext, namespace, clusterName, pod, query string) (string, error) {
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, namespace, clusterName)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, k8sContext, namespace, clusterName)
 	if err != nil {
 		return "", err
 	}

--- a/test/framework/fixtures.go
+++ b/test/framework/fixtures.go
@@ -22,13 +22,17 @@ type TestFixture struct {
 	// test/testdata/fixtures directory.
 	Name string
 
+	// K8sContext is the name of the context where the fixture should be deployed.
+	K8sContext string
+
 	definitionsDir string
 	kustomizeDir   string
 }
 
-func NewTestFixture(name string) *TestFixture {
+func NewTestFixture(name, k8sContext string) *TestFixture {
 	return &TestFixture{
 		Name:           name,
+		K8sContext:     k8sContext,
 		definitionsDir: filepath.Join(fixturesDefinitionsRoot, name),
 		kustomizeDir:   filepath.Join(fixturesKustomizationsRoot, name),
 	}
@@ -39,7 +43,7 @@ func (f *E2eFramework) DeployFixture(namespace string, fixture *TestFixture) err
 	if err != nil {
 		return err
 	}
-	dcContexts := f.AllK8sContexts()[:numDcs]
+	dcContexts := f.DataPlaneContexts[:numDcs]
 	data := &fixtureKustomization{
 		Namespace:  namespace,
 		Fixture:    fixture.Name,
@@ -49,7 +53,7 @@ func (f *E2eFramework) DeployFixture(namespace string, fixture *TestFixture) err
 	if err != nil {
 		return err
 	}
-	return f.kustomizeAndApply(fixture.kustomizeDir, namespace, f.ControlPlaneContext)
+	return f.kustomizeAndApply(fixture.kustomizeDir, namespace, fixture.K8sContext)
 }
 
 type fixtureKustomization struct {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -256,6 +256,19 @@ func (f *Framework) k8sContextNotFound(k8sContext string) error {
 	return fmt.Errorf("context %s not found", k8sContext)
 }
 
+// PatchK8ssandraCluster fetches the K8ssandraCluster specified by key in the control plane,
+// applies changes via updateFn, and then performs a patch operation.
+func (f *Framework) PatchK8ssandraCluster(ctx context.Context, key client.ObjectKey, updateFn func(kc *api.K8ssandraCluster)) error {
+	kc := &api.K8ssandraCluster{}
+	err := f.Client.Get(ctx, key, kc)
+	if err != nil {
+		return err
+	}
+	patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	updateFn(kc)
+	return f.Client.Patch(ctx, kc, patch)
+}
+
 // SetDatacenterStatusReady fetches the CassandraDatacenter specified by key and persists
 // a status update to make the CassandraDatacenter ready. It sets the DatacenterReady and
 // DatacenterInitialized conditions to true.

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -264,7 +264,7 @@ func (f *Framework) PatchK8ssandraCluster(ctx context.Context, key client.Object
 	if err != nil {
 		return err
 	}
-	patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	patch := client.MergeFrom(kc.DeepCopy())
 	updateFn(kc)
 	return f.Client.Patch(ctx, kc, patch)
 }

--- a/test/kustomize/kustomize.go
+++ b/test/kustomize/kustomize.go
@@ -21,7 +21,7 @@ func BuildDir(dir string) (*bytes.Buffer, error) {
 	output, err := cmd.CombinedOutput()
 	buffer := bytes.NewBuffer(output)
 
-	if logOutput {
+	if err != nil || logOutput {
 		fmt.Println(string(output))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR enforces a clearer distinction between control plane and data planes in controller tests and e2e tests.

While this change does not change the tests otherwise, it makes it possible in the future to run e2e tests against clusters where the control plane is different from the data planes.

**Which issue(s) this PR fixes**:
None

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
