### PR TITLE
Override cass cluster name

### DIFF
--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [FEATURE] [#496](https://github.com/k8ssandra/k8ssandra-operator/issues/496) Allow overriding Cassandra cluster names
 * [ENHANCEMENT] [#354](https://github.com/k8ssandra/k8ssandra-operator/issues/354) Add encryption support to Medusa

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -217,6 +217,11 @@ type CassandraClusterTemplate struct {
 	// Client encryption stores which are used by Cassandra and Reaper.
 	// +optional
 	ClientEncryptionStores *encryption.Stores `json:"clientEncryptionStores,omitempty"`
+
+	// Override the Cassandra cluster name. If unspecified, the cluster name will be the same as the K8ssandraCluster
+	// CRD name.
+	// +optional
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_webhook.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
@@ -34,6 +35,7 @@ var (
 	ErrReaperKeyspace  = fmt.Errorf("reaper keyspace can not be changed")
 	ErrNoStorageConfig = fmt.Errorf("storageConfig must be defined at cluster level or dc level")
 	ErrNoResourcesSet  = fmt.Errorf("softPodAntiAffinity requires Resources to be set")
+	ErrClusterName     = fmt.Errorf("cluster name can not be changed")
 )
 
 // log is for logging in this package.
@@ -137,6 +139,11 @@ func (r *K8ssandraCluster) ValidateUpdate(old runtime.Object) error {
 			utils.IsNil(oldCassConfig.CassandraYaml.NumTokens) {
 			return ErrNumTokens
 		}
+	}
+
+	// Verify that the cluster name override was not changed
+	if r.Spec.Cassandra.ClusterName != oldCluster.Spec.Cassandra.ClusterName {
+		return ErrClusterName
 	}
 
 	// Some of these could be extracted in the cass-operator to reusable methods, do not copy code here.

--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.11.0
+- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=master
 
 images:
   - name: k8ssandra/cass-operator
-    newTag: v1.11.0
+    newTag: 34648fd3

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.11.0
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=master
 
 images:
   - name: k8ssandra/cass-operator
-    newTag: v1.11.0
+    newTag: 34648fd3

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -95,6 +95,11 @@ spec:
                     - keystoreSecretRef
                     - truststoreSecretRef
                     type: object
+                  clusterName:
+                    description: Override the Cassandra cluster name. If unspecified,
+                      the cluster name will be the same as the K8ssandraCluster CRD
+                      name.
+                    type: string
                   config:
                     description: CassandraConfig is configuration settings that are
                       applied to cassandra.yaml and the various jvm*.options files.

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -6486,8 +6486,8 @@ spec:
                           properties:
                             additionalVolumes:
                               items:
-                                description: StorageConfig defines additional storage
-                                  configurations
+                                description: AdditionalVolumes StorageConfig defines
+                                  additional storage configurations
                                 properties:
                                   mountPath:
                                     description: Mount path into cassandra container
@@ -7121,7 +7121,8 @@ spec:
                     properties:
                       additionalVolumes:
                         items:
-                          description: StorageConfig defines additional storage configurations
+                          description: AdditionalVolumes StorageConfig defines additional
+                            storage configurations
                           properties:
                             mountPath:
                               description: Mount path into cassandra container

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
@@ -8222,8 +8222,8 @@ spec:
                         properties:
                           additionalVolumes:
                             items:
-                              description: StorageConfig defines additional storage
-                                configurations
+                              description: AdditionalVolumes StorageConfig defines
+                                additional storage configurations
                               properties:
                                 mountPath:
                                   description: Mount path into cassandra container

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -42,7 +42,12 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
 
-	seeds, err := r.findSeeds(ctx, kc, logger)
+	clusterName := kc.Name
+	if kc.Spec.Cassandra.ClusterName != "" {
+		clusterName = kc.Spec.Cassandra.ClusterName
+	}
+
+	seeds, err := r.findSeeds(ctx, kc, clusterName, logger)
 	if err != nil {
 		logger.Error(err, "Failed to find seed nodes")
 		return result.Error(err), actualDcs
@@ -59,10 +64,6 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
 		// its fields are pointers, and without the copy we could end of with shared
 		// references that would lead to unexpected and incorrect values.
-		clusterName := kc.Name
-		if kc.Spec.Cassandra.ClusterName != "" {
-			clusterName = kc.Spec.Cassandra.ClusterName
-		}
 		dcConfig := cassandra.Coalesce(clusterName, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
 		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled())
 

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -42,12 +42,12 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
 
-	clusterName := kc.Name
+	cassClusterName := kc.Name
 	if kc.Spec.Cassandra.ClusterName != "" {
-		clusterName = kc.Spec.Cassandra.ClusterName
+		cassClusterName = kc.Spec.Cassandra.ClusterName
 	}
 
-	seeds, err := r.findSeeds(ctx, kc, clusterName, logger)
+	seeds, err := r.findSeeds(ctx, kc, cassClusterName, logger)
 	if err != nil {
 		logger.Error(err, "Failed to find seed nodes")
 		return result.Error(err), actualDcs
@@ -64,7 +64,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
 		// its fields are pointers, and without the copy we could end of with shared
 		// references that would lead to unexpected and incorrect values.
-		dcConfig := cassandra.Coalesce(clusterName, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
+		dcConfig := cassandra.Coalesce(cassClusterName, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
 		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled())
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on
@@ -120,6 +120,11 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		}
 
 		if err = remoteClient.Get(ctx, dcKey, actualDc); err == nil {
+			// Fail the reconcile if cluster name has changed
+			if actualDc.Spec.ClusterName != cassClusterName {
+				return result.Error(fmt.Errorf("CassandraDatacenter %s has cluster name %s, but expected %s. Cluster name cannot be changed in an existing cluster", dcKey, actualDc.Spec.ClusterName, cassClusterName)), actualDcs
+			}
+
 			r.setStatusForDatacenter(kc, actualDc)
 
 			if !annotations.CompareHashAnnotations(actualDc, desiredDc) {

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -59,7 +59,11 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		// Note that it is necessary to use a copy of the CassandraClusterTemplate because
 		// its fields are pointers, and without the copy we could end of with shared
 		// references that would lead to unexpected and incorrect values.
-		dcConfig := cassandra.Coalesce(kc.Name, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
+		clusterName := kc.Name
+		if kc.Spec.Cassandra.ClusterName != "" {
+			clusterName = kc.Spec.Cassandra.ClusterName
+		}
+		dcConfig := cassandra.Coalesce(clusterName, kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
 		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled())
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -58,9 +58,9 @@ func (r *K8ssandraClusterReconciler) ReconcileMedusa(
 		if res := r.reconcileMedusaConfigMap(ctx, remoteClient, kc, logger, namespace); res.Completed() {
 			return res
 		}
-		medusa.UpdateMedusaInitContainer(dcConfig, medusaSpec, logger)
-		medusa.UpdateMedusaMainContainer(dcConfig, medusaSpec, logger)
-		medusa.UpdateMedusaVolumes(dcConfig, medusaSpec, logger)
+		medusa.UpdateMedusaInitContainer(dcConfig, medusaSpec, kc.Name, logger)
+		medusa.UpdateMedusaMainContainer(dcConfig, medusaSpec, kc.Name, logger)
+		medusa.UpdateMedusaVolumes(dcConfig, medusaSpec, kc.Name, logger)
 		cassandra.AddCqlUser(medusaSpec.CassandraUserSecretRef, dcConfig, medusa.CassandraUserSecretName(medusaSpec, kc.Name))
 	} else {
 		logger.Info("Medusa is not enabled")

--- a/controllers/k8ssandra/seeds.go
+++ b/controllers/k8ssandra/seeds.go
@@ -3,6 +3,7 @@ package k8ssandra
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
@@ -16,7 +17,7 @@ import (
 
 // findSeeds queries for pods labeled as seeds. It does this for each DC, across all
 // clusters.
-func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) ([]corev1.Pod, error) {
+func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ssandraCluster, clusterName string, logger logr.Logger) ([]corev1.Pod, error) {
 	pods := make([]corev1.Pod, 0)
 
 	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
@@ -33,7 +34,7 @@ func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ss
 
 		list := &corev1.PodList{}
 		selector := map[string]string{
-			cassdcapi.ClusterLabel:    kc.Name,
+			cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(clusterName),
 			cassdcapi.DatacenterLabel: dcTemplate.Meta.Name,
 			cassdcapi.SeedNodeLabel:   "true",
 		}

--- a/controllers/k8ssandra/seeds.go
+++ b/controllers/k8ssandra/seeds.go
@@ -17,7 +17,7 @@ import (
 
 // findSeeds queries for pods labeled as seeds. It does this for each DC, across all
 // clusters.
-func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ssandraCluster, clusterName string, logger logr.Logger) ([]corev1.Pod, error) {
+func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ssandraCluster, cassClusterName string, logger logr.Logger) ([]corev1.Pod, error) {
 	pods := make([]corev1.Pod, 0)
 
 	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
@@ -34,7 +34,7 @@ func (r *K8ssandraClusterReconciler) findSeeds(ctx context.Context, kc *api.K8ss
 
 		list := &corev1.PodList{}
 		selector := map[string]string{
-			cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(clusterName),
+			cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(cassClusterName),
 			cassdcapi.DatacenterLabel: dcTemplate.Meta.Name,
 			cassdcapi.SeedNodeLabel:   "true",
 		}

--- a/controllers/medusa/backup_controller_test.go
+++ b/controllers/medusa/backup_controller_test.go
@@ -171,7 +171,7 @@ func createAndVerifyBackup(
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				cassdcapi.ClusterLabel: dc.Spec.ClusterName,
+				cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(dc.Spec.ClusterName),
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -363,7 +363,7 @@ func createDatacenterPods(t *testing.T, f *framework.Framework, ctx context.Cont
 						Namespace: dc.Namespace,
 						Name:      podName,
 						Labels: map[string]string{
-							cassdcapi.ClusterLabel:    dc.Spec.ClusterName,
+							cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(dc.Spec.ClusterName),
 							cassdcapi.DatacenterLabel: dc.Name,
 						},
 					},

--- a/controllers/medusa/cassandrarestore_controller.go
+++ b/controllers/medusa/cassandrarestore_controller.go
@@ -174,7 +174,7 @@ func (r *CassandraRestoreReconciler) podTemplateSpecUpdateComplete(ctx context.C
 	// StatefulSets are scaled back up.
 
 	statefulsetList := &appsv1.StatefulSetList{}
-	labels := client.MatchingLabels{cassdcapi.ClusterLabel: req.Datacenter.Spec.ClusterName, cassdcapi.DatacenterLabel: req.Datacenter.Name}
+	labels := client.MatchingLabels{cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(req.Datacenter.Spec.ClusterName), cassdcapi.DatacenterLabel: req.Datacenter.Name}
 
 	if err := r.List(ctx, statefulsetList, labels); err != nil {
 		req.Log.Error(err, "Failed to get StatefulSets")

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -150,7 +150,7 @@ func createAndVerifyMedusaBackup(dcKey framework.ClusterKey, dc *cassdcapi.Cassa
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
-						cassdcapi.ClusterLabel: dc.Spec.ClusterName,
+						cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(dc.Spec.ClusterName),
 					},
 					Ports: []corev1.ServicePort{
 						{

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -210,7 +210,7 @@ func (r *MedusaRestoreJobReconciler) podTemplateSpecUpdateComplete(ctx context.C
 	// StatefulSets are scaled back up.
 
 	statefulsetList := &appsv1.StatefulSetList{}
-	labels := client.MatchingLabels{cassdcapi.ClusterLabel: req.Datacenter.Spec.ClusterName, cassdcapi.DatacenterLabel: req.Datacenter.Name}
+	labels := client.MatchingLabels{cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(req.Datacenter.Spec.ClusterName), cassdcapi.DatacenterLabel: req.Datacenter.Name}
 
 	if err := r.List(ctx, statefulsetList, labels); err != nil {
 		req.Log.Error(err, "Failed to get StatefulSets")

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -125,7 +125,7 @@ func beforeTest(t *testing.T, ctx context.Context, k8sClient client.Client, test
 			Name:      "test-cassdc-pod1",
 			Namespace: testNamespace,
 			Labels: map[string]string{
-				cassdcapi.ClusterLabel:    cassandraClusterName,
+				cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(cassandraClusterName),
 				cassdcapi.DatacenterLabel: cassandraDatacenterName,
 			},
 		},
@@ -157,7 +157,7 @@ func beforeTest(t *testing.T, ctx context.Context, k8sClient client.Client, test
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{Name: "mgmt-api-http", Port: int32(8080)}},
 			Selector: map[string]string{
-				cassdcapi.ClusterLabel:    cassandraClusterName,
+				cassdcapi.ClusterLabel:    cassdcapi.CleanLabelValue(cassandraClusterName),
 				cassdcapi.DatacenterLabel: cassandraDatacenterName,
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/zapr v1.2.0
 	github.com/google/uuid v1.2.0
 	github.com/gruntwork-io/terratest v0.37.7
-	github.com/k8ssandra/cass-operator v1.11.0
+	github.com/k8ssandra/cass-operator v1.11.1-0.20220614135003-34648fd39f11
 	github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k8ssandra/cass-operator v1.11.0 h1:5ILJ3m4oqi0iNAZxI0VMG2SqO3FKKI6TM/3idT2HLAg=
 github.com/k8ssandra/cass-operator v1.11.0/go.mod h1:Kcv9+EA4FQ9beDiTl+wQOiONAgjt/Yp76I75Z7Y/Plw=
+github.com/k8ssandra/cass-operator v1.11.1-0.20220614135003-34648fd39f11 h1:Lzp8tCIGkaRqOxXU422Ct3fbANN87cEHxtJy91nvM3w=
+github.com/k8ssandra/cass-operator v1.11.1-0.20220614135003-34648fd39f11/go.mod h1:Kcv9+EA4FQ9beDiTl+wQOiONAgjt/Yp76I75Z7Y/Plw=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5 h1:Dq0VdM960G3AbhYwFuaebmsE08IzOYHYhngUfDmWaAc=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5/go.mod h1:WsQymIaVT39xbcstZhdqynUS13AGzP2p6U9Hsk1oy5M=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -113,10 +113,10 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster) string {
 	return medusaIni.String()
 }
 
-func CreateMedusaConfigMap(namespace, clusterName, medusaIni string) *corev1.ConfigMap {
+func CreateMedusaConfigMap(namespace, k8cName, medusaIni string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-medusa", clusterName),
+			Name:      fmt.Sprintf("%s-medusa", k8cName),
 			Namespace: namespace,
 		},
 		Data: map[string]string{
@@ -126,14 +126,14 @@ func CreateMedusaConfigMap(namespace, clusterName, medusaIni string) *corev1.Con
 }
 
 // Get the cassandra user secret name from the medusa spec or generate one based on the cluster name
-func CassandraUserSecretName(medusaSpec *api.MedusaClusterTemplate, clusterName string) string {
+func CassandraUserSecretName(medusaSpec *api.MedusaClusterTemplate, k8cName string) string {
 	if medusaSpec.CassandraUserSecretRef.Name == "" {
-		return fmt.Sprintf("%s-medusa", clusterName)
+		return fmt.Sprintf("%s-medusa", k8cName)
 	}
 	return medusaSpec.CassandraUserSecretRef.Name
 }
 
-func UpdateMedusaInitContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, clusterName string, logger logr.Logger) {
+func UpdateMedusaInitContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, k8cName string, logger logr.Logger) {
 	restoreContainerIndex, found := cassandra.FindInitContainer(dcConfig.PodTemplateSpec, "medusa-restore")
 	restoreContainer := &corev1.Container{Name: "medusa-restore"}
 	if found {
@@ -143,8 +143,8 @@ func UpdateMedusaInitContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec 
 	}
 	setImage(medusaSpec.ContainerImage, restoreContainer)
 	restoreContainer.SecurityContext = medusaSpec.SecurityContext
-	restoreContainer.Env = medusaEnvVars(medusaSpec, clusterName, logger, "RESTORE")
-	restoreContainer.VolumeMounts = medusaVolumeMounts(medusaSpec, clusterName, logger)
+	restoreContainer.Env = medusaEnvVars(medusaSpec, k8cName, logger, "RESTORE")
+	restoreContainer.VolumeMounts = medusaVolumeMounts(medusaSpec, k8cName, logger)
 
 	if !found {
 		logger.Info("Couldn't find medusa-restore init container")
@@ -160,7 +160,7 @@ func UpdateMedusaInitContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec 
 	}
 }
 
-func UpdateMedusaMainContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, clusterName string, logger logr.Logger) {
+func UpdateMedusaMainContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, k8cName string, logger logr.Logger) {
 	medusaContainerIndex, found := cassandra.FindContainer(dcConfig.PodTemplateSpec, "medusa")
 	medusaContainer := &corev1.Container{Name: "medusa"}
 	if found {
@@ -170,12 +170,12 @@ func UpdateMedusaMainContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec 
 	}
 	setImage(medusaSpec.ContainerImage, medusaContainer)
 	medusaContainer.SecurityContext = medusaSpec.SecurityContext
-	medusaContainer.Env = medusaEnvVars(medusaSpec, clusterName, logger, "GRPC")
+	medusaContainer.Env = medusaEnvVars(medusaSpec, k8cName, logger, "GRPC")
 	medusaContainer.Ports = []corev1.ContainerPort{
 		{ContainerPort: 50051, Name: "grpc"},
 	}
 
-	medusaContainer.VolumeMounts = medusaVolumeMounts(medusaSpec, clusterName, logger)
+	medusaContainer.VolumeMounts = medusaVolumeMounts(medusaSpec, k8cName, logger)
 
 	if !found {
 		logger.Info("Couldn't find medusa container")
@@ -194,7 +194,7 @@ func setImage(containerImage *images.Image, container *corev1.Container) {
 	container.ImagePullPolicy = image.PullPolicy
 }
 
-func medusaVolumeMounts(medusaSpec *api.MedusaClusterTemplate, clusterName string, logger logr.Logger) []corev1.VolumeMount {
+func medusaVolumeMounts(medusaSpec *api.MedusaClusterTemplate, k8cName string, logger logr.Logger) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{ // Cassandra config volume
 			Name:      "server-config",
@@ -205,7 +205,7 @@ func medusaVolumeMounts(medusaSpec *api.MedusaClusterTemplate, clusterName strin
 			MountPath: "/var/lib/cassandra",
 		},
 		{ // Medusa config volume
-			Name:      fmt.Sprintf("%s-medusa", clusterName),
+			Name:      fmt.Sprintf("%s-medusa", k8cName),
 			MountPath: "/etc/medusa",
 		},
 		{ // Pod info volume
@@ -240,7 +240,7 @@ func medusaVolumeMounts(medusaSpec *api.MedusaClusterTemplate, clusterName strin
 	return volumeMounts
 }
 
-func medusaEnvVars(medusaSpec *api.MedusaClusterTemplate, clusterName string, logger logr.Logger, mode string) []corev1.EnvVar {
+func medusaEnvVars(medusaSpec *api.MedusaClusterTemplate, k8cName string, logger logr.Logger, mode string) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "MEDUSA_MODE",
@@ -250,7 +250,7 @@ func medusaEnvVars(medusaSpec *api.MedusaClusterTemplate, clusterName string, lo
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: CassandraUserSecretName(medusaSpec, clusterName),
+						Name: CassandraUserSecretName(medusaSpec, k8cName),
 					},
 					Key: "username",
 				},
@@ -260,7 +260,7 @@ func medusaEnvVars(medusaSpec *api.MedusaClusterTemplate, clusterName string, lo
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: CassandraUserSecretName(medusaSpec, clusterName),
+						Name: CassandraUserSecretName(medusaSpec, k8cName),
 					},
 					Key: "password",
 				},
@@ -270,15 +270,15 @@ func medusaEnvVars(medusaSpec *api.MedusaClusterTemplate, clusterName string, lo
 }
 
 // Create or update volumes for medusa
-func UpdateMedusaVolumes(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, clusterName string, logger logr.Logger) {
+func UpdateMedusaVolumes(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.MedusaClusterTemplate, k8cName string, logger logr.Logger) {
 	// Medusa config volume, containing medusa.ini
-	configVolumeIndex, found := cassandra.FindVolume(dcConfig.PodTemplateSpec, fmt.Sprintf("%s-medusa", clusterName))
+	configVolumeIndex, found := cassandra.FindVolume(dcConfig.PodTemplateSpec, fmt.Sprintf("%s-medusa", k8cName))
 	configVolume := &corev1.Volume{
-		Name: fmt.Sprintf("%s-medusa", clusterName),
+		Name: fmt.Sprintf("%s-medusa", k8cName),
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: fmt.Sprintf("%s-medusa", clusterName),
+					Name: fmt.Sprintf("%s-medusa", k8cName),
 				},
 			},
 		},

--- a/pkg/reaper/manager.go
+++ b/pkg/reaper/manager.go
@@ -45,7 +45,7 @@ func (r *restReaperManager) Connect(ctx context.Context, reaper *api.Reaper, use
 }
 
 func (r *restReaperManager) AddClusterToReaper(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) error {
-	return r.reaperClient.AddCluster(ctx, cassdc.Spec.ClusterName, cassdc.GetSeedServiceName())
+	return r.reaperClient.AddCluster(ctx, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName), cassdc.GetSeedServiceName())
 }
 
 func (r *restReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) (bool, error) {
@@ -53,5 +53,5 @@ func (r *restReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassd
 	if err != nil {
 		return false, err
 	}
-	return utils.SliceContains(clusters, cassdc.Name), nil
+	return utils.SliceContains(clusters, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName)), nil
 }

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -21,8 +21,7 @@ const (
 // DefaultResourceName generates a name for a new Reaper resource that is derived from the Cassandra cluster and DC
 // names.
 func DefaultResourceName(dc *cassdcapi.CassandraDatacenter) string {
-	// FIXME sanitize name
-	return dc.Spec.ClusterName + "-" + dc.Name + "-reaper"
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName + "-" + dc.Name + "-reaper")
 }
 
 func NewReaper(

--- a/pkg/stargate/affinity.go
+++ b/pkg/stargate/affinity.go
@@ -79,7 +79,7 @@ func computePodAntiAffinity(allowStargateOnDataNodes bool, dc *cassdcapi.Cassand
 				{
 					Key:      cassdcapi.ClusterLabel,
 					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{dc.Spec.ClusterName},
+					Values:   []string{cassdcapi.CleanLabelValue(dc.Spec.ClusterName)},
 				},
 				{
 					Key:      cassdcapi.DatacenterLabel,

--- a/pkg/stargate/config.go
+++ b/pkg/stargate/config.go
@@ -22,7 +22,7 @@ func FilterYamlConfig(config map[string]interface{}) map[string]interface{} {
 	return filteredConfig
 }
 
-func CreateStargateConfigMap(namespace string, configYaml string, dc cassdcapi.CassandraDatacenter) *corev1.ConfigMap {
+func CreateStargateConfigMap(namespace, configYaml string, dc cassdcapi.CassandraDatacenter) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GeneratedConfigMapName(dc.Spec.ClusterName, dc.Name),

--- a/pkg/stargate/config.go
+++ b/pkg/stargate/config.go
@@ -3,6 +3,7 @@ package stargate
 import (
 	"strings"
 
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ssandra "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -21,17 +22,17 @@ func FilterYamlConfig(config map[string]interface{}) map[string]interface{} {
 	return filteredConfig
 }
 
-func CreateStargateConfigMap(namespace, configYaml, clusterName, dcName string) *corev1.ConfigMap {
+func CreateStargateConfigMap(namespace string, configYaml string, dc cassdcapi.CassandraDatacenter) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GeneratedConfigMapName(clusterName, dcName),
+			Name:      GeneratedConfigMapName(dc.Spec.ClusterName, dc.Name),
 			Namespace: namespace,
 			Labels: map[string]string{
 				k8ssandra.NameLabel:                      k8ssandra.NameLabelValue,
 				k8ssandra.PartOfLabel:                    k8ssandra.PartOfLabelValue,
 				k8ssandra.ComponentLabel:                 k8ssandra.ComponentLabelValueStargate,
 				k8ssandra.CreatedByLabel:                 k8ssandra.CreatedByLabelValueK8ssandraClusterController,
-				k8ssandra.K8ssandraClusterNameLabel:      clusterName,
+				k8ssandra.K8ssandraClusterNameLabel:      dc.Labels[k8ssandra.K8ssandraClusterNameLabel],
 				k8ssandra.K8ssandraClusterNamespaceLabel: namespace,
 			},
 		},

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -234,7 +234,7 @@ func computeDNSPolicy(dc *cassdcapi.CassandraDatacenter) corev1.DNSPolicy {
 }
 
 func computeSeedServiceUrl(dc *cassdcapi.CassandraDatacenter) string {
-	return dc.Spec.ClusterName + "-seed-service." + dc.Namespace + ".svc." + clusterDomain
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName) + "-seed-service." + dc.Namespace + ".svc." + clusterDomain
 }
 
 func computeClusterVersion(dc *cassdcapi.CassandraDatacenter) ClusterVersion {
@@ -347,7 +347,7 @@ func computeVolumes(template *api.StargateTemplate, dc *cassdcapi.CassandraDatac
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: GeneratedConfigMapName(dc.ClusterName, dc.Name),
+					Name: GeneratedConfigMapName(dc.Spec.ClusterName, dc.Name),
 				},
 			},
 		},
@@ -437,5 +437,5 @@ func computeAffinity(template *api.StargateTemplate, dc *cassdcapi.CassandraData
 }
 
 func GeneratedConfigMapName(clusterName, dcName string) string {
-	return fmt.Sprintf("%s-%s", dcName, cassandraConfigMap)
+	return fmt.Sprintf("%s-%s-%s", cassdcapi.CleanupForKubernetes(clusterName), dcName, cassandraConfigMap)
 }

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -501,7 +501,7 @@ func testNewDeploymentsManyRacksFewReplicas(t *testing.T) {
 
 func testNewDeploymentsCassandraConfigMap(t *testing.T) {
 	configMapName := "cassandra-config"
-	generatedConfigMapName := "dc1-cassandra-config"
+	generatedConfigMapName := "cluster1-dc1-cassandra-config"
 
 	stargate := stargate.DeepCopy()
 	stargate.Spec.CassandraConfigMapRef = &corev1.LocalObjectReference{Name: configMapName}

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -5,16 +5,13 @@ import (
 )
 
 func ResourceName(dc *cassdcapi.CassandraDatacenter) string {
-	// FIXME sanitize name
-	return dc.Spec.ClusterName + "-" + dc.Name + "-stargate"
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName + "-" + dc.Name + "-stargate")
 }
 
 func ServiceName(dc *cassdcapi.CassandraDatacenter) string {
-	// FIXME sanitize name
-	return dc.Spec.ClusterName + "-" + dc.Name + "-stargate-service"
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName + "-" + dc.Name + "-stargate-service")
 }
 
 func DeploymentName(dc *cassdcapi.CassandraDatacenter, rack *cassdcapi.Rack) string {
-	// FIXME sanitize name
-	return dc.Spec.ClusterName + "-" + dc.Name + "-" + rack.Name + "-stargate-deployment"
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName + "-" + dc.Name + "-" + rack.Name + "-stargate-deployment")
 }

--- a/pkg/telemetry/prom_cass_servicemonitor.go
+++ b/pkg/telemetry/prom_cass_servicemonitor.go
@@ -340,7 +340,7 @@ func (cfg PrometheusResourcer) NewCassServiceMonitor() (promapi.ServiceMonitor, 
 					//"cassandra.datastax.com/prom-metrics": "true",
 				},
 				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: cassdcapi.ClusterLabel, Operator: "In", Values: []string{clusterName}},
+					{Key: cassdcapi.ClusterLabel, Operator: "In", Values: []string{cassdcapi.CleanLabelValue(clusterName)}},
 					{Key: cassdcapi.DatacenterLabel, Operator: "In", Values: []string{cfg.MonitoringTargetName}},
 				},
 			},

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -2,11 +2,12 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace string, f *framework.E2eFramework) {
@@ -69,11 +70,11 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-rack1-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-rack1-sts-0"
 	count := 6
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], dc1Namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-rack1-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-rack1-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], dc2Namespace, pod, count, 0, "-u", username, "-pw", password)
 }

--- a/test/e2e/gc_test.go
+++ b/test/e2e/gc_test.go
@@ -2,12 +2,13 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 func gcTest(gcName string) e2eTestFunc {
@@ -22,7 +23,7 @@ func gcTest(gcName string) e2eTestFunc {
 		dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc1")
 		checkDatacenterReady(t, ctx, dc1Key, f)
 
-		logs, err := f.GetContainerLogs(f.DataPlaneContexts[0], namespace, "test-dc1-default-sts-0", "server-system-logger")
+		logs, err := f.GetContainerLogs(f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-default-sts-0", "server-system-logger")
 		require.Containsf(t, logs, gcName, "Could not find %s in logs", gcName)
 
 		switch gcName {

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -28,19 +28,20 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
+	dcPrefix := DcPrefix(t, f, dcKey)
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dcPrefix+"-default-sts-0", "reaper_db")
 
 	testDeleteReaperManually(t, f, ctx, kcKey, dcKey, reaperKey)
 	testRemoveReaperFromK8ssandraCluster(t, f, ctx, kcKey, dcKey, reaperKey)
 
 	t.Log("deploying Reaper ingress routes in", f.DataPlaneContexts[0])
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, dcPrefix+"-reaper-service", reaperRestHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
@@ -59,13 +60,14 @@ func createSingleReaperWithEncryption(t *testing.T, ctx context.Context, namespa
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
+	dcPrefix := DcPrefix(t, f, dcKey)
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("deploying Reaper ingress routes in context", f.DataPlaneContexts[0])
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, dcPrefix+"-reaper-service", reaperRestHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
@@ -89,18 +91,21 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
-	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
-	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-stargate"}}
-	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-stargate"}}
+	dc1Prefix := DcPrefix(t, f, dc1Key)
+	dc2Prefix := DcPrefix(t, f, dc2Key)
 
-	t.Logf("check Stargate auth keyspace created in both clusters. DC prefixes: %s / %s ", DcPrefix(t, f, dc1Key), DcPrefix(t, f, dc2Key))
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0", stargate.AuthKeyspace)
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", DcPrefix(t, f, dc2Key)+"-default-sts-0", stargate.AuthKeyspace)
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc1Prefix + "-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc2Prefix + "-reaper"}}
+	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc1Prefix + "-stargate"}}
+	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc2Prefix + "-stargate"}}
+
+	t.Logf("check Stargate auth keyspace created in both clusters. DC prefixes: %s / %s ", dc1Prefix, dc2Prefix)
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dc1Prefix+"-default-sts-0", stargate.AuthKeyspace)
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", dc2Prefix+"-default-sts-0", stargate.AuthKeyspace)
 
 	t.Log("check Reaper custom keyspace created in both clusters")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0", "reaper_ks")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", DcPrefix(t, f, dc2Key)+"-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dc1Prefix+"-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", dc2Prefix+"-default-sts-0", "reaper_ks")
 
 	checkStargateReady(t, f, ctx, stargate1Key)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dc1Key)
@@ -119,23 +124,23 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, dc1Prefix+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, dc2Prefix+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
 	t.Log("deploying Stargate and Reaper ingress routes in all data plane clusters")
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, dc1Prefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, dc1Prefix+"-reaper-service", reaperRestHostAndPort)
 
 	stargateRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateRest
 	stargateCqlHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateCql
 	reaperRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].ReaperRest
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, dc2Prefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, dc2Prefix+"-reaper-service", reaperRestHostAndPort)
 
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
@@ -174,8 +179,11 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
-	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
+	dc1Prefix := DcPrefix(t, f, dc1Key)
+	dc2Prefix := DcPrefix(t, f, dc2Key)
+
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc1Prefix + "-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dc2Prefix + "-reaper"}}
 
 	checkReaperReady(t, f, ctx, reaper1Key)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dc1Key)
@@ -185,9 +193,9 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 
 	t.Log("deploying Stargate and Reaper ingress routes in both clusters")
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, dc1Prefix+"-reaper-service", reaperRestHostAndPort)
 	reaperRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, dc2Prefix+"-reaper-service", reaperRestHostAndPort)
 
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
@@ -210,13 +218,13 @@ func createReaperAndDatacenter(t *testing.T, ctx context.Context, namespace stri
 	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper1"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
-
+	dcPrefix := DcPrefix(t, f, dcKey)
 	t.Log("create Reaper keyspace")
-	_, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-rack1-sts-0",
+	_, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", dcPrefix+"-rack1-sts-0",
 		"CREATE KEYSPACE reaper_db WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : 3} ")
 	require.NoError(t, err, "failed to create Reaper keyspace")
 
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-rack1-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dcPrefix+"-rack1-sts-0", "reaper_db")
 
 	checkReaperReady(t, f, ctx, reaperKey)
 

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -26,9 +26,9 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
@@ -57,9 +57,9 @@ func createSingleReaperWithEncryption(t *testing.T, ctx context.Context, namespa
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
@@ -170,11 +170,12 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
-	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
+
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
 
 	checkReaperReady(t, f, ctx, reaper1Key)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dc1Key)

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
@@ -25,28 +26,28 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
 	checkReaperReady(t, f, ctx, reaperKey)
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-default-sts-0", "reaper_db")
 
 	testDeleteReaperManually(t, f, ctx, kcKey, dcKey, reaperKey)
 	testRemoveReaperFromK8ssandraCluster(t, f, ctx, kcKey, dcKey, reaperKey)
 
 	t.Log("deploying Reaper ingress routes in", f.DataPlaneContexts[0])
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-reaper-service", reaperRestHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
 		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
 		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
 		username, password := retrieveCredentials(t, f, ctx, reaperUiSecretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dcKey), "reaper_db", username, password)
 	})
 }
 
@@ -56,7 +57,7 @@ func createSingleReaperWithEncryption(t *testing.T, ctx context.Context, namespa
 
 	kcKey := types.NamespacedName{Namespace: namespace, Name: "test"}
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dcKey, f)
 	checkReaperReady(t, f, ctx, reaperKey)
@@ -64,14 +65,14 @@ func createSingleReaperWithEncryption(t *testing.T, ctx context.Context, namespa
 
 	t.Log("deploying Reaper ingress routes in context", f.DataPlaneContexts[0])
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-reaper-service", reaperRestHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
 		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
 		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
 		username, password := retrieveCredentials(t, f, ctx, reaperUiSecretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dcKey), "reaper_db", username, password)
 	})
 }
 
