### PR TITLE
Don't restart whole Cassandra 4 DC when Stargate is added or removed

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -22,3 +22,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration
   [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
+* [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -718,7 +718,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("delete Stargate in k8ssandracluster resource")
 	err = f.Client.Get(ctx, kcKey, k8ssandra)
 	require.NoError(err, "failed to get K8ssandraCluster in namespace %s", namespace)
-	dcLastRestart := k8ssandra.Status.Datacenters["dc1"].Cassandra.LastRollingRestart
+	dcGeneration := k8ssandra.Status.Datacenters["dc1"].Cassandra.ObservedGeneration
 	patch := client.MergeFromWithOptions(k8ssandra.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	stargateTemplate := k8ssandra.Spec.Cassandra.Datacenters[0].Stargate
 	k8ssandra.Spec.Cassandra.Datacenters[0].Stargate = nil
@@ -745,7 +745,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("check that Cassandra DC was not restarted")
 	err = f.Client.Get(ctx, kcKey, k8ssandra)
 	require.NoError(err, "failed to get K8ssandraCluster in namespace %s", namespace)
-	require.Equal(dcLastRestart, k8ssandra.Status.Datacenters["dc1"].Cassandra.LastRollingRestart)
+	require.Equal(dcGeneration, k8ssandra.Status.Datacenters["dc1"].Cassandra.ObservedGeneration)
 
 	t.Log("re-create Stargate in k8ssandracluster resource")
 	err = f.Client.Get(ctx, kcKey, k8ssandra)
@@ -759,7 +759,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	t.Log("check that Cassandra DC was not restarted")
 	err = f.Client.Get(ctx, kcKey, k8ssandra)
 	require.NoError(err, "failed to get K8ssandraCluster in namespace %s", namespace)
-	require.Equal(dcLastRestart, k8ssandra.Status.Datacenters["dc1"].Cassandra.LastRollingRestart)
+	require.Equal(dcGeneration, k8ssandra.Status.Datacenters["dc1"].Cassandra.ObservedGeneration)
 
 	t.Log("retrieve database credentials")
 	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], namespace, k8ssandra.SanitizedName())


### PR DESCRIPTION
**What this PR does**:
Always set `AllowAlterRfDuringRangeMovement` for Cassandra 4 (not just when there are Stargate nodes).
Otherwise adding/removing Stargate node triggers a configuration change and a restart of the DC.

**Which issue(s) this PR fixes**:
Fixes #714

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
