### PR TITLE
Order datacenters by upgrade priority during reconcile

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -17,4 +17,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [FEATURE] [#657](https://github.com/k8ssandra/k8ssandra-operator/issues/657) Basic DSE Support
 * [FEATURE] [#661](https://github.com/k8ssandra/k8ssandra-operator/issues/661) Support all dse.yaml options
+* [ENHANCEMENT] [#669](https://github.com/k8ssandra/k8ssandra-operator/issues/669) Deterministic DSE upgrades
 * [BUGFIX] [#641](https://github.com/k8ssandra/k8ssandra-operator/issues/641) Reaper ServiceMonitor is not properly configured

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -441,10 +441,12 @@ func newRebuildTask(targetDc, namespace, srcDc string, numNodes int) *cassctlapi
 // The datacenters with the highest priority are first in the list.
 // The datacenters with the lowest priority are last in the list.
 func sortDatacentersByPriority(datacenters []api.CassandraDatacenterTemplate) []api.CassandraDatacenterTemplate {
-	sort.Slice(datacenters, func(i, j int) bool {
-		return dcUpgradePriority(datacenters[i]) > dcUpgradePriority(datacenters[j])
+	sortedDatacenters := make([]api.CassandraDatacenterTemplate, len(datacenters))
+	copy(sortedDatacenters, datacenters)
+	sort.Slice(sortedDatacenters, func(i, j int) bool {
+		return dcUpgradePriority(sortedDatacenters[i]) > dcUpgradePriority(sortedDatacenters[j])
 	})
-	return datacenters
+	return sortedDatacenters
 }
 
 // dcUpgradePriority returns the upgrade priority for the given datacenter.

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -3,6 +3,7 @@ package k8ssandra
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -52,7 +53,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 	}
 
 	// Reconcile CassandraDatacenter objects only
-	for idx, dcTemplate := range kc.Spec.Cassandra.Datacenters {
+	for idx, dcTemplate := range sortDatacentersByPriority(kc.Spec.Cassandra.Datacenters) {
 		if !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcTemplate.K8sContext) {
 			// ReplicatedSecret has not replicated yet, wait until it has
 			logger.Info("Waiting for replication to complete")
@@ -433,4 +434,33 @@ func newRebuildTask(targetDc, namespace, srcDc string, numNodes int) *cassctlapi
 	annotations.AddHashAnnotation(task)
 
 	return task
+}
+
+// sortDatacentersByPriority sorts the datacenters by upgrade priority.
+// The datacenters are sorted in descending order of priority.
+// The datacenters with the highest priority are first in the list.
+// The datacenters with the lowest priority are last in the list.
+func sortDatacentersByPriority(datacenters []api.CassandraDatacenterTemplate) []api.CassandraDatacenterTemplate {
+	sort.Slice(datacenters, func(i, j int) bool {
+		return dcUpgradePriority(datacenters[i]) > dcUpgradePriority(datacenters[j])
+	})
+	return datacenters
+}
+
+// dcUpgradePriority returns the upgrade priority for the given datacenter.
+func dcUpgradePriority(dc api.CassandraDatacenterTemplate) int {
+	if dc.DseWorkloads == nil {
+		// Cassandra workload
+		return 2
+	}
+
+	if dc.DseWorkloads.AnalyticsEnabled {
+		return 3
+	}
+
+	if dc.DseWorkloads.SearchEnabled {
+		return 1
+	}
+
+	return 2
 }

--- a/controllers/k8ssandra/datacenters_test.go
+++ b/controllers/k8ssandra/datacenters_test.go
@@ -1,0 +1,139 @@
+package k8ssandra
+
+import (
+	"context"
+	"testing"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/test/framework"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	analyticsWorkloadDc = api.CassandraDatacenterTemplate{
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "6.8.17",
+			DseWorkloads: &cassdcapi.DseWorkloads{
+				AnalyticsEnabled: true,
+			},
+		},
+	}
+
+	searchWorkloadDc = api.CassandraDatacenterTemplate{
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "6.8.17",
+			DseWorkloads: &cassdcapi.DseWorkloads{
+				SearchEnabled: true,
+			},
+		},
+	}
+
+	graphWorkloadDc = api.CassandraDatacenterTemplate{
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "6.8.17",
+			DseWorkloads: &cassdcapi.DseWorkloads{
+				GraphEnabled: true,
+			},
+		},
+	}
+
+	mixedWorkloadDc = api.CassandraDatacenterTemplate{
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "6.8.17",
+			DseWorkloads: &cassdcapi.DseWorkloads{
+				GraphEnabled:     true,
+				AnalyticsEnabled: true,
+			},
+		},
+	}
+
+	cassandraWorkloadDc = api.CassandraDatacenterTemplate{
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "6.8.17",
+			DseWorkloads: &cassdcapi.DseWorkloads{
+				GraphEnabled:     false,
+				AnalyticsEnabled: false,
+				SearchEnabled:    false,
+			},
+		},
+	}
+)
+
+func datacentersTest(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	t.Run("DcUpgradePriorityTest", dcUpgradePriorityTest)
+	t.Run("SortDatacentersForUpgradeTest", sortDatacentersForUpgradeTest)
+	t.Run("SortNoChangeTest", sortNoChangeTest)
+}
+
+func dcUpgradePriorityTest(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(3, dcUpgradePriority(analyticsWorkloadDc))
+	assert.Equal(1, dcUpgradePriority(searchWorkloadDc))
+	assert.Equal(2, dcUpgradePriority(graphWorkloadDc))
+	assert.Equal(3, dcUpgradePriority(mixedWorkloadDc))
+	assert.Equal(2, dcUpgradePriority(cassandraWorkloadDc))
+}
+
+func sortDatacentersForUpgradeTest(t *testing.T) {
+	assert := assert.New(t)
+
+	datacenters := []api.CassandraDatacenterTemplate{}
+	datacenters = append(datacenters, cassandraWorkloadDc)
+	datacenters = append(datacenters, analyticsWorkloadDc)
+	datacenters = append(datacenters, searchWorkloadDc)
+	datacenters = append(datacenters, graphWorkloadDc)
+	datacenters = append(datacenters, mixedWorkloadDc)
+	sortedDatacenters := sortDatacentersByPriority(datacenters)
+	assert.Equal(5, len(sortedDatacenters), "Expected 5 datacenters")
+	// The analytics enabled DCs should be first, which includes the mixed workload DC
+	assert.True(sortedDatacenters[0].DseWorkloads.AnalyticsEnabled, "Analytics workload DCs should be first")
+	assert.True(sortedDatacenters[1].DseWorkloads.AnalyticsEnabled, "Analytics workload DCs should be first")
+	// Second and third datacenters should be Cassandra and Graph only
+	assert.False(sortedDatacenters[2].DseWorkloads.AnalyticsEnabled || sortedDatacenters[2].DseWorkloads.SearchEnabled, "Analytics workload DC should be first and search should be last")
+	assert.False(sortedDatacenters[3].DseWorkloads.AnalyticsEnabled || sortedDatacenters[3].DseWorkloads.SearchEnabled, "Analytics workload DC should be first and search should be last")
+	// Search comes last
+	assert.Equal(searchWorkloadDc, sortedDatacenters[4], "Search workload DC should be last")
+}
+
+func sortNoChangeTest(t *testing.T) {
+	assert := assert.New(t)
+
+	cassandraDc1 := api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "dc1",
+		},
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "4.0.0",
+		},
+	}
+
+	cassandraDc2 := api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "dc2",
+		},
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "4.0.0",
+		},
+	}
+
+	cassandraDc3 := api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "dc3",
+		},
+		DatacenterOptions: api.DatacenterOptions{
+			ServerVersion: "4.0.0",
+		},
+	}
+
+	datacenters := []api.CassandraDatacenterTemplate{}
+	datacenters = append(datacenters, cassandraDc1)
+	datacenters = append(datacenters, cassandraDc2)
+	datacenters = append(datacenters, cassandraDc3)
+	sortedDatacenters := sortDatacentersByPriority(datacenters)
+	assert.Equal(3, len(sortedDatacenters), "Expected 3 datacenters")
+	assert.Equal("dc1", sortedDatacenters[0].Meta.Name, "Datacenter order should not change")
+	assert.Equal("dc2", sortedDatacenters[1].Meta.Name, "Datacenter order should not change")
+	assert.Equal("dc3", sortedDatacenters[2].Meta.Name, "Datacenter order should not change")
+}

