### PR TITLE
Remove `kubebuilder:pruning:PreserveUnknownFields` annotation from `CassandraDatacenterTemplate`

### DIFF
--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -233,8 +233,6 @@ type CassandraClusterTemplate struct {
 	ClusterName string `json:"clusterName,omitempty"`
 }
 
-// +kubebuilder:pruning:PreserveUnknownFields
-
 type CassandraDatacenterTemplate struct {
 	Meta EmbeddedObjectMeta `json:"metadata,omitempty"`
 

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -13056,7 +13056,6 @@ spec:
                       required:
                       - size
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                     type: array
                   extraVolumes:
                     description: Volumes defines additional volumes to be added to


### PR DESCRIPTION
**What this PR does**:

Removes `kubebuilder:pruning:PreserveUnknownFields`, which allows CRs to skip validation and can lead to silent errors.

**Which issue(s) this PR fixes**:
#652 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