@@ -84,21 +85,22 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
-	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
-	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
-	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-stargate"}}
 
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
-	t.Log("check Stargate auth keyspace created in both clusters")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", stargate.AuthKeyspace)
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", "test-dc2-default-sts-0", stargate.AuthKeyspace)
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
+	stargate1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-stargate"}}
+	stargate2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-stargate"}}
+
+	t.Logf("check Stargate auth keyspace created in both clusters. DC prefixes: %s / %s ", DcPrefix(t, f, dc1Key), DcPrefix(t, f, dc2Key))
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0", stargate.AuthKeyspace)
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", DcPrefix(t, f, dc2Key)+"-default-sts-0", stargate.AuthKeyspace)
 
 	t.Log("check Reaper custom keyspace created in both clusters")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", "reaper_ks")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", "test-dc2-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0", "reaper_ks")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[1], namespace, "test", DcPrefix(t, f, dc2Key)+"-default-sts-0", "reaper_ks")
 
 	checkStargateReady(t, f, ctx, stargate1Key)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dc1Key)
@@ -117,23 +119,23 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, "test-dc1-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, "test-dc2-default-sts-0", 2, 0, "-u", username, "-pw", password)
+	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-default-sts-0", 2, 0, "-u", username, "-pw", password)
 
 	t.Log("deploying Stargate and Reaper ingress routes in all data plane clusters")
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service", reaperRestHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-reaper-service", reaperRestHostAndPort)
 
 	stargateRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateRest
 	stargateCqlHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateCql
 	reaperRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].ReaperRest
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, "test-dc2-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, "test-dc2-reaper-service", reaperRestHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-reaper-service", reaperRestHostAndPort)
 
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
@@ -141,12 +143,12 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
 		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dc1Key), "reaper_ks", username, password)
 	})
 	t.Run("TestReaperApi[1]", func(t *testing.T) {
 		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[1], "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[1], DcClusterName(t, f, dc2Key), "reaper_ks", username, password)
 	})
 
 	replication := map[string]int{"dc1": 1, "dc2": 1}
