### PR TITLE
Harmonize resource names using the cassdc cluster name as prefix if set

### DIFF
--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -184,7 +184,7 @@ func (in *K8ssandraCluster) SanitizedName() string {
 	if in.Spec.Cassandra.ClusterName != "" {
 		return cassdcapi.CleanupForKubernetes(in.Spec.Cassandra.ClusterName)
 	}
-	return in.ObjectMeta.Name
+	return in.Name
 }
 
 // +kubebuilder:object:root=true

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -181,7 +181,7 @@ func (in *K8ssandraCluster) GetInitializedDatacenters() []CassandraDatacenterTem
 
 // Name returns a sanitized version of the cassandra cluster name override if it exists, otherwise the k8c object name
 func (in *K8ssandraCluster) SanitizedName() string {
-	if in.Spec.Cassandra.ClusterName != "" {
+	if in.Spec.Cassandra != nil && in.Spec.Cassandra.ClusterName != "" {
 		return cassdcapi.CleanupForKubernetes(in.Spec.Cassandra.ClusterName)
 	}
 	return in.Name

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -179,7 +179,8 @@ func (in *K8ssandraCluster) GetInitializedDatacenters() []CassandraDatacenterTem
 	return datacenters
 }
 
-// Name returns a sanitized version of the cassandra cluster name override if it exists, otherwise the k8c object name
+// SanitizedName returns a sanitized version of the Cassandra cluster name override if it exists,
+// otherwise the k8c object name.
 func (in *K8ssandraCluster) SanitizedName() string {
 	if in.Spec.Cassandra != nil && in.Spec.Cassandra.ClusterName != "" {
 		return cassdcapi.CleanupForKubernetes(in.Spec.Cassandra.ClusterName)

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -179,6 +179,14 @@ func (in *K8ssandraCluster) GetInitializedDatacenters() []CassandraDatacenterTem
 	return datacenters
 }
 
+// Name returns a sanitized version of the cassandra cluster name override if it exists, otherwise the k8c object name
+func (in *K8ssandraCluster) SanitizedName() string {
+	if in.Spec.Cassandra.ClusterName != "" {
+		return cassdcapi.CleanupForKubernetes(in.Spec.Cassandra.ClusterName)
+	}
+	return in.ObjectMeta.Name
+}
+
 // +kubebuilder:object:root=true
 
 // K8ssandraClusterList contains a list of K8ssandraCluster

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -61,8 +61,8 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Name))
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Name))
+	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.SanitizedName()))
+	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.SanitizedName()))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -30,9 +30,9 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 		MonitoringTargetName: actualDc.Name,
 		ServiceMonitorName:   kc.SanitizedName() + "-" + actualDc.Name + "-" + "cass-servicemonitor",
 		Logger:               logger,
-		CommonLabels:         mustLabels(kc.SanitizedName(), kc.Namespace, actualDc.Name),
+		CommonLabels:         mustLabels(kc.Name, kc.Namespace, actualDc.Name),
 	}
