### PR TITLE
Integrate CDC into k8ssandra-operator reconciliation logic and APIs

### DIFF
--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -314,6 +314,11 @@ type DatacenterOptions struct {
 	// +optional
 	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 
+	// CDC defines the desired state for CDC integrations. It can be used to feed mutation events from Cassandra into an Apache Pulsar cluster,
+	// from where they can be expored to external systems.
+	// +optional
+	CDC *cassdcapi.CDCConfiguration `json:"cdc,omitempty"`
+
 	// Containers defines containers to be deployed in each Cassandra pod.
 	// K8ssandra-operator and cass-operator will create their own containers, which can be referenced here to override specific settings,
 	// such as mounts or resources request/limits for example.

--- a/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
@@ -1432,6 +1432,11 @@ func (in *DatacenterOptions) DeepCopyInto(out *DatacenterOptions) {
 		*out = new(telemetryv1alpha1.TelemetrySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CDC != nil {
+		in, out := &in.CDC, &out.CDC
+		*out = new(v1beta1.CDCConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]v1.Container, len(*in))

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -67,6 +67,62 @@ spec:
                     items:
                       type: string
                     type: array
+                  cdc:
+                    description: CDC defines the desired state for CDC integrations.
+                      It can be used to feed mutation events from Cassandra into an
+                      Apache Pulsar cluster, from where they can be expored to external
+                      systems.
+                    properties:
+                      cdcConcurrentProcessors:
+                        type: integer
+                      cdcPollIntervalM:
+                        type: integer
+                      cdcWorkingDir:
+                        type: string
+                      enabled:
+                        type: boolean
+                      errorCommitLogReprocessEnabled:
+                        type: boolean
+                      pulsarAuthParams:
+                        type: string
+                      pulsarAuthPluginClassName:
+                        type: string
+                      pulsarBatchDelayInMs:
+                        type: integer
+                      pulsarKeyBasedBatcher:
+                        type: boolean
+                      pulsarMaxPendingMessages:
+                        type: integer
+                      pulsarMaxPendingMessagesAcrossPartitions:
+                        type: integer
+                      pulsarServiceUrl:
+                        type: string
+                      sslAllowInsecureConnection:
+                        type: string
+                      sslCipherSuites:
+                        type: string
+                      sslEnabledProtocols:
+                        type: string
+                      sslHostnameVerificationEnable:
+                        type: string
+                      sslKeystorePassword:
+                        type: string
+                      sslKeystorePath:
+                        type: string
+                      sslProvider:
+                        type: string
+                      sslTruststorePassword:
+                        type: string
+                      sslTruststorePath:
+                        type: string
+                      sslTruststoreType:
+                        type: string
+                      topicPrefix:
+                        type: string
+                    required:
+                    - enabled
+                    - pulsarServiceUrl
+                    type: object
                   clientEncryptionStores:
                     description: Client encryption stores which are used by Cassandra
                       and Reaper.
@@ -2834,6 +2890,62 @@ spec:
                     description: Datacenters a list of the DCs in the cluster.
                     items:
                       properties:
+                        cdc:
+                          description: CDC defines the desired state for CDC integrations.
+                            It can be used to feed mutation events from Cassandra
+                            into an Apache Pulsar cluster, from where they can be
+                            expored to external systems.
+                          properties:
+                            cdcConcurrentProcessors:
+                              type: integer
+                            cdcPollIntervalM:
+                              type: integer
+                            cdcWorkingDir:
+                              type: string
+                            enabled:
+                              type: boolean
+                            errorCommitLogReprocessEnabled:
+                              type: boolean
+                            pulsarAuthParams:
+                              type: string
+                            pulsarAuthPluginClassName:
+                              type: string
+                            pulsarBatchDelayInMs:
+                              type: integer
+                            pulsarKeyBasedBatcher:
+                              type: boolean
+                            pulsarMaxPendingMessages:
+                              type: integer
+                            pulsarMaxPendingMessagesAcrossPartitions:
+                              type: integer
+                            pulsarServiceUrl:
+                              type: string
+                            sslAllowInsecureConnection:
+                              type: string
+                            sslCipherSuites:
+                              type: string
+                            sslEnabledProtocols:
+                              type: string
+                            sslHostnameVerificationEnable:
+                              type: string
+                            sslKeystorePassword:
+                              type: string
+                            sslKeystorePath:
+                              type: string
+                            sslProvider:
+                              type: string
+                            sslTruststorePassword:
+                              type: string
+                            sslTruststorePath:
+                              type: string
+                            sslTruststoreType:
+                              type: string
+                            topicPrefix:
+                              type: string
+                          required:
+                          - enabled
+                          - pulsarServiceUrl
+                          type: object
                         config:
                           description: CassandraConfig is configuration settings that
                             are applied to cassandra.yaml and the various jvm*.options
@@ -5686,8 +5798,8 @@ spec:
                                 Such volumes are automatically mounted by cass-operator
                                 into the cassandra containers.
                               items:
-                                description: AdditionalVolumes StorageConfig defines
-                                  additional storage configurations
+                                description: StorageConfig defines additional storage
+                                  configurations
                                 properties:
                                   mountPath:
                                     description: Mount path into cassandra container
@@ -12443,8 +12555,8 @@ spec:
                           properties:
                             additionalVolumes:
                               items:
-                                description: AdditionalVolumes StorageConfig defines
-                                  additional storage configurations
+                                description: StorageConfig defines additional storage
+                                  configurations
                                 properties:
                                   mountPath:
                                     description: Mount path into cassandra container
@@ -12934,8 +13046,7 @@ spec:
                           volumes are automatically mounted by cass-operator into
                           the cassandra containers.
                         items:
-                          description: AdditionalVolumes StorageConfig defines additional
-                            storage configurations
+                          description: StorageConfig defines additional storage configurations
                           properties:
                             mountPath:
                               description: Mount path into cassandra container
@@ -16167,8 +16278,7 @@ spec:
                     properties:
                       additionalVolumes:
                         items:
-                          description: AdditionalVolumes StorageConfig defines additional
-                            storage configurations
+                          description: StorageConfig defines additional storage configurations
                           properties:
                             mountPath:
                               description: Mount path into cassandra container

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -79,8 +79,6 @@ spec:
                         type: integer
                       cdcWorkingDir:
                         type: string
-                      enabled:
-                        type: boolean
                       errorCommitLogReprocessEnabled:
                         type: boolean
                       pulsarAuthParams:
@@ -96,6 +94,7 @@ spec:
                       pulsarMaxPendingMessagesAcrossPartitions:
                         type: integer
                       pulsarServiceUrl:
+                        minLength: 1
                         type: string
                       sslAllowInsecureConnection:
                         type: string
@@ -120,7 +119,6 @@ spec:
                       topicPrefix:
                         type: string
                     required:
-                    - enabled
                     - pulsarServiceUrl
                     type: object
                   clientEncryptionStores:
@@ -2902,8 +2900,6 @@ spec:
                               type: integer
                             cdcWorkingDir:
                               type: string
-                            enabled:
-                              type: boolean
                             errorCommitLogReprocessEnabled:
                               type: boolean
                             pulsarAuthParams:
@@ -2919,6 +2915,7 @@ spec:
                             pulsarMaxPendingMessagesAcrossPartitions:
                               type: integer
                             pulsarServiceUrl:
+                              minLength: 1
                               type: string
                             sslAllowInsecureConnection:
                               type: string
@@ -2943,7 +2940,6 @@ spec:
                             topicPrefix:
                               type: string
                           required:
-                          - enabled
                           - pulsarServiceUrl
                           type: object
                         config:
@@ -5798,8 +5794,8 @@ spec:
                                 Such volumes are automatically mounted by cass-operator
                                 into the cassandra containers.
                               items:
-                                description: StorageConfig defines additional storage
-                                  configurations
+                                description: AdditionalVolumes StorageConfig defines
+                                  additional storage configurations
                                 properties:
                                   mountPath:
                                     description: Mount path into cassandra container
@@ -12555,8 +12551,8 @@ spec:
                           properties:
                             additionalVolumes:
                               items:
-                                description: StorageConfig defines additional storage
-                                  configurations
+                                description: AdditionalVolumes StorageConfig defines
+                                  additional storage configurations
                                 properties:
                                   mountPath:
                                     description: Mount path into cassandra container
@@ -13046,7 +13042,8 @@ spec:
                           volumes are automatically mounted by cass-operator into
                           the cassandra containers.
                         items:
-                          description: StorageConfig defines additional storage configurations
+                          description: AdditionalVolumes StorageConfig defines additional
+                            storage configurations
                           properties:
                             mountPath:
                               description: Mount path into cassandra container
@@ -16278,7 +16275,8 @@ spec:
                     properties:
                       additionalVolumes:
                         items:
-                          description: StorageConfig defines additional storage configurations
+                          description: AdditionalVolumes StorageConfig defines additional
+                            storage configurations
                           properties:
                             mountPath:
                               description: Mount path into cassandra container

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
@@ -8275,8 +8275,8 @@ spec:
                         properties:
                           additionalVolumes:
                             items:
-                              description: StorageConfig defines additional storage
-                                configurations
+                              description: AdditionalVolumes StorageConfig defines
+                                additional storage configurations
                               properties:
                                 mountPath:
                                   description: Mount path into cassandra container

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
@@ -8275,8 +8275,8 @@ spec:
                         properties:
                           additionalVolumes:
                             items:
-                              description: AdditionalVolumes StorageConfig defines
-                                additional storage configurations
+                              description: StorageConfig defines additional storage
+                                configurations
                               properties:
                                 mountPath:
                                   description: Mount path into cassandra container

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -677,7 +677,6 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 								},
 							},
 							CDC: &cassdcapi.CDCConfiguration{
-								Enabled:          true,
 								PulsarServiceUrl: pointer.String("pulsar://test-url"),
 							},
 						},
