### PR TITLE
Use Cassandra internals for JMX authentication

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -16,6 +16,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
+* [ENHANCEMENT] [#323](https://github.com/k8ssandra/k8ssandra/issues/323) Use Cassandra internals for JMX authentication
 * [ENHANCEMENT] [#770](https://github.com/k8ssandra/k8ssandra-operator/issues/770) Update to Go 1.19 and Operator SDK 1.25.2
 * [ENHANCEMENT] [#525](https://github.com/k8ssandra/k8ssandra-operator/issues/525) Deep-merge cluster- and dc-level templates
 * [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -49,8 +49,8 @@ type ReaperTemplate struct {
 	// +optional
 	CassandraUserSecretRef corev1.LocalObjectReference `json:"cassandraUserSecretRef,omitempty"`
 
-	// +kubebuilder:deprecatedversion:warning="JMX security is now based on CQL roles. Reaper will use
-	// cassandraUsefSecretRef for authentication, JmxUserSecretRef is now ignored."
+	// Defines the username and password that Reaper will use to authenticate JMX connections to Cassandra clusters.
+	// +kubebuilder:deprecatedversion:warning="JMX security is now based on CQL roles. Reaper will use CassandraUsefSecretRef for authentication, JmxUserSecretRef is now ignored."
 	// +optional
 	JmxUserSecretRef corev1.LocalObjectReference `json:"jmxUserSecretRef,omitempty"`
 

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -49,11 +49,8 @@ type ReaperTemplate struct {
 	// +optional
 	CassandraUserSecretRef corev1.LocalObjectReference `json:"cassandraUserSecretRef,omitempty"`
 
-	// Defines the username and password that Reaper will use to authenticate JMX connections to Cassandra clusters.
-	// These credentials will be automatically passed to each Cassandra node in the datacenter, as well as to the Reaper
-	// instance, so that the latter can authenticate against the former. If JMX authentication is not required, leave
-	// this field empty. The secret must be in the same namespace as Reaper itself and must contain two keys: "username"
-	// and "password".
+	// Deprecated: JMX security is now based on CQL roles. Reaper will use cassandraUsefSecretRef for authentication,
+	// this field is ignored.
 	// +optional
 	JmxUserSecretRef corev1.LocalObjectReference `json:"jmxUserSecretRef,omitempty"`
 

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -49,9 +49,8 @@ type ReaperTemplate struct {
 	// +optional
 	CassandraUserSecretRef corev1.LocalObjectReference `json:"cassandraUserSecretRef,omitempty"`
 
-	// Defines the username and password that Reaper will use to authenticate JMX connections to Cassandra clusters.
-	// +kubebuilder:deprecatedversion:warning="JMX security is now based on CQL roles. Reaper will use CassandraUsefSecretRef for authentication, JmxUserSecretRef is now ignored."
-	// +optional
+	// Deprecated: JMX security is now based on CQL roles. Reaper will use cassandraUsefSecretRef for authentication,
+	// this field is ignored.
 	JmxUserSecretRef corev1.LocalObjectReference `json:"jmxUserSecretRef,omitempty"`
 
 	// Defines the secret which contains the username and password for the Reaper UI and REST API authentication.

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -49,8 +49,8 @@ type ReaperTemplate struct {
 	// +optional
 	CassandraUserSecretRef corev1.LocalObjectReference `json:"cassandraUserSecretRef,omitempty"`
 
-	// Deprecated: JMX security is now based on CQL roles. Reaper will use cassandraUsefSecretRef for authentication,
-	// this field is ignored.
+	// +kubebuilder:deprecatedversion:warning="JMX security is now based on CQL roles. Reaper will use
+	// cassandraUsefSecretRef for authentication, JmxUserSecretRef is now ignored."
 	// +optional
 	JmxUserSecretRef corev1.LocalObjectReference `json:"jmxUserSecretRef,omitempty"`
 

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -17243,9 +17243,8 @@ spec:
                         type: object
                     type: object
                   jmxUserSecretRef:
-                    description: 'Deprecated: JMX security is now based on CQL roles.
-                      Reaper will use cassandraUsefSecretRef for authentication, this
-                      field is ignored.'
+                    description: Defines the username and password that Reaper will
+                      use to authenticate JMX connections to Cassandra clusters.
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -17243,8 +17243,9 @@ spec:
                         type: object
                     type: object
                   jmxUserSecretRef:
-                    description: Defines the username and password that Reaper will
-                      use to authenticate JMX connections to Cassandra clusters.
+                    description: 'Deprecated: JMX security is now based on CQL roles.
+                      Reaper will use cassandraUsefSecretRef for authentication, this
+                      field is ignored.'
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -17243,14 +17243,9 @@ spec:
                         type: object
                     type: object
                   jmxUserSecretRef:
-                    description: 'Defines the username and password that Reaper will
-                      use to authenticate JMX connections to Cassandra clusters. These
-                      credentials will be automatically passed to each Cassandra node
-                      in the datacenter, as well as to the Reaper instance, so that
-                      the latter can authenticate against the former. If JMX authentication
-                      is not required, leave this field empty. The secret must be
-                      in the same namespace as Reaper itself and must contain two
-                      keys: "username" and "password".'
+                    description: 'Deprecated: JMX security is now based on CQL roles.
+                      Reaper will use cassandraUsefSecretRef for authentication, this
+                      field is ignored.'
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1360,8 +1360,9 @@ spec:
                     type: object
                 type: object
               jmxUserSecretRef:
-                description: Defines the username and password that Reaper will use
-                  to authenticate JMX connections to Cassandra clusters.
+                description: 'Deprecated: JMX security is now based on CQL roles.
+                  Reaper will use cassandraUsefSecretRef for authentication, this
+                  field is ignored.'
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1360,9 +1360,8 @@ spec:
                     type: object
                 type: object
               jmxUserSecretRef:
-                description: 'Deprecated: JMX security is now based on CQL roles.
-                  Reaper will use cassandraUsefSecretRef for authentication, this
-                  field is ignored.'
+                description: Defines the username and password that Reaper will use
+                  to authenticate JMX connections to Cassandra clusters.
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1360,13 +1360,9 @@ spec:
                     type: object
                 type: object
               jmxUserSecretRef:
-                description: 'Defines the username and password that Reaper will use
-                  to authenticate JMX connections to Cassandra clusters. These credentials
-                  will be automatically passed to each Cassandra node in the datacenter,
-                  as well as to the Reaper instance, so that the latter can authenticate
-                  against the former. If JMX authentication is not required, leave
-                  this field empty. The secret must be in the same namespace as Reaper
-                  itself and must contain two keys: "username" and "password".'
+                description: 'Deprecated: JMX security is now based on CQL roles.
+                  Reaper will use cassandraUsefSecretRef for authentication, this
+                  field is ignored.'
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -62,7 +62,6 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
 	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.SanitizedName()))
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.SanitizedName()))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
@@ -129,8 +128,7 @@ func createSingleDcClusterNoAuth(t *testing.T, ctx context.Context, f *framework
 
 	t.Log("check that authentication is disabled in Reaper CRD")
 	require.Eventually(t, withReaper(func(r *reaperapi.Reaper) bool {
-		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{} &&
-			r.Spec.JmxUserSecretRef == corev1.LocalObjectReference{}
+		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{}
 	}), timeout, interval)
 
 	t.Log("deleting K8ssandraCluster")
@@ -182,7 +180,6 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 	verifyFinalizerAdded(ctx, t, f, kcKey.NamespacedName)
 	verifySuperuserSecretCreated(ctx, t, f, kc)
 	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Name))
-	verifySecretCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Name))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
@@ -258,8 +255,7 @@ func createSingleDcClusterAuth(t *testing.T, ctx context.Context, f *framework.F
 
 	t.Log("check that authentication is enabled in Reaper CRD")
 	require.Eventually(t, withReaper(func(r *reaperapi.Reaper) bool {
-		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultUserSecretName("cluster1")} &&
-			r.Spec.JmxUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultJmxUserSecretName("cluster1")}
+		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultUserSecretName("cluster1")}
 	}), timeout, interval)
 
 	t.Log("deleting K8ssandraCluster")

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -293,7 +293,6 @@ func createSingleDcClusterAuthExternalSecrets(t *testing.T, ctx context.Context,
 
 	// verify not created
 	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultUserSecretName(kc.Name))