--- a/controllers/k8ssandra/datacenters_test.go
+++ b/controllers/k8ssandra/datacenters_test.go
@@ -1,17 +1,18 @@
 package k8ssandra
 
 import (
-	"context"
 	"testing"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
 	analyticsWorkloadDc = api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "analytics",
+		},
 		DatacenterOptions: api.DatacenterOptions{
 			ServerVersion: "6.8.17",
 			DseWorkloads: &cassdcapi.DseWorkloads{
@@ -21,6 +22,9 @@ var (
 	}
 
 	searchWorkloadDc = api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "search",
+		},
 		DatacenterOptions: api.DatacenterOptions{
 			ServerVersion: "6.8.17",
 			DseWorkloads: &cassdcapi.DseWorkloads{
@@ -30,6 +34,9 @@ var (
 	}
 
 	graphWorkloadDc = api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "graph",
+		},
 		DatacenterOptions: api.DatacenterOptions{
 			ServerVersion: "6.8.17",
 			DseWorkloads: &cassdcapi.DseWorkloads{
@@ -39,6 +46,9 @@ var (
 	}
 
 	mixedWorkloadDc = api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "mixed",
+		},
 		DatacenterOptions: api.DatacenterOptions{
 			ServerVersion: "6.8.17",
 			DseWorkloads: &cassdcapi.DseWorkloads{
@@ -49,6 +59,9 @@ var (
 	}
 
 	cassandraWorkloadDc = api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Name: "cassandra",
+		},
 		DatacenterOptions: api.DatacenterOptions{
 			ServerVersion: "6.8.17",
 			DseWorkloads: &cassdcapi.DseWorkloads{
@@ -60,7 +73,7 @@ var (
 	}
 )
 
-func datacentersTest(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+func TestDatacenters(t *testing.T) {
 	t.Run("DcUpgradePriorityTest", dcUpgradePriorityTest)
 	t.Run("SortDatacentersForUpgradeTest", sortDatacentersForUpgradeTest)
 	t.Run("SortNoChangeTest", sortNoChangeTest)
@@ -88,13 +101,13 @@ func sortDatacentersForUpgradeTest(t *testing.T) {
 	sortedDatacenters := sortDatacentersByPriority(datacenters)
 	assert.Equal(5, len(sortedDatacenters), "Expected 5 datacenters")
 	// The analytics enabled DCs should be first, which includes the mixed workload DC
-	assert.True(sortedDatacenters[0].DseWorkloads.AnalyticsEnabled, "Analytics workload DCs should be first")
-	assert.True(sortedDatacenters[1].DseWorkloads.AnalyticsEnabled, "Analytics workload DCs should be first")
+	assert.Equal("analytics", sortedDatacenters[0].Meta.Name, "Analytics workload DCs should be first")
+	assert.Equal("mixed", sortedDatacenters[1].Meta.Name, "Analytics workload DCs should be first")
 	// Second and third datacenters should be Cassandra and Graph only
-	assert.False(sortedDatacenters[2].DseWorkloads.AnalyticsEnabled || sortedDatacenters[2].DseWorkloads.SearchEnabled, "Analytics workload DC should be first and search should be last")
-	assert.False(sortedDatacenters[3].DseWorkloads.AnalyticsEnabled || sortedDatacenters[3].DseWorkloads.SearchEnabled, "Analytics workload DC should be first and search should be last")
+	assert.Equal("cassandra", sortedDatacenters[2].Meta.Name, "Analytics workload DC should be first and search should be last")
+	assert.Equal("graph", sortedDatacenters[3].Meta.Name, "Analytics workload DC should be first and search should be last")
 	// Search comes last
-	assert.Equal(searchWorkloadDc, sortedDatacenters[4], "Search workload DC should be last")
+	assert.Equal("search", sortedDatacenters[4].Meta.Name, "Search workload DC should be last")
 }
 
 func sortNoChangeTest(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
DSE requires a specific ordering for upgrades, depending on which workload (graph, transactional, search or analytics) the DC is running.
This PR assigns a priority to each type of workload and orders datacenters reconciliation by that priority.
If no workload is assigned to the datacenters, the ordering remains unchanged.

**Which issue(s) this PR fixes**:
Fixes #669 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
