### PR TITLE
Change reaper metrics port from health to admin

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -15,3 +15,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#641](https://github.com/k8ssandra/k8ssandra-operator/issues/641) Reaper ServiceMonitor is not properly configured

--- a/pkg/reaper/service.go
+++ b/pkg/reaper/service.go
@@ -31,6 +31,14 @@ func NewService(key types.NamespacedName, reaper *api.Reaper) *corev1.Service {
 					Type:   intstr.String,
 					StrVal: "app",
 				},
+			}, {
+				Port:     8081,
+				Name:     "admin",
+				Protocol: corev1.ProtocolTCP,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.String,
+					StrVal: "admin",
+				},
 			}},
 			Selector: labels,
 		},

--- a/pkg/reaper/service_test.go
+++ b/pkg/reaper/service_test.go
@@ -20,9 +20,9 @@ func TestNewService(t *testing.T) {
 	assert.Equal(t, createServiceAndDeploymentLabels(reaper), service.Labels)
 
 	assert.Equal(t, createServiceAndDeploymentLabels(reaper), service.Spec.Selector)
-	assert.Len(t, service.Spec.Ports, 1)
+	assert.Len(t, service.Spec.Ports, 2)
 
-	port := corev1.ServicePort{
+	appPort := corev1.ServicePort{
 		Name:     "app",
 		Protocol: corev1.ProtocolTCP,
 		Port:     8080,
@@ -31,5 +31,15 @@ func TestNewService(t *testing.T) {
 			StrVal: "app",
 		},
 	}
-	assert.Equal(t, port, service.Spec.Ports[0])
+	adminPort := corev1.ServicePort{
+		Name:     "admin",
+		Protocol: corev1.ProtocolTCP,
+		Port:     8081,
+		TargetPort: intstr.IntOrString{
+			Type:   intstr.String,
+			StrVal: "admin",
+		},
+	}
+	assert.Contains(t, service.Spec.Ports, appPort)
+	assert.Contains(t, service.Spec.Ports, adminPort)
 }

--- a/pkg/telemetry/prom_reaper_servicemonitor.go
+++ b/pkg/telemetry/prom_reaper_servicemonitor.go
@@ -20,7 +20,7 @@ spec:
   endpoints:
     - interval: 15s
       path: /prometheusMetrics
-      port: health
+      port: admin
       scheme: http
       scrapeTimeout: 15s
 `

--- a/pkg/telemetry/prom_reaper_servicemonitor_test.go
+++ b/pkg/telemetry/prom_reaper_servicemonitor_test.go
@@ -23,5 +23,5 @@ func Test_PrometheusResourcer_NewReaperServiceMonitor_SUCCESS(t *testing.T) {
 	if err != nil {
 		assert.Fail(t, "error creating new service monitor", err)
 	}
-	assert.Equal(t, "health", actualSM.Spec.Endpoints[0].Port)
+	assert.Equal(t, "admin", actualSM.Spec.Endpoints[0].Port)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes the Reaper service monitor port for Promethues metrics scraping

**Which issue(s) this PR fixes**:
Fixes #641 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