@@ -168,8 +170,8 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}}
-	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
-	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-reaper"}}
+	reaper1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-reaper"}}
+	reaper2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-reaper"}}
 
 	checkDatacenterReady(t, ctx, dc1Key, f)
 	checkDatacenterReady(t, ctx, dc2Key, f)
@@ -182,9 +184,9 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 
 	t.Log("deploying Stargate and Reaper ingress routes in both clusters")
 	reaperRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, "test-dc1-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-reaper-service", reaperRestHostAndPort)
 	reaperRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].ReaperRest
-	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, "test-dc2-reaper-service", reaperRestHostAndPort)
+	f.DeployReaperIngresses(t, ctx, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-reaper-service", reaperRestHostAndPort)
 
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
@@ -192,12 +194,12 @@ func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespac
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
 		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dc1Key), "reaper_ks", username, password)
 	})
 	t.Run("TestReaperApi[1]", func(t *testing.T) {
 		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: uiSecretKey}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[1], "test", "reaper_ks", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[1], DcClusterName(t, f, dc2Key), "reaper_ks", username, password)
 	})
 }
 
@@ -209,11 +211,11 @@ func createReaperAndDatacenter(t *testing.T, ctx context.Context, namespace stri
 	checkDatacenterReady(t, ctx, dcKey, f)
 
 	t.Log("create Reaper keyspace")
-	_, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-rack1-sts-0",
+	_, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-rack1-sts-0",
 		"CREATE KEYSPACE reaper_db WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : 3} ")
 	require.NoError(t, err, "failed to create Reaper keyspace")
 
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-rack1-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-rack1-sts-0", "reaper_db")
 
 	checkReaperReady(t, f, ctx, reaperKey)
 