-	verifySecretNotCreated(ctx, t, f, kc.Namespace, reaper.DefaultJmxUserSecretName(kc.Name))
 	verifyReplicatedSecretNotReconciled(ctx, t, f, kc)
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
@@ -362,8 +361,7 @@ func createSingleDcClusterAuthExternalSecrets(t *testing.T, ctx context.Context,
 
 	t.Log("check that authentication is enabled in Reaper CRD")
 	require.Never(t, withReaper(func(r *reaperapi.Reaper) bool {
-		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultUserSecretName("cluster1")} ||
-			r.Spec.JmxUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultJmxUserSecretName("cluster1")}
+		return r.Spec.CassandraUserSecretRef == corev1.LocalObjectReference{Name: reaper.DefaultUserSecretName("cluster1")}
 	}), timeout, interval)
 
 	t.Log("deleting K8ssandraCluster")

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -2571,10 +2571,6 @@ func injectContainersAndVolumes(t *testing.T, ctx context.Context, f *framework.
 	require.True(foundInit, "failed to find injected-init-container")
 	require.Equal(2, posInit, "injected-init-container should be the third init container")
 
-	posJmxInit, foundJmxInit := cassandra.FindInitContainer(dc.Spec.PodTemplateSpec, "jmx-credentials")
-	require.True(foundJmxInit, "failed to find jmx-credentials init container")
-	require.Equal(3, posJmxInit, "jmx-credentials should be the fourth init container")
-
 	_, foundMain := cassandra.FindContainer(dc.Spec.PodTemplateSpec, "injected-container")
 	require.True(foundMain, "failed to find injected-container")
 

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -57,18 +57,13 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 		if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
 			logger.Info("Reconciling Reaper user secrets")
 			var cassandraUserSecretRef corev1.LocalObjectReference
-			var jmxUserSecretRef corev1.LocalObjectReference
 			var uiUserSecretRef corev1.LocalObjectReference
 			if kc.Spec.Reaper != nil {
 				cassandraUserSecretRef = kc.Spec.Reaper.CassandraUserSecretRef
-				jmxUserSecretRef = kc.Spec.Reaper.JmxUserSecretRef
 				uiUserSecretRef = kc.Spec.Reaper.UiUserSecretRef
 			}
 			if cassandraUserSecretRef.Name == "" {
 				cassandraUserSecretRef.Name = reaper.DefaultUserSecretName(kc.SanitizedName())
-			}
-			if jmxUserSecretRef.Name == "" {
-				jmxUserSecretRef.Name = reaper.DefaultJmxUserSecretName(kc.SanitizedName())
 			}
 			if uiUserSecretRef.Name == "" {
 				uiUserSecretRef.Name = reaper.DefaultUiSecretName(kc.SanitizedName())
@@ -76,10 +71,6 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 			kcKey := utils.GetKey(kc)
 			if err := secret.ReconcileSecret(ctx, r.Client, cassandraUserSecretRef.Name, kcKey); err != nil {
 				logger.Error(err, "Failed to reconcile Reaper CQL user secret", "ReaperCassandraUserSecretRef", cassandraUserSecretRef)
-				return result.Error(err)
-			}
-			if err := secret.ReconcileSecret(ctx, r.Client, jmxUserSecretRef.Name, kcKey); err != nil {
-				logger.Error(err, "Failed to reconcile Reaper JMX user secret", "ReaperJmxUserSecretRef", jmxUserSecretRef)
 				return result.Error(err)
 			}
 			if err := secret.ReconcileSecret(ctx, r.Client, uiUserSecretRef.Name, kcKey); err != nil {

--- a/controllers/reaper/reaper_controller.go
+++ b/controllers/reaper/reaper_controller.go
@@ -370,7 +370,8 @@ func (r *ReaperReconciler) collectAuthVarsForType(ctx context.Context, actualRea
 		secretRef = &actualReaper.Spec.CassandraUserSecretRef
 		envVars = []*corev1.EnvVar{reaper.EnableCassAuthVar}
 	case "jmx":
-		secretRef = &actualReaper.Spec.JmxUserSecretRef
+		// JMX auth is based on the CQL role, so reuse the same secret (JmxUserSecretRef is deprecated)
+		secretRef = &actualReaper.Spec.CassandraUserSecretRef
 		envVars = []*corev1.EnvVar{}
 	case "ui":
 		secretRef = &actualReaper.Spec.UiUserSecretRef

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -380,7 +380,6 @@ func testCreateReaperWithAuthEnabled(t *testing.T, ctx context.Context, k8sClien
 	t.Log("create the Reaper object and modify it")
 	rpr := newReaper(testNamespace)
 	rpr.Spec.CassandraUserSecretRef.Name = "top-secret-cass"
-	rpr.Spec.JmxUserSecretRef.Name = "top-secret-jmx"
 	rpr.Spec.UiUserSecretRef.Name = "top-secret-ui"
 	err = k8sClient.Create(ctx, rpr)
 	require.NoError(t, err)
@@ -408,11 +407,11 @@ func testCreateReaperWithAuthEnabled(t *testing.T, ctx context.Context, k8sClien
 	assert.True(t, envVarHasValue(envVars, "REAPER_CASS_AUTH_ENABLED", "true"), "Cassandra auth enabled env var is not set to true")
 
 	assert.True(t, envVarExists(envVars, "REAPER_JMX_AUTH_USERNAME"), "Cassandra auth username env var not found")
-	assert.True(t, envVarSecretHasName(envVars, "REAPER_JMX_AUTH_USERNAME", "top-secret-jmx"), "Cassandra jmx username env var secret name not found")
+	assert.True(t, envVarSecretHasName(envVars, "REAPER_JMX_AUTH_USERNAME", "top-secret-cass"), "Cassandra jmx username env var secret name not found")
 	assert.True(t, envVarSecretHasKey(envVars, "REAPER_JMX_AUTH_USERNAME", "username"), "Cassandra jmx username env var secret key not found")
 
 	assert.True(t, envVarExists(envVars, "REAPER_JMX_AUTH_PASSWORD"), "Cassandra auth password env var not found")
-	assert.True(t, envVarSecretHasName(envVars, "REAPER_JMX_AUTH_PASSWORD", "top-secret-jmx"), "Cassandra jmx password env var secret name not found")
+	assert.True(t, envVarSecretHasName(envVars, "REAPER_JMX_AUTH_PASSWORD", "top-secret-cass"), "Cassandra jmx password env var secret name not found")
 	assert.True(t, envVarSecretHasKey(envVars, "REAPER_JMX_AUTH_PASSWORD", "password"), "Cassandra jmx password env var secret key not found")
 
 	assert.True(t, envVarExists(envVars, "REAPER_AUTH_ENABLED"), "Reaper auth enabled env var not found")

--- a/pkg/cassandra/auth.go
+++ b/pkg/cassandra/auth.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const JmxInitContainer = "jmx-credentials"
-
 // ApplyAuth modifies the dc config depending on whether auth is enabled in the cluster or not.
 func ApplyAuth(dcConfig *DatacenterConfig, authEnabled bool, useExternalSecrets bool) error {
 

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// TODO remove
 var DefaultJmxInitImage = images.Image{
 	Registry:   images.DefaultRegistry,
 	Repository: images.DockerOfficialRepository,

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -20,16 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// TODO remove
-var DefaultJmxInitImage = images.Image{
-	Registry:   images.DefaultRegistry,
-	Repository: images.DockerOfficialRepository,
-	Name:       "busybox",
-	Tag:        "1.34.1",
-	// When changing the default version above, please also change the kubebuilder marker in
-	// apis/reaper/v1alpha1/reaper_types.go accordingly.
-}
-
 // SystemReplication represents the replication factor of the system_auth, system_traces,
 // and system_distributed keyspaces. This is applied to each datacenter. The replication
 // is configured per DC.

--- a/pkg/reaper/datacenter_test.go
+++ b/pkg/reaper/datacenter_test.go
@@ -29,40 +29,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				Cluster: "cluster1",
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name:            cassandra.JmxInitContainer,
-							Image:           "docker.io/library/busybox:1.34.1",
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "SUPERUSER_JMX_USERNAME",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-superuser"},
-											Key:                  "username",
-										},
-									},
-								},
-								{
-									Name: "SUPERUSER_JMX_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-superuser"},
-											Key:                  "password",
-										},
-									},
-								},
-							},
-							Args: []string{
-								"/bin/sh",
-								"-c",
-								"echo \"$SUPERUSER_JMX_USERNAME $SUPERUSER_JMX_PASSWORD\" >> /config/jmxremote.password",
-							},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "server-config",
-								MountPath: "/config",
-							}},
-						}},
 						Containers: []corev1.Container{{
 							Name: reconciliation.CassandraContainerName,
 						}},