@@ -738,7 +737,6 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.Networking, dc2.Spec.Networking)
 	assert.Equal(dc2Size, dc2.Spec.Size)
-	assert.True(dc2.Spec.CDC.Enabled)
 	assert.Equal(*dc2.Spec.CDC.PulsarServiceUrl, "pulsar://test-url")
 
 	actualConfig, err = gabs.ParseJSON(dc2.Spec.Config)

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -676,6 +676,10 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 									MaxHeapSize: parseQuantity("1024Mi"),
 								},
 							},
+							CDC: &cassdcapi.CDCConfiguration{
+								Enabled:          true,
+								PulsarServiceUrl: pointer.String("pulsar://test-url"),
+							},
 						},
 					},
 				},
@@ -734,6 +738,8 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.Networking, dc2.Spec.Networking)
 	assert.Equal(dc2Size, dc2.Spec.Size)
+	assert.True(dc2.Spec.CDC.Enabled)
+	assert.Equal(*dc2.Spec.CDC.PulsarServiceUrl, "pulsar://test-url")
 
 	actualConfig, err = gabs.ParseJSON(dc2.Spec.Config)
 	require.NoError(err, fmt.Sprintf("failed to parse dc2 config %s", dc2.Spec.Config))

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.22/go.mod h1:91uVCVzvX2QD16sMCenoxxXo6L1wJnLMX2PSufFMtF0=
+github.com/Miles-Garnsey/cass-operator v1.8.0-rc.1.0.20220617033052-cec71ffc7fac h1:W1AVgA7mScYU26n69sA+VJJCo4NyREaCp1T+7bykgCU=
+github.com/Miles-Garnsey/cass-operator v1.8.0-rc.1.0.20220617033052-cec71ffc7fac/go.mod h1:vOjZ8NP9RNua8mbrZMkXFPBO9YbwVVfnJQIS8Yf8kHU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -113,6 +113,7 @@ type DatacenterConfig struct {
 	Containers               []corev1.Container
 	InitContainers           []corev1.Container
 	ExtraVolumes             *api.K8ssandraVolumes
+	CDC                      *cassdcapi.CDCConfiguration
 }
 
 const (
@@ -175,6 +176,7 @@ func NewDatacenter(klusterKey types.NamespacedName, template *DatacenterConfig) 
 			Users:               template.Users,
 			Networking:          template.Networking,
 			PodTemplateSpec:     template.PodTemplateSpec,
+			CDC:                 template.CDC,
 		},
 	}
 