@@ -226,7 +228,7 @@ func createReaperAndDatacenter(t *testing.T, ctx context.Context, namespace stri
 		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
 		secretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "reaper-ui-secret"}}
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
-		testReaperApi(t, ctx, f.DataPlaneContexts[0], "test", "reaper_db", username, password)
+		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dcKey), "reaper_db", username, password)
 	})
 }
 
@@ -350,8 +352,9 @@ func connectReaperApi(t *testing.T, ctx context.Context, k8sContext, clusterName
 }
 
 func testReaperApi(t *testing.T, ctx context.Context, k8sContext, clusterName, keyspace, username, password string) {
-	reaperClient := connectReaperApi(t, ctx, k8sContext, clusterName, username, password)
-	repairId := triggerRepair(t, ctx, clusterName, keyspace, reaperClient)
+	sanitizedClusterName := cassdcapi.CleanupForKubernetes(clusterName)
+	reaperClient := connectReaperApi(t, ctx, k8sContext, sanitizedClusterName, username, password)
+	repairId := triggerRepair(t, ctx, sanitizedClusterName, keyspace, reaperClient)
 	t.Log("Waiting for one segment to be repaired and canceling run")
 	waitForOneSegmentToBeDone(t, ctx, repairId, reaperClient)
 	err := reaperClient.AbortRepairRun(ctx, repairId)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1390,7 +1390,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 func checkDatacenterReady(t *testing.T, ctx context.Context, key framework.ClusterKey, f *framework.E2eFramework) {
 	t.Logf("check that datacenter %s in cluster %s is ready", key.Name, key.K8sContext)
 	withDatacenter := f.NewWithDatacenter(ctx, key)
-	assert.Eventually(t, withDatacenter(func(dc *cassdcapi.CassandraDatacenter) bool {
+	require.Eventually(t, withDatacenter(func(dc *cassdcapi.CassandraDatacenter) bool {
 		status := dc.GetConditionStatus(cassdcapi.DatacenterReady)
 		return status == corev1.ConditionTrue && dc.Status.CassandraOperatorProgress == cassdcapi.ProgressReady
 	}), polling.datacenterReady.timeout, polling.datacenterReady.interval, fmt.Sprintf("timed out waiting for datacenter %s to become ready", key.Name))

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -743,6 +743,7 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	require.NoError(err, "failed to upgrade to latest version")
 
 	newStargateResourceHash := GetStargateResourceHash(t, f, ctx, stargateDeploymentKey)
+	t.Logf("Stargate initial deployment resource hash: %s / Current hash: %s", initialStargateResourceHash, newStargateResourceHash)
 	if initialStargateResourceHash != newStargateResourceHash {
 		// Stargate deployment was modified after the upgrade, we need to wait for the new pod to be ready
 		t.Log("Stargate deployment updated, waiting for new pod to be ready")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -647,7 +647,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
@@ -702,7 +702,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -725,7 +725,7 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
@@ -741,7 +741,7 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -764,7 +764,7 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
@@ -775,7 +775,7 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -798,13 +798,13 @@ func createSingleDatacenterClusterReaperEncryption(t *testing.T, ctx context.Con
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-reaper"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-default-sts-0", "reaper_db")
 }
 
 // createStargateAndDatacenter creates a CassandraDatacenter with 3 nodes, one per rack. It also creates 1 or 3 Stargate
@@ -824,7 +824,7 @@ func createStargateAndDatacenter(t *testing.T, ctx context.Context, namespace st
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 3}
@@ -855,14 +855,14 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-rack1-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-rack1-sts-0"
 	count := 6
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-rack1-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-rack1-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
@@ -892,20 +892,20 @@ func createMultiDatacenterClusterDifferentTopologies(t *testing.T, ctx context.C
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-default-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-default-sts-0"
 	count := 3
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-default-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-default-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	replication := map[string]int{"dc1": 2, "dc2": 1}
-	checkKeyspaceReplication(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.Name, "test-dc1-default-sts-0",
+	checkKeyspaceReplication(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.Name, DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"system_auth", replication)
 }
 
@@ -932,7 +932,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc1-stargate",
+			Name:      DcPrefix(t, f, dc1Key) + "-stargate",
 		},
 	}
 	checkStargateReady(t, f, ctx, sg1Key)
@@ -941,18 +941,18 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc1-reaper",
+			Name:      DcPrefix(t, f, dc1Key) + "-reaper",
 		},
 	}
 	checkReaperReady(t, f, ctx, reaper1Key)
 
 	dcSize := 2
 	t.Log("create keyspaces")
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		fmt.Sprintf("CREATE KEYSPACE ks1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : %d}", dcSize))
 	require.NoError(err, "failed to create keyspace")
 
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		fmt.Sprintf("CREATE KEYSPACE ks2 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : %d}", dcSize))
 	require.NoError(err, "failed to create keyspace")
 
