### PR TITLE
Add support for Golang 1.18+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,13 @@ endif
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+# Go v1.17 and older needs to use "go get". Go v1.18 and newer needs to use "go install"
+GOLANG_MINOR_VERSION := $(shell go env GOVERSION | sed "s/^go\([0-9]*\).\([0-9]*\).\([0-9]*\)/\2/g")
+ifeq (0, $(shell test ${GOLANG_MINOR_VERSION} -lt 18))
+GO_GET_CMD="get"
+else
+GO_GET_CMD="install"
+endif
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
@@ -361,7 +368,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go ${GO_GET_CMD} $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.4.1)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
@@ -354,13 +354,6 @@ endif
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-# Go v1.17 and older needs to use "go get". Go v1.18 and newer needs to use "go install"
-GOLANG_MINOR_VERSION := $(shell go env GOVERSION | sed "s/^go\([0-9]*\).\([0-9]*\).\([0-9]*\)/\2/g")
-ifeq (0, $(shell test ${GOLANG_MINOR_VERSION} -lt 18))
-GO_GET_CMD="get"
-else
-GO_GET_CMD="install"
-endif
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
@@ -368,7 +361,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go ${GO_GET_CMD} $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Updates the Makefile to support Golang 1.18+. Specifically, it changes the `go-get-tool` function to use `go install` instead of `go get` ~when the Golang version is 1.18 or newer~.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
