### PR TITLE
Disallow rack name change of a live cluster

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#728](https://github.com/k8ssandra/k8ssandra-operator/issues/728) Add token generation utility
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration
   [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
+* [ENHANCEMENT] [#667](https://github.com/k8ssandra/k8ssandra-operator/issues/667) Disallow rack name change of a live cluster

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -532,6 +532,20 @@ func ValidateConfig(desiredDc, actualDc *cassdcapi.CassandraDatacenter) error {
 		return fmt.Errorf("tried to change num_tokens in an existing datacenter")
 	}
 
+	desiredRacks := desiredDc.GetRacks()
+	actualRacks := actualDc.GetRacks()
+	if len(desiredRacks) < len(actualRacks) {
+		return fmt.Errorf("number of racks can't be lowered (current=%d, desired=%d)",
+			len(actualRacks), len(desiredRacks))
+	}
+	for i, actualRack := range actualRacks {
+		desiredRack := desiredRacks[i]
+		if desiredRack.Name != actualRack.Name {
+			return fmt.Errorf("racks can't be renamed (index %d, current=%s, desired=%s)",
+				i, actualRack.Name, desiredRack.Name)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does**:
Add checks in the webhook and controller that no racks are deleted, and the rack names do not change (according to the declaration order).

**Which issue(s) this PR fixes**:
Fixes #667

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