@@ -992,14 +992,14 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-default-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-default-sts-0"
 	count := dcSize * 2
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-default-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-default-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(err, "timed out waiting for nodetool status check against "+pod)
@@ -1007,7 +1007,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 	keyspaces := []string{"system_auth", stargate.AuthKeyspace, "ks1", "ks2"}
 	for _, ks := range keyspaces {
 		assert.Eventually(func() bool {
-			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 				fmt.Sprintf("SELECT replication FROM system_schema.keyspaces WHERE keyspace_name = '%s'", ks))
 			if err != nil {
 				t.Logf("replication check for keyspace %s failed: %v", ks, err)
@@ -1021,7 +1021,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc2-stargate",
+			Name:      DcPrefix(t, f, dc2Key) + "-stargate",
 		},
 	}
 	checkStargateReady(t, f, ctx, sg2Key)
@@ -1030,7 +1030,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc2-reaper",
+			Name:      DcPrefix(t, f, dc2Key) + "-reaper",
 		},
 	}
 	checkReaperReady(t, f, ctx, reaper2Key)
@@ -1069,14 +1069,14 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-default-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-default-sts-0"
 	count := 2
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-default-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-default-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(err, "timed out waiting for nodetool status check against "+pod)
@@ -1085,7 +1085,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc1-stargate",
+			Name:      DcPrefix(t, f, dc1Key) + "-stargate",
 		},
 	}
 	checkStargateReady(t, f, ctx, sg1Key)
