### PR TITLE
Fix duplicate metrics in Prometheus SM for CassDC

### DIFF
--- a/pkg/telemetry/prom_cass_servicemonitor.go
+++ b/pkg/telemetry/prom_cass_servicemonitor.go
@@ -335,9 +335,8 @@ func (cfg PrometheusResourcer) NewCassServiceMonitor() (promapi.ServiceMonitor, 
 		Spec: promapi.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					k8ssandraapi.ManagedByLabel: "cass-operator",
-					//It appears that this label is always set true by cass-operator, so I don't think filtering on it adds any value and we should look to deprecate.
-					//"cassandra.datastax.com/prom-metrics": "true",
+					k8ssandraapi.ManagedByLabel:           "cass-operator",
+					"cassandra.datastax.com/prom-metrics": "true",
 				},
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: cassdcapi.ClusterLabel, Operator: "In", Values: []string{cassdcapi.CleanLabelValue(clusterName)}},


### PR DESCRIPTION
Fix issue where two services get scraped by prometheus (${cassandraDatacenter}-service and also ${cassandraDatacenter}-all-pods-service).

**What this PR does**:

There are two cassDC linked services, both have the following labels:

* `app.kubernetes.io/managed-by: cass-operator`
* `cassandra.datastax.com/cluster: <clustername>`
* `cassandra.datastax.com/datacenter: <dcname>`

To avoid scraping both services, `all-pods-service` also has `cassandra.datastax.com/prom-metrics=true`, but this isn't currently used in the selectors. It should be.

**Which issue(s) this PR fixes**:
Fixes #597 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
