### PR TITLE
Fix cluster name excessive sanitization when it is overridden.

### DIFF
--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#675](https://github.com/k8ssandra/k8ssandra-operator/issues/675) K8ssandra is ignoring capital letters in the clusterName
 * [BUGFIX] [#567](https://github.com/k8ssandra/k8ssandra-operator/issues/567) Fix no seeds error when all the Cassandra pods of a DC get restarted at once
 
 ## v1.2.0 - 2022-07-22

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -179,13 +179,12 @@ func (in *K8ssandraCluster) GetInitializedDatacenters() []CassandraDatacenterTem
 	return datacenters
 }
 
-// SanitizedName returns a sanitized version of the Cassandra cluster name override if it exists,
-// otherwise the k8c object name.
+// SanitizedName returns a sanitized version of the name returned by CassClusterName()
 func (in *K8ssandraCluster) SanitizedName() string {
 	return cassdcapi.CleanupForKubernetes(in.CassClusterName())
 }
 
-// CassClusterName returns a sanitized version of the Cassandra cluster name override if it exists,
+// CassClusterName returns the Cassandra cluster name override if it exists,
 // otherwise the k8c object name.
 func (in *K8ssandraCluster) CassClusterName() string {
 	if in.Spec.Cassandra != nil && in.Spec.Cassandra.ClusterName != "" {

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -182,8 +182,14 @@ func (in *K8ssandraCluster) GetInitializedDatacenters() []CassandraDatacenterTem
 // SanitizedName returns a sanitized version of the Cassandra cluster name override if it exists,
 // otherwise the k8c object name.
 func (in *K8ssandraCluster) SanitizedName() string {
+	return cassdcapi.CleanupForKubernetes(in.CassClusterName())
+}
+
+// CassClusterName returns a sanitized version of the Cassandra cluster name override if it exists,
+// otherwise the k8c object name.
+func (in *K8ssandraCluster) CassClusterName() string {
 	if in.Spec.Cassandra != nil && in.Spec.Cassandra.ClusterName != "" {
-		return cassdcapi.CleanupForKubernetes(in.Spec.Cassandra.ClusterName)
+		return in.Spec.Cassandra.ClusterName
 	}
 	return in.Name
 }

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -43,7 +43,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 
 	actualDcs := make([]*cassdcapi.CassandraDatacenter, 0, len(kc.Spec.Cassandra.Datacenters))
 
-	cassClusterName := kc.SanitizedName()
+	cassClusterName := kc.CassClusterName()
 
 	seeds, err := r.findSeeds(ctx, kc, cassClusterName, logger)
 	if err != nil {

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -300,10 +300,10 @@ func createSingleDcCluster(t *testing.T, ctx context.Context, f *framework.Frame
 	}, timeout, interval)
 
 	// Check that the datacenter has the original cluster name, without sanitization.
-	// dc1 := cassdcapi.CassandraDatacenter{}
-	// err = f.Get(ctx, dcKey, &dc1)
-	// require.NoError(err, "failed to get CassandraDatacenter")
-	// require.Equal(kc.Spec.Cassandra.ClusterName, dc1.Spec.ClusterName)
+	dc1 := cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dcKey, &dc1)
+	require.NoError(err, "failed to get CassandraDatacenter")
+	require.Equal(kc.Spec.Cassandra.ClusterName, dc1.Spec.ClusterName)
 
 	// Test cluster deletion
 	t.Log("deleting K8ssandraCluster")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -681,6 +681,8 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 
 	dcKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dcKey, f)
+	// Check that the Cassandra cluster name override is passed to the cassdc without being modified
+	checkCassandraClusterName(t, ctx, k8ssandra, dcKey, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 	dcPrefix := DcPrefix(t, f, dcKey)
 	require.NoError(checkMetricsFiltersPresence(t, ctx, f, dcKey))
@@ -1811,4 +1813,13 @@ func findContainerInPod(t *testing.T, pod corev1.Pod, containerName string) (ind
 		}
 	}
 	return -1, false
+}
+
+func checkCassandraClusterName(t *testing.T, ctx context.Context, k8ssandra *api.K8ssandraCluster, dcKey framework.ClusterKey, f *framework.E2eFramework) {
+	t.Logf("check that the cassdc object has the right overriden cluster name, without any modification: %s", k8ssandra.Spec.Cassandra.ClusterName)
+	cassdc := &cassdcapi.CassandraDatacenter{}
+	err := f.Get(ctx, dcKey, cassdc)
+	require.NoError(t, err, "failed to get cassdc object")
+
+	require.Equal(t, k8ssandra.Spec.Cassandra.ClusterName, cassdc.Spec.ClusterName, "cassdc cluster name is not the expected one")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Avoids sanitizing the cluster name when creating the cassdc, allowing the Cassandra cluster name to retain non k8s compliant characters.

**Which issue(s) this PR fixes**:
Fixes #675 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