@@ -1094,7 +1094,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 		K8sContext: f.DataPlaneContexts[0],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc1-reaper",
+			Name:      DcPrefix(t, f, dc1Key) + "-reaper",
 		},
 	}
 	checkReaperReady(t, f, ctx, reaper1Key)
@@ -1103,7 +1103,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc2-stargate",
+			Name:      DcPrefix(t, f, dc2Key) + "-stargate",
 		},
 	}
 	checkStargateReady(t, f, ctx, sg2Key)
@@ -1112,17 +1112,17 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 		K8sContext: f.DataPlaneContexts[1],
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
-			Name:      "test-dc2-reaper",
+			Name:      DcPrefix(t, f, dc2Key) + "-reaper",
 		},
 	}
 	checkReaperReady(t, f, ctx, reaper2Key)
 
 	t.Log("create keyspaces")
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"CREATE KEYSPACE ks1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 2}")
 	require.NoError(err, "failed to create keyspace")
 
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"CREATE KEYSPACE ks2 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 2}")
 	require.NoError(err, "failed to create keyspace")
 
@@ -1140,7 +1140,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	keyspaces := []string{"system_auth", stargate.AuthKeyspace, reaperapi.DefaultKeyspace, "ks1", "ks2"}
 	for _, ks := range keyspaces {
 		assert.Eventually(func() bool {
-			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", "test-dc1-default-sts-0",
+			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
 				fmt.Sprintf("SELECT replication FROM system_schema.keyspaces WHERE keyspace_name = '%s'", ks))
 			if err != nil {
 				t.Logf("replication check for keyspace %s failed: %v", ks, err)
@@ -1151,7 +1151,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	}
 
 	t.Log("check that nodes in dc1 do not see nodes in dc2 anymore")
-	pod = "test-dc1-default-sts-0"
+	pod = DcPrefix(t, f, dc1Key) + "-default-sts-0"
 	count = 1
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 }
@@ -1174,10 +1174,10 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	checkDatacenterReady(t, ctx, dc2Key, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
-	t.Log("check k8ssandra cluster status updated for Stargate test-dc1-stargate")
+	t.Logf("check k8ssandra cluster status updated for Stargate %s-stargate", DcPrefix(t, f, dc1Key))
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
 		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
@@ -1203,10 +1203,10 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 		return kdcStatus.Stargate.IsReady()
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval)
 
-	stargateKey = framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-stargate"}}
+	stargateKey = framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
-	t.Log("check k8ssandra cluster status updated for Stargate test-dc2-stargate")
+	t.Logf("check k8ssandra cluster status updated for Stargate %s-stargate", DcPrefix(t, f, dc2Key))
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
 		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
@@ -1237,14 +1237,14 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
-	pod := "test-dc1-rack1-sts-0"
+	pod := DcPrefix(t, f, dc1Key) + "-rack1-sts-0"
 	count := 4
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[0], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	t.Log("check nodes in dc2 see nodes in dc1")
-	pod = "test-dc2-rack1-sts-0"
+	pod = DcPrefix(t, f, dc2Key) + "-rack1-sts-0"
 	checkNodeToolStatus(t, f, f.DataPlaneContexts[1], namespace, pod, count, 0, "-u", username, "-pw", password)
 
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
@@ -1252,13 +1252,13 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[1])
 	stargateRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateRest
 	stargateCqlHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, "test-dc2-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
 
 	replication := map[string]int{"dc1": 1, "dc2": 1}
