### PR TITLE
Fix reaper test encoding to match comment

### DIFF
--- a/test/testdata/fixtures/multi-dc-encryption-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-encryption-reaper/k8ssandra.yaml
@@ -14,7 +14,7 @@ metadata:
   name: reaper-ui-secret
 data:
   # username: reaper-ui
-  username: cmVhcGVyLWpteA==
+  username: cmVhcGVyLXVpCg==
   # password: R3ap3r
   password: UjNhcDNy
 ---

--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -14,7 +14,7 @@ metadata:
   name: reaper-ui-secret
 data:
   # username: reaper-ui
-  username: cmVhcGVyLWpteA==
+  username: cmVhcGVyLXVpCg==
   # password: R3ap3r
   password: UjNhcDNy
 ---

--- a/test/testdata/fixtures/reaper/reaper-ui-secret.yaml
+++ b/test/testdata/fixtures/reaper/reaper-ui-secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: reaper-ui-secret
 data:
   # username: reaper-ui
-  username: cmVhcGVyLWpteA==
+  username: cmVhcGVyLXVpCg==
   # password: R3ap3r
   password: UjNhcDNy


### PR DESCRIPTION
**What this PR does**:
The value encoded for `reaper-ui` username does not coincide with the commented value in tests.

**Which issue(s) this PR fixes**:
Fixes #499 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