-	logger.Info("merged TelemetrySpec constructed", "mergedSpec", mergedSpec, "cluster", kc.SanitizedName())
+	logger.Info("merged TelemetrySpec constructed", "mergedSpec", mergedSpec, "cluster", kc.Name)
 	// Confirm telemetry config is valid (e.g. Prometheus is installed if it is requested.)
 	promInstalled, err := telemetry.IsPromInstalled(remoteClient, logger)
 	if err != nil {

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -28,11 +28,11 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 	cfg := telemetry.PrometheusResourcer{
 		MonitoringTargetNS:   actualDc.Namespace,
 		MonitoringTargetName: actualDc.Name,
-		ServiceMonitorName:   kc.Name + "-" + actualDc.Name + "-" + "cass-servicemonitor",
+		ServiceMonitorName:   kc.SanitizedName() + "-" + actualDc.Name + "-" + "cass-servicemonitor",
 		Logger:               logger,
-		CommonLabels:         mustLabels(kc.Name, kc.Namespace, actualDc.Name),
+		CommonLabels:         mustLabels(kc.SanitizedName(), kc.Namespace, actualDc.Name),
 	}
-	logger.Info("merged TelemetrySpec constructed", "mergedSpec", mergedSpec, "cluster", kc.Name)
+	logger.Info("merged TelemetrySpec constructed", "mergedSpec", mergedSpec, "cluster", kc.SanitizedName())
 	// Confirm telemetry config is valid (e.g. Prometheus is installed if it is requested.)
 	promInstalled, err := telemetry.IsPromInstalled(remoteClient, logger)
 	if err != nil {

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -43,10 +43,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
 
-	cassClusterName := kc.Name
-	if kc.Spec.Cassandra.ClusterName != "" {
-		cassClusterName = kc.Spec.Cassandra.ClusterName
-	}
+	cassClusterName := kc.SanitizedName()
 
 	seeds, err := r.findSeeds(ctx, kc, cassClusterName, logger)
 	if err != nil {

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -25,7 +25,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 	// required to connect to Cassandra nodes by CQL nor JMX.
 	if kc.Spec.Cassandra.SuperuserSecretRef.Name == "" {
 		patch := client.MergeFromWithOptions(kc.DeepCopy(), client.MergeFromWithOptimisticLock{})
-		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.Name)
+		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.SanitizedName())
 		if err := r.Patch(ctx, kc, patch); err != nil {
 			if errors.IsConflict(err) {
 				return result.RequeueSoon(1 * time.Second)
@@ -33,7 +33,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 			return result.Error(fmt.Errorf("failed to set default superuser secret name: %v", err))
 		}
 
-		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.Name)
+		kc.Spec.Cassandra.SuperuserSecretRef.Name = secret.DefaultSuperuserSecretName(kc.SanitizedName())
 		logger.Info("Setting default superuser secret", "SuperuserSecretName", kc.Spec.Cassandra.SuperuserSecretRef.Name)
 	}
 
@@ -59,13 +59,13 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 				uiUserSecretRef = kc.Spec.Reaper.UiUserSecretRef
 			}
 			if cassandraUserSecretRef.Name == "" {
-				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.Name)
+				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.SanitizedName())
 			}
 			if jmxUserSecretRef.Name == "" {
-				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.Name)
+				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.SanitizedName())
 			}
 			if uiUserSecretRef.Name == "" {
-				uiUserSecretRef.Name = reaper.DefaultUiSecretName(kc.Name)
+				uiUserSecretRef.Name = reaper.DefaultUiSecretName(kc.SanitizedName())
 			}
 			kcKey := utils.GetKey(kc)
 			if err := secret.ReconcileSecret(ctx, r.Client, cassandraUserSecretRef.Name, kcKey); err != nil {

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -55,13 +55,13 @@ func NewReaper(
 		// that the k8ssandra controller created two secrets with default names, and we need to manually fill in this
 		// info in desiredReaper.Spec since it wasn't persisted in reaperTemplate.
 		if desiredReaper.Spec.CassandraUserSecretRef.Name == "" {
-			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.Name)
+			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.SanitizedName())
 		}
 		if desiredReaper.Spec.JmxUserSecretRef.Name == "" {
-			desiredReaper.Spec.JmxUserSecretRef.Name = DefaultJmxUserSecretName(kc.Name)
+			desiredReaper.Spec.JmxUserSecretRef.Name = DefaultJmxUserSecretName(kc.SanitizedName())
 		}
 		if desiredReaper.Spec.UiUserSecretRef.Name == "" {
-			desiredReaper.Spec.UiUserSecretRef.Name = DefaultUiSecretName(kc.Name)
+			desiredReaper.Spec.UiUserSecretRef.Name = DefaultUiSecretName(kc.SanitizedName())
 		}
 	}
 	// If the cluster is already initialized and some DCs are flagged as stopped, we cannot achieve QUORUM in the

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -33,7 +33,7 @@ func NewStargate(
 ) *stargateapi.Stargate {
 
 	cassandraEncryption := stargateapi.CassandraEncryption{}
-	dcConfig := cassandra.Coalesce(kc.Name, kc.Spec.Cassandra, &dcTemplate)
+	dcConfig := cassandra.Coalesce(kc.SanitizedName(), kc.Spec.Cassandra, &dcTemplate)
 
 	if cassandra.ClientEncryptionEnabled(dcConfig) {
 		logger.Info("Client encryption enabled, setting it up in Stargate")

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -66,7 +66,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], dc1Namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], dc1Namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -713,7 +713,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	checkStargateReady(t, f, ctx, stargateKey)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
@@ -775,7 +775,7 @@ func createSingleDatacenterClusterWithUpgrade(t *testing.T, ctx context.Context,
 	}
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
@@ -811,7 +811,7 @@ func createSingleDatacenterClusterWithEncryption(t *testing.T, ctx context.Conte
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])
@@ -848,7 +848,7 @@ func createSingleDatacenterClusterReaperEncryption(t *testing.T, ctx context.Con
 	checkReaperK8cStatusReady(t, f, ctx, kcKey, dcKey)
 
 	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, "test", dcPrefix+"-default-sts-0", "reaper_db")