@@ -1286,10 +1286,10 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 	t.Log("check k8ssandra cluster status")
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc1-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc1Key) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
-	t.Log("check k8ssandra cluster status updated for Stargate test-dc1-stargate")
+	t.Logf("check k8ssandra cluster status updated for Stargate %s-stargate", DcPrefix(t, f, dc1Key))
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
 		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
@@ -1315,10 +1315,10 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 		return kdcStatus.Stargate.IsReady()
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval)
 
-	stargateKey = framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-dc2-stargate"}}
+	stargateKey = framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dc2Key) + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
-	t.Log("check k8ssandra cluster status updated for Stargate test-dc2-stargate")
+	t.Logf("check k8ssandra cluster status updated for Stargate %s-stargate", DcPrefix(t, f, dc2Key))
 	require.Eventually(func() bool {
 		k8ssandra := &api.K8ssandraCluster{}
 		err := f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "test"}, k8ssandra)
@@ -1351,13 +1351,13 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, "test-dc1-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dc1Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[1])
 	stargateRestHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateRest
 	stargateCqlHostAndPort = ingressConfigs[f.DataPlaneContexts[1]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, "test-dc2-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[1], namespace, DcPrefix(t, f, dc2Key)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[1], namespace)
 
 	replication := map[string]int{"dc1": 1, "dc2": 1}
@@ -1551,4 +1551,26 @@ func configureZeroLog() {
 		Out:        os.Stderr,
 		TimeFormat: zerolog.TimeFormatUnix,
 	})