@@ -332,6 +334,10 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 		dcConfig.MgmtAPIHeap = clusterTemplate.DatacenterOptions.MgmtAPIHeap
 	} else {
 		dcConfig.MgmtAPIHeap = dcTemplate.DatacenterOptions.MgmtAPIHeap
+	}
+
+	if dcTemplate.CDC != nil {
+		dcConfig.CDC = dcTemplate.CDC
 	}
 
 	if dcTemplate.DatacenterOptions.SoftPodAntiAffinity == nil {

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -573,6 +573,20 @@ func TestNewDatacenter_Fail_NoServerVersion(t *testing.T) {
 	assert.IsType(t, DCConfigIncomplete{}, err)
 }
 
+func TestCDC(t *testing.T) {
+	template := GetDatacenterConfig()
+	template.CDC = &cassdcapi.CDCConfiguration{
+		Enabled:          true,
+		PulsarServiceUrl: pointer.String("pulsar://test-url"),
+	}
+	cassDC, err := NewDatacenter(
+		types.NamespacedName{Name: "testdc", Namespace: "test-namespace"},
+		&template,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, cassDC.Spec.CDC, template.CDC)
+}
+
 func TestDatacentersReplication(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -576,7 +576,6 @@ func TestNewDatacenter_Fail_NoServerVersion(t *testing.T) {
 func TestCDC(t *testing.T) {
 	template := GetDatacenterConfig()
 	template.CDC = &cassdcapi.CDCConfiguration{
-		Enabled:          true,
 		PulsarServiceUrl: pointer.String("pulsar://test-url"),
 	}
 	cassDC, err := NewDatacenter(


### PR DESCRIPTION
**What this PR does**:

What it says on the tin.

Note that I've modified go.mod to use my recent changes to cass-operator. We need to revert this back to using a non-snapshot release prior to merge, but this is required because the cass-operator changes aren't yet merged.

**Which issue(s) this PR fixes**:
Fixes #570 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