+	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName(), dcPrefix+"-default-sts-0", "reaper_db")
 }
 
 // createStargateAndDatacenter creates a CassandraDatacenter with 3 nodes, one per rack. It also creates 1 or 3 Stargate
@@ -896,7 +896,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -933,7 +933,7 @@ func createMultiDatacenterClusterDifferentTopologies(t *testing.T, ctx context.C
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -950,7 +950,7 @@ func createMultiDatacenterClusterDifferentTopologies(t *testing.T, ctx context.C
 	assert.NoError(t, err, "timed out waiting for nodetool status check against "+pod)
 
 	replication := map[string]int{"dc1": 2, "dc2": 1}
-	checkKeyspaceReplication(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.Name, DcPrefix(t, f, dc1Key)+"-default-sts-0",
+	checkKeyspaceReplication(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"system_auth", replication)
 }
 
@@ -993,11 +993,11 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 
 	dcSize := 2
 	t.Log("create keyspaces")
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		fmt.Sprintf("CREATE KEYSPACE ks1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : %d}", dcSize))
 	require.NoError(err, "failed to create keyspace")
 
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		fmt.Sprintf("CREATE KEYSPACE ks2 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : %d}", dcSize))
 	require.NoError(err, "failed to create keyspace")
 
@@ -1033,7 +1033,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -1052,7 +1052,7 @@ func addDcToCluster(t *testing.T, ctx context.Context, namespace string, f *fram
 	keyspaces := []string{"system_auth", stargate.AuthKeyspace, "ks1", "ks2"}
 	for _, ks := range keyspaces {
 		assert.Eventually(func() bool {
-			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 				fmt.Sprintf("SELECT replication FROM system_schema.keyspaces WHERE keyspace_name = '%s'", ks))
 			if err != nil {
 				t.Logf("replication check for keyspace %s failed: %v", ks, err)
@@ -1110,7 +1110,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	checkDatacenterReady(t, ctx, dc2Key, f)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -1163,11 +1163,11 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	checkReaperReady(t, f, ctx, reaper2Key)
 
 	t.Log("create keyspaces")
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"CREATE KEYSPACE ks1 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 2}")
 	require.NoError(err, "failed to create keyspace")
 
-	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 		"CREATE KEYSPACE ks2 WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 2}")
 	require.NoError(err, "failed to create keyspace")
 
@@ -1185,7 +1185,7 @@ func removeDcFromCluster(t *testing.T, ctx context.Context, namespace string, f 
 	keyspaces := []string{"system_auth", stargate.AuthKeyspace, reaperapi.DefaultKeyspace, "ks1", "ks2"}
 	for _, ks := range keyspaces {
 		assert.Eventually(func() bool {
-			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, "test", DcPrefix(t, f, dc1Key)+"-default-sts-0",
+			output, err := f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), DcPrefix(t, f, dc1Key)+"-default-sts-0",
 				fmt.Sprintf("SELECT replication FROM system_schema.keyspaces WHERE keyspace_name = '%s'", ks))
 			if err != nil {
 				t.Logf("replication check for keyspace %s failed: %v", ks, err)
@@ -1278,7 +1278,7 @@ func checkStargateApisWithMultiDcCluster(t *testing.T, ctx context.Context, name
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("check that nodes in dc1 see nodes in dc2")
@@ -1392,7 +1392,7 @@ func checkStargateApisWithMultiDcEncryptedCluster(t *testing.T, ctx context.Cont
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval)
 
 	t.Log("retrieve database credentials")
-	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.Name)
+	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())
 	require.NoError(err, "failed to retrieve database credentials")
 
 	t.Log("deploying Stargate ingress routes in context", f.DataPlaneContexts[0])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Uses the Cassandra cluster name (sanitized) override if it exists to prefix the various resources created by K8ssandra-operator.

**Which issue(s) this PR fixes**:
Fixes #619

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