@@ -75,58 +41,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				Users:   []cassdcapi.CassandraUser{{SecretName: "cluster1-reaper", Superuser: true}},
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name:            "jmx-credentials",
-							Image:           "docker.io/library/busybox:1.34.1",
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "SUPERUSER_JMX_USERNAME",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-superuser"},
-											Key:                  "username",
-										},
-									},
-								},
-								{
-									Name: "SUPERUSER_JMX_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-superuser"},
-											Key:                  "password",
-										},
-									},
-								},
-								{
-									Name: "REAPER_JMX_USERNAME",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-reaper-jmx"},
-											Key:                  "username",
-										},
-									},
-								},
-								{
-									Name: "REAPER_JMX_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "cluster1-reaper-jmx"},
-											Key:                  "password",
-										},
-									},
-								},
-							},
-							Args: []string{
-								"/bin/sh",
-								"-c",
-								"echo \"$SUPERUSER_JMX_USERNAME $SUPERUSER_JMX_PASSWORD\" >> /config/jmxremote.password && echo \"$REAPER_JMX_USERNAME $REAPER_JMX_PASSWORD\" >> /config/jmxremote.password",
-							},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "server-config",
-								MountPath: "/config",
-							}},
-						}},
 						Containers: []corev1.Container{{
 							Name: reconciliation.CassandraContainerName,
 							Env:  []corev1.EnvVar{{Name: "LOCAL_JMX", Value: "no"}},
@@ -164,7 +78,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 			&reaperapi.ReaperClusterTemplate{
 				ReaperTemplate: reaperapi.ReaperTemplate{
 					CassandraUserSecretRef: corev1.LocalObjectReference{Name: "cass-user"},
-					JmxUserSecretRef:       corev1.LocalObjectReference{Name: "jmx-user"},
 				},
 			},
 			&cassandra.DatacenterConfig{
@@ -174,45 +87,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				Users:              []cassdcapi.CassandraUser{{SecretName: "another-user", Superuser: true}},
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
-							{
-								Name: "another-init-container",
-							},
-							{
-								Name:            cassandra.JmxInitContainer,
-								Image:           "docker.io/library/busybox:1.34.1",
-								ImagePullPolicy: corev1.PullIfNotPresent,
-								Env: []corev1.EnvVar{
-									{
-										Name: "SUPERUSER_JMX_USERNAME",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "k8c-superuser"},
-												Key:                  "username",
-											},
-										},
-									},
-									{
-										Name: "SUPERUSER_JMX_PASSWORD",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "k8c-superuser"},
-												Key:                  "password",
-											},
-										},
-									},
-								},
-								Args: []string{
-									"/bin/sh",
-									"-c",
-									"echo \"$SUPERUSER_JMX_USERNAME $SUPERUSER_JMX_PASSWORD\" >> /config/jmxremote.password",
-								},
-								VolumeMounts: []corev1.VolumeMount{{
-									Name:      "server-config",
-									MountPath: "/config",
-								}},
-							},
-						},
 						Containers: []corev1.Container{
 							{
 								Name: reconciliation.CassandraContainerName,
@@ -237,60 +111,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				},
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
-							{Name: "another-init-container"},
-							{
-								Name:            cassandra.JmxInitContainer,
-								Image:           "docker.io/library/busybox:1.34.1",
-								ImagePullPolicy: corev1.PullIfNotPresent,
-								Env: []corev1.EnvVar{
-									{
-										Name: "SUPERUSER_JMX_USERNAME",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "k8c-superuser"},
-												Key:                  "username",
-											},
-										},
-									},
-									{
-										Name: "SUPERUSER_JMX_PASSWORD",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "k8c-superuser"},
-												Key:                  "password",
-											},
-										},
-									},
-									{
-										Name: "REAPER_JMX_USERNAME",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "jmx-user"},
-												Key:                  "username",
-											},
-										},
-									},
-									{
-										Name: "REAPER_JMX_PASSWORD",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{Name: "jmx-user"},
-												Key:                  "password",
-											},
-										},
-									},
-								},
-								Args: []string{
-									"/bin/sh",
-									"-c",
-									"echo \"$SUPERUSER_JMX_USERNAME $SUPERUSER_JMX_PASSWORD\" >> /config/jmxremote.password && echo \"$REAPER_JMX_USERNAME $REAPER_JMX_PASSWORD\" >> /config/jmxremote.password",
-								},
-								VolumeMounts: []corev1.VolumeMount{{
-									Name:      "server-config",
-									MountPath: "/config",
-								}},
-							}},
 						Containers: []corev1.Container{
 							{
 								Name: reconciliation.CassandraContainerName,
@@ -315,7 +135,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				ReaperTemplate: reaperapi.ReaperTemplate{
 					// should be ignored
 					CassandraUserSecretRef: corev1.LocalObjectReference{Name: "cass-user"},
-					JmxUserSecretRef:       corev1.LocalObjectReference{Name: "jmx-user"},
 				},
 			},
 			&cassandra.DatacenterConfig{
@@ -324,9 +143,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				Users:   []cassdcapi.CassandraUser{{SecretName: "another-user", Superuser: true}},
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name: "another-init-container",
-						}},
 						Containers: []corev1.Container{
 							{
 								Name: reconciliation.CassandraContainerName,
@@ -345,9 +161,6 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 				Users:   []cassdcapi.CassandraUser{{SecretName: "another-user", Superuser: true}},
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{{
-							Name: "another-init-container",
-						}},
 						Containers: []corev1.Container{
 							{
 								Name: reconciliation.CassandraContainerName,

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -50,16 +50,14 @@ func NewReaper(
 	}
 	if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
 		// if auth is enabled in this cluster, the k8ssandra controller will automatically create two secrets for
-		// Reaper: one for CQL connections, one for JMX connections. Here we assume that these secrets exist. If the
+		// Reaper: one for CQL and JMX connections, one for the UI. Here we assume that these secrets exist. If the
 		// secrets were specified by the user they should be already present in desiredReaper.Spec; otherwise, we assume
 		// that the k8ssandra controller created two secrets with default names, and we need to manually fill in this
 		// info in desiredReaper.Spec since it wasn't persisted in reaperTemplate.
 		if desiredReaper.Spec.CassandraUserSecretRef.Name == "" {
 			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.SanitizedName())
 		}
-		if desiredReaper.Spec.JmxUserSecretRef.Name == "" {
-			desiredReaper.Spec.JmxUserSecretRef.Name = DefaultJmxUserSecretName(kc.SanitizedName())
-		}
+		// Note: deliberately skip JmxUserSecretRef, which is deprecated.
 		if desiredReaper.Spec.UiUserSecretRef.Name == "" {
 			desiredReaper.Spec.UiUserSecretRef.Name = DefaultUiSecretName(kc.SanitizedName())
 		}

--- a/pkg/reaper/secrets.go
+++ b/pkg/reaper/secrets.go
@@ -39,11 +39,6 @@ func DefaultUserSecretName(clusterName string) string {
 	return fmt.Sprintf("%v-reaper", clusterName)
 }
 
-// DefaultJmxUserSecretName generates a name for the Reaper JMX user, that is derived from the Cassandra cluster name.
-func DefaultJmxUserSecretName(clusterName string) string {
-	return fmt.Sprintf("%v-reaper-jmx", clusterName)
-}
-
 func DefaultUiSecretName(clusterName string) string {
 	return fmt.Sprintf("%v-reaper-ui", clusterName)
 }

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -214,28 +214,28 @@ func testAuthenticationEnabled(
 func checkLocalJmxFailsWithNoCredentials(t *testing.T, f *framework.E2eFramework, k8sContext, namespace, pod string) {
 	_, _, err := f.GetNodeToolStatus(k8sContext, namespace, pod)
 	if assert.Error(t, err, "expected unauthenticated local JMX connection on pod %v to fail", pod) {
-		assert.Contains(t, err.Error(), "Credentials required")
+		assert.Contains(t, err.Error(), "Required key 'username' is missing")
 	}
 }
 
 func checkLocalJmxFailsWithWrongCredentials(t *testing.T, f *framework.E2eFramework, k8sContext, namespace, pod string) {
 	_, _, err := f.GetNodeToolStatus(k8sContext, namespace, pod, "-u", "nonexistent", "-pw", "irrelevant")
 	if assert.Error(t, err, "expected local JMX connection with wrong credentials on pod %v to fail", pod) {
-		assert.Contains(t, err.Error(), "Invalid username or password")
+		assert.Contains(t, err.Error(), "Provided username nonexistent and/or password are incorrect")
 	}
 }
 
 func checkRemoteJmxFailsWithNoCredentials(t *testing.T, f *framework.E2eFramework, k8sContext, namespace, pod, host string) {
 	_, _, err := f.GetNodeToolStatus(k8sContext, namespace, pod, "-h", host)
 	if assert.Error(t, err, "expected unauthenticated remote JMX connection from pod %v to host %v to fail", pod, host) {
-		assert.Contains(t, err.Error(), "Credentials required")
+		assert.Contains(t, err.Error(), "Required key 'username' is missing")
 	}
 }
 
 func checkRemoteJmxFailsWithWrongCredentials(t *testing.T, f *framework.E2eFramework, k8sContext, namespace, pod, host string) {
 	_, _, err := f.GetNodeToolStatus(k8sContext, namespace, pod, "-u", "nonexistent", "-pw", "irrelevant", "-h", host)
 	if assert.Error(t, err, "expected remote JMX connection with wrong credentials from pod %v to host %v to fail", pod) {
-		assert.Contains(t, err.Error(), "Invalid username or password")
+		assert.Contains(t, err.Error(), "Provided username nonexistent and/or password are incorrect")
 	}
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1880,9 +1880,9 @@ func checkInjectedContainersPresence(t *testing.T, ctx context.Context, f *frame
 	}
 
 	if initContainerIndex, initContainerFound := cassandra.FindInitContainer(cassdc.Spec.PodTemplateSpec, "init-busybox"); initContainerFound {
-		require.Equal(t, 2, initContainerIndex, "busybox container should be the third container in cassandra pod")
+		require.Equal(t, 1, initContainerIndex, "init-busybox container should be the second init container in cassandra pod")
 	} else {
-		return fmt.Errorf("cannot find busybox injected container in pod template spec")
+		return fmt.Errorf("cannot find init-busybox injected container in pod template spec")
 	}
 	return nil
 }

--- a/test/testdata/fixtures/reaper/cassdc.yaml
+++ b/test/testdata/fixtures/reaper/cassdc.yaml
@@ -20,12 +20,21 @@ spec:
       slow_query_log_timeout_in_ms: 0
       sstable_preemptive_open_interval_in_mb: 0
       thrift_prepared_statements_cache_size_mb: 1
+      authenticator: PasswordAuthenticator
+      authorizer: CassandraAuthorizer
+      role_manager: CassandraRoleManager
     jvm-options:
       additional-jvm-opts:
         - -Dcassandra.system_distributed_replication_dc_names=dc1
         - -Dcassandra.system_distributed_replication_per_dc=1
+        - -Dcassandra.jmx.remote.login.config=CassandraLogin
+        - -Djava.security.auth.login.config=/etc/cassandra/cassandra-jaas.config
+        - -Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy
       initial_heap_size: 512m
       max_heap_size: 512m
+  users:
+    - secretName: reaper-cql-secret
+      superuser: true
   serverType: cassandra
   serverVersion: 3.11.11
   networking:
@@ -51,27 +60,6 @@ spec:
       storageClassName: standard
   podTemplateSpec:
     spec:
-      initContainers:
-        - name: reaper-jmx-credentials
-          image: "docker.io/busybox:1.33.1"
-          env:
-            - name: "REAPER_JMX_USERNAME"
-              valueFrom:
-                secretKeyRef:
-                  name: reaper-jmx-secret
-                  key: "username"
-            - name: "REAPER_JMX_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: reaper-jmx-secret
-                  key: "password"
-          args:
-            - "/bin/sh"
-            - "-c"
-            - "echo \"$REAPER_JMX_USERNAME $REAPER_JMX_PASSWORD\" > /config/jmxremote.password"
-          volumeMounts:
-            - name: "server-config"
-              mountPath: "/config"
       containers:
         - name: cassandra
           env:

--- a/test/testdata/fixtures/reaper/kustomization.yaml
+++ b/test/testdata/fixtures/reaper/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
   - cassdc.yaml
   - reaper.yaml
   - reaper-cql-secret.yaml
-  - reaper-jmx-secret.yaml
   - reaper-ui-secret.yaml

--- a/test/testdata/fixtures/reaper/reaper-jmx-secret.yaml
+++ b/test/testdata/fixtures/reaper/reaper-jmx-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: reaper-jmx-secret
-data:
-  # username: reaper-jmx
-  username: cmVhcGVyLWpteA==
-  # password: R3ap3r
-  password: UjNhcDNy

--- a/test/testdata/fixtures/reaper/reaper.yaml
+++ b/test/testdata/fixtures/reaper/reaper.yaml
@@ -8,8 +8,6 @@ spec:
     name: dc1
   cassandraUserSecretRef:
     name: reaper-cql-secret
-  jmxUserSecretRef:
-    name: reaper-jmx-secret
   uiUserSecretRef:
     name: reaper-ui-secret
   containerImage:

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -20,7 +20,6 @@ spec:
               requests:
                 storage: 5Gi
         initContainers:
-          - name: "jmx-credentials"
           - name: "server-config-init"
           - name: init-busybox
             image: busybox


### PR DESCRIPTION
**What this PR does**:
- configure Cassandra to delegate JMX authentication to the underlying CQL roles
- remove the now-obsolete JMX init container
- stop creating a JMX secret for Reaper; use its CQL secret instead.

**Which issue(s) this PR fixes**:
Fixes k8ssandra/k8ssandra#323

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