+}
+
+func DcPrefix(
+	t *testing.T,
+	f *framework.E2eFramework,
+	dcKey framework.ClusterKey) string {
+	// Get the cassdc object
+	cassdc := &cassdcapi.CassandraDatacenter{}
+	err := f.Get(context.Background(), dcKey, cassdc)
+	require.NoError(t, err)
+	return framework.CleanupForKubernetes(fmt.Sprintf("%s-%s", cassdc.Spec.ClusterName, cassdc.Name))
+}
+
+func DcClusterName(
+	t *testing.T,
+	f *framework.E2eFramework,
+	dcKey framework.ClusterKey) string {
+	// Get the cassdc object
+	cassdc := &cassdcapi.CassandraDatacenter{}
+	err := f.Get(context.Background(), dcKey, cassdc)
+	require.NoError(t, err)
+	return cassdc.Spec.ClusterName
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -646,8 +646,9 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
+	dcPrefix := DcPrefix(t, f, dcKey)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
@@ -702,7 +703,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, dcPrefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -724,14 +725,15 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
+	dcPrefix := DcPrefix(t, f, dcKey)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	// Save the Stargate deployment resource hash to verify if it was modified by the upgrade.
 	// It'll allow to wait for the pod to be successfully upgraded before performing the Stargate API tests.
-	stargateDeploymentKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-default-stargate-deployment"}}
+	stargateDeploymentKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-default-stargate-deployment"}}
 	initialStargateResourceHash := GetStargateResourceHash(t, f, ctx, stargateDeploymentKey)
 	initialStargatePodNames := GetStargatePodNames(t, f, ctx, stargateDeploymentKey)
 	require.Len(initialStargatePodNames, 1, "expected 1 Stargate pod in namespace %s", namespace)
@@ -757,7 +759,7 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, dcPrefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -779,8 +781,9 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
+	dcPrefix := DcPrefix(t, f, dcKey)
 
-	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-stargate"}}
+	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
@@ -791,7 +794,7 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, dcPrefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 1}
@@ -813,14 +816,15 @@ func createSingleDatacenterClusterReaperEncryption(t *testing.T, ctx context.Con
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
+	dcPrefix := DcPrefix(t, f, dcKey)
 
-	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: DcPrefix(t, f, dcKey) + "-reaper"}}
+	reaperKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-reaper"}}
 	checkReaperReady(t, f, ctx, reaperKey)
 
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dcKey)+"-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dcPrefix+"-default-sts-0", "reaper_db")
 }
 
 // createStargateAndDatacenter creates a CassandraDatacenter with 3 nodes, one per rack. It also creates 1 or 3 Stargate
@@ -829,7 +833,7 @@ func createStargateAndDatacenter(t *testing.T, ctx context.Context, namespace st
 
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
-
+	dcPrefix := DcPrefix(t, f, dcKey)
 	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "s1"}}
 	checkStargateReady(t, f, ctx, stargateKey)
 
@@ -840,7 +844,7 @@ func createStargateAndDatacenter(t *testing.T, ctx context.Context, namespace st
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
 	stargateRestHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateRest
 	stargateCqlHostAndPort := ingressConfigs[f.DataPlaneContexts[0]].StargateCql
-	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
+	f.DeployStargateIngresses(t, f.DataPlaneContexts[0], namespace, dcPrefix+"-stargate-service", username, password, stargateRestHostAndPort, stargateCqlHostAndPort)
 	defer f.UndeployAllIngresses(t, f.DataPlaneContexts[0], namespace)
 
 	replication := map[string]int{"dc1": 3}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1613,7 +1613,7 @@ func waitForStargateUpgrade(t *testing.T, f *framework.E2eFramework, ctx context
 		}
 	}()
 
-	stargateUpgradeTimeout := time.After(10 * time.Minute)
+	stargateUpgradeTimeout := time.After(5 * time.Minute)
 	for {
 		select {
 		case newStargateResourceHash := <-stargateChan:

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1601,7 +1601,7 @@ func DcClusterName(
 }
 
 func waitForStargateUpgrade(t *testing.T, f *framework.E2eFramework, ctx context.Context, stargateDeploymentKey framework.ClusterKey, initialStargateResourceHash string) string {
-	stargateChan := make(chan string, 1)
+	stargateChan := make(chan string)
 	go func() {
 		for {
 			stargateDeploymentResourceHash := GetStargateResourceHash(t, f, ctx, stargateDeploymentKey)

--- a/test/testdata/fixtures/multi-dc-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-medusa/k8ssandra.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test
 spec:
   cassandra:
+    clusterName: "E2E Test Cluster"
     serverVersion: "4.0.0"
     serverImage: k8ssandra/cass-management-api:4.0.0
     storageConfig:

--- a/test/testdata/fixtures/multi-dc-mixed/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-mixed/k8ssandra.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test
 spec:
   cassandra:
+    clusterName: "E2E Test Cluster"
     serverVersion: "4.0.3"
     storageConfig:
       cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -33,6 +33,7 @@ spec:
       name: reaper-ui-secret # pre-existing secret with non-default name
     heapSize: 256Mi
   cassandra:
+    clusterName: "E2E Test Cluster"
     serverVersion: "4.0.1"
     datacenters:
       - metadata:

--- a/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-stargate/k8ssandra.yaml
@@ -21,6 +21,7 @@ metadata:
   name: test
 spec:
   cassandra:
+    clusterName: "E2E Test Cluster"
     serverVersion: "3.11.11"
     storageConfig:
       cassandraDataVolumeClaimSpec:

--- a/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
@@ -9,7 +9,7 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 1
+        size: 2
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard

--- a/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
@@ -9,7 +9,7 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 2
+        size: 1
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   cassandra:
     serverVersion: 3.11.11
+    clusterName: "Weird Cluster Name"
     datacenters:
       - metadata:
           name: dc1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Allows setting a cluster name override. When done so, the cassdc objects generated by K8ssandra-operator will have a different name than the K8ssandraCluster object. This permits using characters that are not accepted in Kubernetes object names (such as spaces or uppercase letters).
This is essential to allowing migration from clusters with such names.

**Which issue(s) this PR fixes**:
Fixes #496

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
