### PR TITLE
Remove dc

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -17,6 +17,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [FEATURE] [#657](https://github.com/k8ssandra/k8ssandra-operator/issues/657) Basic DSE Support
 * [FEATURE] [#661](https://github.com/k8ssandra/k8ssandra-operator/issues/661) Support all dse.yaml options
+* [ENHANCEMENT] [#699](https://github.com/k8ssandra/k8ssandra-operator/issues/699) Prevent DC decommission if user keyspaces are replicated to it
 * [ENHANCEMENT] [#695](https://github.com/k8ssandra/k8ssandra-operator/issues/695) Support DSE multi DC clusters
 * [ENHANCEMENT] [#669](https://github.com/k8ssandra/k8ssandra-operator/issues/669) Deterministic DSE upgrades
 * [BUGFIX] [#696](https://github.com/k8ssandra/k8ssandra-operator/issues/696) Upgrade datacenters sequentially instead of concurrently

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -85,6 +85,9 @@ type K8ssandraClusterStatus struct {
 	//
 	// TODO Figure out how to inline this field
 	Datacenters map[string]K8ssandraStatus `json:"datacenters,omitempty"`
+
+	// +kubebuilder:default=None
+	Error string `json:"error,omitempty"`
 }
 
 type K8ssandraClusterConditionType string
@@ -123,6 +126,7 @@ type K8ssandraStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=k8ssandraclusters,shortName=k8c;k8cs
+// +kubebuilder:printcolumn:name="Error",type=string,JSONPath=".status.error",description="Latest reconcile error"
 
 // K8ssandraCluster is the Schema for the k8ssandraclusters API. The K8ssandraCluster CRD name is also the name of the
 // Cassandra cluster (which corresponds to cluster_name in cassandra.yaml).

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -18,7 +18,12 @@ spec:
     singular: k8ssandracluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Latest reconcile error
+      jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: K8ssandraCluster is the Schema for the k8ssandraclusters API.
@@ -25247,6 +25252,9 @@ spec:
                   but when I do it won't serialize. \n TODO Figure out how to inline
                   this field"
                 type: object
+              error:
+                default: None
+                type: string
             type: object
         type: object
     served: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:

--- a/controllers/k8ssandra/add_dc_test.go
+++ b/controllers/k8ssandra/add_dc_test.go
@@ -39,7 +39,8 @@ func addDc(t *testing.T, ctx context.Context, f *framework.Framework, namespace 
 	t.Run("SchemaDisagreementOnSystemKeyspaces", addDcTest(ctx, f, schemaDisagreementOnSystemKeyspaces, true))
 	t.Run("SchemaDisagreementOnStargate", addDcTest(ctx, f, schemaDisagreementOnStargate, true))
 	t.Run("ConfigureSrcDcForRebuild", addDcTest(ctx, f, configureSrcDcForRebuild, false))
-	t.Run("DeleteDcWithUserKeyspaces", addDcTest(ctx, f, deleteDcWithUserKeyspaces, false))
+	t.Run("DeleteDcWithUserKeyspacesFails", addDcTest(ctx, f, deleteDcWithUserKeyspacesFails, false))
+	t.Run("DeleteDcWithUserKeyspacesSucceeds", addDcTest(ctx, f, deleteDcWithUserKeyspacesSucceeds, false))
 	t.Run("DeleteDcWithStargateAndReaper", addDcTest(ctx, f, deleteDcWithStargateAndReaper, false))
 }
 

--- a/controllers/k8ssandra/cleanup.go
+++ b/controllers/k8ssandra/cleanup.go
@@ -3,6 +3,7 @@ package k8ssandra
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -461,7 +461,7 @@ func dcUpgradePriority(dc api.CassandraDatacenterTemplate) int {
 }
 
 func (r *K8ssandraClusterReconciler) removeRebuildDcAnnotation(kc *api.K8ssandraCluster, ctx context.Context) result.ReconcileResult {
-	patch := client.MergeFromWithOptions(kc.DeepCopy())
+	patch := client.MergeFrom(kc.DeepCopy())
 	delete(kc.Annotations, api.RebuildDcAnnotation)
 	if err := r.Client.Patch(ctx, kc, patch); err != nil {
 		err = fmt.Errorf("failed to remove %s annotation: %v", api.RebuildDcAnnotation, err)

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -18,7 +18,6 @@ package k8ssandra
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -96,7 +95,6 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			r.Recorder.Event(kc, core.EventTypeWarning, "Reconcile Error", err.Error())
 		} else {
 			kc.Status.Error = "None"
-			r.Recorder.Event(kc, core.EventTypeNormal, "Updated", fmt.Sprintf("Updated K8ssandraCluster %s/%s", kc.Namespace, kc.Name))
 		}
 		if patchErr := r.Status().Patch(ctx, kc, patch); patchErr != nil {
 			logger.Error(patchErr, "failed to update k8ssandracluster status")

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -87,7 +87,7 @@ func (r *K8ssandraClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	kc = kc.DeepCopy()
-	patch := client.MergeFromWithOptions(kc.DeepCopy())
+	patch := client.MergeFrom(kc.DeepCopy())
 	result, err := r.reconcile(ctx, kc, logger)
 	if kc.GetDeletionTimestamp() == nil {
 		if err != nil {

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -83,6 +83,7 @@ func TestK8ssandraCluster(t *testing.T) {
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApiFactory,
+			Recorder:         mgr.GetEventRecorderFor("k8ssandracluster-controller"),
 		}).SetupWithManager(mgr, clusters)
 		return err
 	})

--- a/controllers/k8ssandra/remove_dc_test.go
+++ b/controllers/k8ssandra/remove_dc_test.go
@@ -51,7 +51,6 @@ func deleteDcWithUserKeyspacesFails(ctx context.Context, t *testing.T, f *framew
 
 	for _, ks := range userKeyspaces {
 		mockMgmtApi.On(testutils.GetKeyspaceReplication, ks).Return(replicationStr, nil)
-		//mockMgmtApi.On(testutils.AlterKeyspace, ks, updatedReplication).Return(nil)
 	}
 
 	adapter := func(ctx context.Context, datacenter *cassdcapi.CassandraDatacenter, client client.Client, logger logr.Logger) (cassandra.ManagementApiFacade, error) {

--- a/controllers/k8ssandra/remove_dc_test.go
+++ b/controllers/k8ssandra/remove_dc_test.go
@@ -2,6 +2,7 @@ package k8ssandra
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -26,9 +27,8 @@ const (
 	cassdcFinalizer = "finalizer.cassandra.datastax.com"
 )
 
-func deleteDcWithUserKeyspaces(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
+func deleteDcWithUserKeyspacesFails(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
 	require := require.New(t)
-	//assert := assert.New(t)
 
 	replication := map[string]int{"dc1": 3, "dc2": 3}
 	updatedReplication := map[string]int{"dc1": 3}
@@ -36,6 +36,63 @@ func deleteDcWithUserKeyspaces(ctx context.Context, t *testing.T, f *framework.F
 	// We need a version of the map with string values because GetKeyspaceReplication returns
 	// a map[string]string.
 	replicationStr := map[string]string{"class": cassandra.NetworkTopology, "dc1": "3", "dc2": "3"}
+
+	userKeyspaces := []string{"ks1", "ks2"}
+
+	mockMgmtApi := testutils.NewFakeManagementApiFacade()
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_auth", replication).Return(nil)
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_auth", updatedReplication).Return(nil)
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_distributed", replication).Return(nil)
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_distributed", updatedReplication).Return(nil)
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_traces", replication).Return(nil)
+	mockMgmtApi.On(testutils.EnsureKeyspaceReplication, "system_traces", updatedReplication).Return(nil)
+	mockMgmtApi.On(testutils.ListKeyspaces, "").Return(userKeyspaces, nil)
+	mockMgmtApi.On(testutils.GetSchemaVersions).Return(map[string][]string{"fake": {"test"}}, nil)
+
+	for _, ks := range userKeyspaces {
+		mockMgmtApi.On(testutils.GetKeyspaceReplication, ks).Return(replicationStr, nil)
+		//mockMgmtApi.On(testutils.AlterKeyspace, ks, updatedReplication).Return(nil)
+	}
+
+	adapter := func(ctx context.Context, datacenter *cassdcapi.CassandraDatacenter, client client.Client, logger logr.Logger) (cassandra.ManagementApiFacade, error) {
+		return mockMgmtApi, nil
+	}
+	managementApiFactory.SetAdapter(adapter)
+
+	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: kc.Namespace, Name: "dc2"}, K8sContext: f.DataPlaneContexts[1]}
+
+	addDatacenterFinalizer(ctx, t, f, dc2Key)
+
+	kcKey := utils.GetKey(kc)
+
+	err := f.Client.Get(ctx, kcKey, kc)
+	require.NoError(err, "failed to get K8ssandraCluster")
+
+	t.Log("remove dc2 from k8ssandraCluster spec")
+	kc.Spec.Cassandra.Datacenters = kc.Spec.Cassandra.Datacenters[:1]
+	err = f.Client.Update(ctx, kc)
+	require.NoError(err, "failed to remove dc2 from K8ssandraCluster spec")
+
+	t.Log("verify that dc2 removal generates an error")
+	require.Eventually(func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(kc.Status.Error, "cannot decommission DC dc2")
+	}, timeout, interval, "expected error on dc2 removal not found")
+
+}
+
+func deleteDcWithUserKeyspacesSucceeds(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
+	require := require.New(t)
+
+	replication := map[string]int{"dc1": 3}
+	updatedReplication := map[string]int{"dc1": 3}
+
+	// We need a version of the map with string values because GetKeyspaceReplication returns
+	// a map[string]string.
+	replicationStr := map[string]string{"class": cassandra.NetworkTopology, "dc1": "3"}
 
 	userKeyspaces := []string{"ks1", "ks2"}
 
@@ -75,6 +132,15 @@ func deleteDcWithUserKeyspaces(ctx context.Context, t *testing.T, f *framework.F
 
 	assertDecommissionAnnotationAdded(ctx, t, f, dc2Key)
 
+	t.Log("verify that dc2 removal generates no error")
+	require.Eventually(func() bool {
+		err := f.Client.Get(ctx, kcKey, kc)
+		if err != nil {
+			return false
+		}
+		return kc.Status.Error == "None"
+	}, timeout, interval, "unexpected error on dc2 removal found")
+
 	// Make sure the status isn't updated too soon
 	assertDatacenterInClusterStatus(ctx, t, f, kcKey, dc2Key)
 
@@ -83,12 +149,6 @@ func deleteDcWithUserKeyspaces(ctx context.Context, t *testing.T, f *framework.F
 	f.AssertObjectDoesNotExist(ctx, t, dc2Key, &cassdcapi.CassandraDatacenter{}, timeout, interval)
 
 	assertDatacenterRemovedFromClusterStatus(ctx, t, f, kcKey, dc2Key)
-
-	verifyReplicationOfSystemKeyspacesUpdated(t, mockMgmtApi, replication, updatedReplication)
-
-	for _, ks := range userKeyspaces {
-		verifyKeyspaceReplicationAltered(t, mockMgmtApi, ks, updatedReplication)
-	}
 }
 
 func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
@@ -99,7 +159,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 
 	// We need a version of the map with string values because GetKeyspaceReplication returns
 	// a map[string]string.
-	replicationStr := map[string]string{"class": cassandra.NetworkTopology, "dc1": "3", "dc2": "3"}
+	updatedReplicationStr := map[string]string{"class": cassandra.NetworkTopology, "dc1": "3"}
 
 	userKeyspaces := []string{"ks1", "ks2"}
 
@@ -119,8 +179,7 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	mockMgmtApi.On(testutils.GetSchemaVersions).Return(map[string][]string{"fake": {"test"}}, nil)
 
 	for _, ks := range userKeyspaces {
-		mockMgmtApi.On(testutils.GetKeyspaceReplication, ks).Return(replicationStr, nil)
-		mockMgmtApi.On(testutils.AlterKeyspace, ks, updatedReplication).Return(nil)
+		mockMgmtApi.On(testutils.GetKeyspaceReplication, ks).Return(updatedReplicationStr, nil)
 	}
 
 	adapter := func(ctx context.Context, datacenter *cassdcapi.CassandraDatacenter, client client.Client, logger logr.Logger) (cassandra.ManagementApiFacade, error) {
@@ -237,10 +296,6 @@ func deleteDcWithStargateAndReaper(ctx context.Context, t *testing.T, f *framewo
 	f.AssertObjectDoesNotExist(ctx, t, reaper2Key, &reaperapi.Reaper{}, timeout, interval)
 
 	verifyReplicationOfInternalKeyspacesUpdated(t, mockMgmtApi, replication, updatedReplication)
-
-	for _, ks := range userKeyspaces {
-		verifyKeyspaceReplicationAltered(t, mockMgmtApi, ks, updatedReplication)
-	}
 }
 
 func assertDecommissionAnnotationAdded(ctx context.Context, t *testing.T, f *framework.Framework, dcKey framework.ClusterKey) {

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -78,6 +78,7 @@ func setupBackupTestEnv(t *testing.T, ctx context.Context) *testutils.MultiClust
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApi,
+			Recorder:         controlPlaneMgr.GetEventRecorderFor("k8ssandracluster-controller"),
 		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err
@@ -137,6 +138,7 @@ func setupRestoreTestEnv(t *testing.T, ctx context.Context) *testutils.MultiClus
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApi,
+			Recorder:         controlPlaneMgr.GetEventRecorderFor("cassandrabackup-controller"),
 		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err
@@ -205,6 +207,7 @@ func setupMedusaBackupTestEnv(t *testing.T, ctx context.Context) *testutils.Mult
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApi,
+			Recorder:         controlPlaneMgr.GetEventRecorderFor("cassandrabackup-controller"),
 		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err
@@ -266,6 +269,7 @@ func setupMedusaRestoreJobTestEnv(t *testing.T, ctx context.Context) *testutils.
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApi,
+			Recorder:         controlPlaneMgr.GetEventRecorderFor("cassandrabackup-controller"),
 		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err
@@ -336,6 +340,7 @@ func setupMedusaTaskTestEnv(t *testing.T, ctx context.Context) *testutils.MultiC
 			Scheme:           scheme.Scheme,
 			ClientCache:      clientCache,
 			ManagementApi:    managementApi,
+			Recorder:         controlPlaneMgr.GetEventRecorderFor("cassandrabackup-controller"),
 		}).SetupWithManager(controlPlaneMgr, clusters)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func main() {
 			Scheme:           mgr.GetScheme(),
 			ClientCache:      clientCache,
 			ManagementApi:    cassandra.NewManagementApiFactory(),
+			Recorder:         mgr.GetEventRecorderFor("k8ssandracluster-controller"),
 		}).SetupWithManager(mgr, additionalClusters); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "K8ssandraCluster")
 			os.Exit(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Prevents DC decommission if user keyspaces are still replicated to it.
This PR also adds event creation at the end of a reconcile. The event will contain the error message if the reconcile failed.
Additionally, the error message will be stored in a new `.spec.error` field which is displayed when running `kubectl get k8c` commands, thanks to the kubebuilder printcolumn annotation.

**Which issue(s) this PR fixes**:
Fixes #699 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
