### PR TITLE
Fix no seeds error

### DIFF
--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#567](https://github.com/k8ssandra/k8ssandra-operator/issues/567) Fix no seeds error when all the Cassandra pods of a DC get restarted at once
+
 ## v1.2.0 - 2022-07-22
 
 * [CHANGE] Update to Reaper v3.2.0

--- a/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-upgrade/k8ssandra.yaml
@@ -9,7 +9,7 @@ spec:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 2
+        size: 1
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR filters out local DC seeds from the additional seed endpoints that k8ssandra-operator populates.
Having these unnecessary additional seeds led cass-operator to avoid labeling nodes as seed if all of them were terminated, as it still saw endpoints in the additional seed list (but those would be unreachable as the ip changed).
Additional seeds are only useful when expanding to a new datacenter, which requires seeds from remote datacenters only.
By removing local seeds from the additional seed list, we allow cass-operator to set local seeds and still cover expansions with remote DCs seeds in the additional endpoints.

**Which issue(s) this PR fixes**:
Fixes #567

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
