### PR TITLE
Fix the system schema replication annotation issue after 1.1 upgrade

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -9,7 +9,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'
@@ -70,6 +72,7 @@ jobs:
           - GCTests/4.0-jdk11-G1
           - GCTests/4.0-jdk11-CMS
           - GCTests/4.0-jdk11-ZGC
+          - UpgradeTest
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -72,7 +72,7 @@ jobs:
           - GCTests/4.0-jdk11-G1
           - GCTests/4.0-jdk11-CMS
           - GCTests/4.0-jdk11-ZGC
-          - UpgradeTest
+          - UpgradeOperatorImage
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -9,7 +9,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'

--- a/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
@@ -8,7 +8,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'

--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -9,7 +9,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'

--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -8,7 +8,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'

--- a/.github/workflows/version_tests.yaml
+++ b/.github/workflows/version_tests.yaml
@@ -9,7 +9,9 @@ on:
       - 'docs/**'
       - 'CHANGELOG/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'

--- a/CHANGELOG/CHANGELOG-1.1.md
+++ b/CHANGELOG/CHANGELOG-1.1.md
@@ -14,6 +14,7 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+* [BUGFIX] [#550](https://github.com/k8ssandra/k8ssandra-operator/issues/550) Fix system schema replication annotation parsing failure after 1.1.0 upgrade
 
 ## v1.1.0 2022-05-13
 * [CHANGE] [#545](https://github.com/k8ssandra/k8ssandra-operator/pull/545) Update to cass-operator v1.11.0

--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: v1.1-dev
+    newTag: v1.1-latest
 

--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: v1.1.1-dev
+    newTag: v1.1-dev
 

--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: v1.1.0
+    newTag: v1.1.1-dev
 

--- a/controllers/k8ssandra/schemas.go
+++ b/controllers/k8ssandra/schemas.go
@@ -132,7 +132,7 @@ func (r *K8ssandraClusterReconciler) checkInitialSystemReplication(
 					replication[dc] = replicationOldFormat.ReplicationFactor
 				}
 			} else {
-				logger.Error(err, "could not parse the inital-system-replication annotation of the K8ssandraCluster object")
+				logger.Error(err, "could not parse the initial-system-replication annotation of the K8ssandraCluster object")
 				return nil, err
 			}
 		}

--- a/controllers/k8ssandra/schemas.go
+++ b/controllers/k8ssandra/schemas.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// an annotation is used to store the initial replication factor for system keyspaces.
+// its schema evolved in v1.1 but we need to be able to parse the old format for upgrades.
 type SystemReplicationOldFormat struct {
 	Datacenters       []string `json:"datacenters"`
 	ReplicationFactor int      `json:"replicationFactor"`

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -286,7 +286,7 @@ func TestOperator(t *testing.T) {
 			fixture:  framework.NewTestFixture("gc/4.0-jdk11-ZGC", controlPlane),
 		}))
 	})
-	t.Run("UpgradeTest", e2eTest(ctx, &e2eTestOpts{
+	t.Run("UpgradeOperatorImage", e2eTest(ctx, &e2eTestOpts{
 		testFunc:       createSingleDatacenterClusterWithUpgrade,
 		fixture:        framework.NewTestFixture("single-dc-upgrade", controlPlane),
 		initialVersion: pointer.String("v1.0.0"),
@@ -484,12 +484,6 @@ func upgradeToLatest(t *testing.T, ctx context.Context, f *framework.E2eFramewor
 
 	if err := f.DeployK8ssandraOperator(deploymentConfig); err != nil {
 		t.Logf("failed to deploy k8ssandra-operator")
-		return err
-	}
-
-	// Force a restart of the operator to load the latest image
-	if err := f.DeleteK8ssandraOperatorPods(namespace, polling.operatorDeploymentReady.timeout, polling.operatorDeploymentReady.interval); err != nil {
-		t.Logf("failed to restart k8ssandra-operator")
 		return err
 	}
 

--- a/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
@@ -1,0 +1,38 @@
+apiVersion: k8ssandra.io/v1alpha1
+kind: K8ssandraCluster
+metadata:
+  name: test
+spec:
+  cassandra:
+    serverVersion: 3.11.11
+    datacenters:
+      - metadata:
+          name: dc1
+        k8sContext: kind-k8ssandra-0
+        size: 2
+        storageConfig:
+          cassandraDataVolumeClaimSpec:
+            storageClassName: standard
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 5Gi
+        stargate:
+          size: 1
+          heapSize: 384Mi
+          livenessProbe:
+            initialDelaySeconds: 100
+            periodSeconds: 10
+            failureThreshold: 20
+            successThreshold: 1
+            timeoutSeconds: 20
+          readinessProbe:
+            initialDelaySeconds: 100
+            periodSeconds: 10
+            failureThreshold: 20
+            successThreshold: 1
+            timeoutSeconds: 20
+          cassandraConfigMapRef:
+            name: cassandra-config
+    mgmtAPIHeap: 64Mi

--- a/test/testdata/fixtures/single-dc-upgrade/kustomization.yaml
+++ b/test/testdata/fixtures/single-dc-upgrade/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - k8ssandra.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Implement a fix for errors when upgrading from v1.0 to v1.1.
The format of the `initial-system-replication` annotation has changed from `{"datacenters":["dc2","dc1"],"replicationFactor":3}` to `{'dc1':3, 'dc2':3}`, but the code only tries to parse the latter in v1.1.
This results in looping reconcile errors.

The fix identifies if the format is the old one, and if so lets the operator recompute the annotation and overwrite it.

This PR also adds an minimal e2e test that performs an upgrade from v1.0.0 to `latest` (which is the version built off 

**Which issue(s) this PR fixes**:
Fixes #550

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
