### PR TITLE
Create make targets to prepare a cluster for e2e tests

### DIFF
--- a/CHANGELOG/CHANGELOG-1.0.md
+++ b/CHANGELOG/CHANGELOG-1.0.md
@@ -22,6 +22,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [TESTING] [#112](https://github.com/k8ssandra/k8ssandra-operator/issues/112) ⁃ Run 
   e2e tests against arbitrary context names
 * [TESTING] [#462](https://github.com/k8ssandra/k8ssandra-operator/issues/462) ⁃ Use yq to parse fixture files
+* [TESTING] [#517](https://github.com/k8ssandra/k8ssandra-operator/issues/517) ⁃ Create make targets to prepare a cluster for e2e tests
 
 ## v1.0.1 2022-03-07
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR introduces a few make targets that aim to make developers lives easier. Especially, when a dev is required to run the same e2e test many times, this can now be done with a sequence like:

```makefile
# create and prepare the cluster for the first time
make multi-create multi-prepare
# run the test
make e2e-test E2E_TEST=...
# Make changes to code then rebuild and reload the operator image
make multi-prepare
# re-run the test again
make e2e-test E2E_TEST=...
# etc
```

**Which issue(s) this PR fixes**:
Fixes #517 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
