### PR TITLE
Add external secret annotation

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -14,4 +14,4 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-
+[FEATURE] [#599](https://github.com/k8ssandra/k8ssandra-operator/issues/599) Introduce a secrets provider setting in the CRD

--- a/apis/config/v1beta1/groupversion_info.go
+++ b/apis/config/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta contains API Schema definitions for the config v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=config.k8ssandra.io
+// +kubebuilder:object:generate=true
+// +groupName=config.k8ssandra.io
 package v1beta1
 
 import (

--- a/apis/k8ssandra/v1alpha1/groupversion_info.go
+++ b/apis/k8ssandra/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the k8ssandra.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=k8ssandra.io
+// +kubebuilder:object:generate=true
+// +groupName=k8ssandra.io
 package v1alpha1
 
 import (

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -67,6 +67,14 @@ type K8ssandraClusterSpec struct {
 	// Replication settings changes will only apply to system_* keyspaces as well as reaper_db and data_endpoint_auth (Stargate).
 	// +optional
 	ExternalDatacenters []string `json:"externalDatacenters,omitempty"`
+
+	// SecretsProvider defines whether the secrets used for credentials and certs will be backed
+	// by an external secret backend (e.g. vault). This moves the responsibility of generating and
+	// storing secrets from the operators to the user and will rely on a mutating webhook to inject
+	// the secrets into the necessary resources
+	// +kubebuilder:validation:Enum=internal;external
+	// +kubebuilder:default=internal
+	SecretsProvider string `json:"secretsProvider,omitempty"`
 }
 
 func (in K8ssandraClusterSpec) IsAuthEnabled() bool {

--- a/apis/medusa/v1alpha1/groupversion_info.go
+++ b/apis/medusa/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the medusa v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=medusa.k8ssandra.io
+// +kubebuilder:object:generate=true
+// +groupName=medusa.k8ssandra.io
 package v1alpha1
 
 import (

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -61,6 +61,14 @@ type ReaperTemplate struct {
 	// +optional
 	UiUserSecretRef corev1.LocalObjectReference `json:"uiUserSecretRef,omitempty"`
 
+	// SecretsProvider defines whether the secrets used for credentials and certs will be backed
+	// by an external secret backend. This moves the responsibility of generating and storing
+	// secrets from the operators to the user and will rely on a mutating webhook to inject
+	// the secrets into the necessary resources
+	// +kubebuilder:validation:Enum=internal;external
+	// +kubebuilder:default=internal
+	SecretsProvider string `json:"secretsProvider,omitempty"`
+
 	// The image to use for the Reaper pod main container.
 	// The default is "thelastpickle/cassandra-reaper:3.2.0".
 	// +optional

--- a/apis/replication/v1alpha1/groupversion_info.go
+++ b/apis/replication/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the k8ssandra.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=replication.k8ssandra.io
+// +kubebuilder:object:generate=true
+// +groupName=replication.k8ssandra.io
 package v1alpha1
 
 import (

--- a/apis/stargate/v1alpha1/groupversion_info.go
+++ b/apis/stargate/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the k8ssandra.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=stargate.k8ssandra.io
+// +kubebuilder:object:generate=true
+// +groupName=stargate.k8ssandra.io
 package v1alpha1
 
 import (

--- a/apis/stargate/v1alpha1/stargate_types.go
+++ b/apis/stargate/v1alpha1/stargate_types.go
@@ -112,6 +112,14 @@ type StargateTemplate struct {
 	// Authentication options.
 	// +optional
 	AuthOptions *AuthOptions `json:"authOptions,omitempty"`
+
+	// SecretsProvider defines whether the secrets used for credentials and certs will be backed
+	// by an external secret backend. This moves the responsibility of generating and storing
+	// secrets from the operators to the user and will rely on a mutating webhook to inject
+	// the secrets into the necessary resources
+	// +kubebuilder:validation:Enum=internal;external
+	// +kubebuilder:default=internal
+	SecretsProvider string `json:"secretsProvider,omitempty"`
 }
 
 // StargateClusterTemplate defines global rules to apply to all Stargate pods in all datacenters in the cluster.

--- a/apis/telemetry/v1alpha1/telemetry_types.go
+++ b/apis/telemetry/v1alpha1/telemetry_types.go
@@ -1,5 +1,5 @@
 // package v1alpha1: Types in this package are instantiated in the other types in k8ssandra-operator, especially Stargate types and Cassandra types.
-//+kubebuilder:object:generate=true
+// +kubebuilder:object:generate=true
 package v1alpha1
 
 type TelemetrySpec struct {

--- a/config/crd/bases/config.k8ssandra.io_clientconfigs.yaml
+++ b/config/crd/bases/config.k8ssandra.io_clientconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: clientconfigs.config.k8ssandra.io
 spec:
@@ -49,13 +49,8 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
             type: object
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: k8ssandraclusters.k8ssandra.io
 spec:
@@ -140,6 +140,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -150,6 +151,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -755,6 +757,7 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     description: 'Selects a field of the pod: supports
                                       metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -773,6 +776,7 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     description: 'Selects a resource of the container:
                                       only resources limits and requests (limits.cpu,
@@ -798,6 +802,7 @@ spec:
                                     required:
                                     - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -819,6 +824,7 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
@@ -850,6 +856,7 @@ spec:
                                       be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -868,6 +875,7 @@ spec:
                                       defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -2605,6 +2613,7 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: 'Selects a field of the pod:
                                             supports metadata.name, metadata.namespace,
@@ -2624,6 +2633,7 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: 'Selects a resource of the
                                             container: only resources limits and requests
@@ -2651,6 +2661,7 @@ spec:
                                           required:
                                           - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace
@@ -2673,6 +2684,7 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                   - name
@@ -2705,6 +2717,7 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend
                                         to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -2723,6 +2736,7 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -3918,6 +3932,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         description: 'dataSourceRef specifies the
                                           object from which to populate the volume
@@ -3967,6 +3982,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resources:
                                         description: 'resources represents the minimum
                                           resources the volume should have. If RecoverVolumeExpansionFailure
@@ -4054,6 +4070,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
@@ -4226,6 +4243,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is optional: User is the
                                           rados user name, default is admin More info:
@@ -4264,6 +4282,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeID:
                                         description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -4348,6 +4367,7 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   csi:
                                     description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
@@ -4383,6 +4403,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       readOnly:
                                         description: readOnly specifies a read-only
                                           configuration for the volume. Defaults to
@@ -4444,6 +4465,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -4495,6 +4517,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -4638,6 +4661,7 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               dataSourceRef:
                                                 description: 'dataSourceRef specifies
                                                   the object from which to populate
@@ -4693,6 +4717,7 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               resources:
                                                 description: 'resources represents
                                                   the minimum resources the volume
@@ -4794,6 +4819,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               storageClassName:
                                                 description: 'storageClassName is
                                                   the name of the StorageClass required
@@ -4897,6 +4923,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - driver
                                     type: object
@@ -5099,6 +5126,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       targetPortal:
                                         description: targetPortal is iSCSI Target
                                           Portal. The Portal is either an IP or ip_addr:port
@@ -5295,6 +5323,7 @@ spec:
                                                     be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             downwardAPI:
                                               description: downwardAPI information
                                                 about the downwardAPI data to project
@@ -5328,6 +5357,7 @@ spec:
                                                         required:
                                                         - fieldPath
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
@@ -5388,6 +5418,7 @@ spec:
                                                         required:
                                                         - resource
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                     required:
                                                     - path
                                                     type: object
@@ -5466,6 +5497,7 @@ spec:
                                                     must be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             serviceAccountToken:
                                               description: serviceAccountToken is
                                                 information about the serviceAccountToken
@@ -5598,6 +5630,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is the rados user name.
                                           Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -5643,6 +5676,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       sslEnabled:
                                         description: sslEnabled Flag enable/disable
                                           SSL communication with Gateway, default
@@ -5775,6 +5809,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeName:
                                         description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
@@ -5921,6 +5956,7 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: 'Selects a field of the pod:
                                             supports metadata.name, metadata.namespace,
@@ -5940,6 +5976,7 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: 'Selects a resource of the
                                             container: only resources limits and requests
@@ -5967,6 +6004,7 @@ spec:
                                           required:
                                           - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace
@@ -5989,6 +6027,7 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                   - name
@@ -6021,6 +6060,7 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend
                                         to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -6039,6 +6079,7 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -7196,6 +7237,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             registry:
                               default: docker.io
                               description: The Docker registry to use. Defaults to
@@ -7456,6 +7498,7 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           weight:
                                             description: Weight associated with matching
                                               the corresponding nodeSelectorTerm,
@@ -7569,10 +7612,12 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
@@ -7665,6 +7710,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -7734,6 +7780,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -7853,6 +7900,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -7916,6 +7964,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -8036,6 +8085,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -8105,6 +8155,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -8224,6 +8275,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -8287,6 +8339,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -8372,6 +8425,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             containerImage:
                               default:
                                 repository: stargateio
@@ -8407,6 +8461,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 registry:
                                   default: docker.io
                                   description: The Docker registry to use. Defaults
@@ -8746,6 +8801,7 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -8877,10 +8933,12 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -8986,6 +9044,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -9066,6 +9125,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -9200,6 +9260,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -9272,6 +9333,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -9407,6 +9469,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -9487,6 +9550,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -9621,6 +9685,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -9693,6 +9758,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -9784,6 +9850,7 @@ spec:
                                           kind, uid?'
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   containerImage:
                                     default:
                                       repository: stargateio
@@ -9820,6 +9887,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       registry:
                                         default: docker.io
                                         description: The Docker registry to use. Defaults
@@ -10228,6 +10296,19 @@ spec:
                                           value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
+                                  secretsProvider:
+                                    default: internal
+                                    description: SecretsProvider defines whether the
+                                      secrets used for credentials and certs will
+                                      be backed by an external secret backend. This
+                                      moves the responsibility of generating and storing
+                                      secrets from the operators to the user and will
+                                      rely on a mutating webhook to inject the secrets
+                                      into the necessary resources
+                                    enum:
+                                    - internal
+                                    - external
+                                    type: string
                                   serviceAccount:
                                     default: default
                                     description: ServiceAccount is the service account
@@ -10522,6 +10603,18 @@ spec:
                                     an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
+                            secretsProvider:
+                              default: internal
+                              description: SecretsProvider defines whether the secrets
+                                used for credentials and certs will be backed by an
+                                external secret backend. This moves the responsibility
+                                of generating and storing secrets from the operators
+                                to the user and will rely on a mutating webhook to
+                                inject the secrets into the necessary resources
+                              enum:
+                              - internal
+                              - external
+                              type: string
                             serviceAccount:
                               default: default
                               description: ServiceAccount is the service account name
@@ -10702,6 +10795,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         description: 'dataSourceRef specifies the
                                           object from which to populate the volume
@@ -10751,6 +10845,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resources:
                                         description: 'resources represents the minimum
                                           resources the volume should have. If RecoverVolumeExpansionFailure
@@ -10838,6 +10933,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
@@ -10901,6 +10997,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -10946,6 +11043,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -11030,6 +11128,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -11209,6 +11308,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -11254,6 +11354,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -11338,6 +11439,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -11497,6 +11599,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is optional: User is the rados
                                     user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
@@ -11532,6 +11635,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -11611,6 +11715,7 @@ spec:
                                     or its keys must be defined
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
@@ -11644,6 +11749,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
@@ -11702,6 +11808,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       mode:
                                         description: 'Optional: mode bits used to
                                           set permissions on this file, must be an
@@ -11747,6 +11854,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -11878,6 +11986,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           description: 'dataSourceRef specifies the
                                             object from which to populate the volume
@@ -11928,6 +12037,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resources:
                                           description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
@@ -12020,6 +12130,7 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           description: 'storageClassName is the name
                                             of the StorageClass required by the claim.
@@ -12118,6 +12229,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -12308,6 +12420,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   description: targetPortal is iSCSI Target Portal.
                                     The Portal is either an IP or ip_addr:port if
@@ -12490,6 +12603,7 @@ spec:
                                               the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         description: downwardAPI information about
                                           the downwardAPI data to project
@@ -12521,6 +12635,7 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   description: 'Optional: mode bits
                                                     used to set permissions on this
@@ -12576,6 +12691,7 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -12647,6 +12763,7 @@ spec:
                                               the Secret or its key must be defined
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         description: serviceAccountToken is information
                                           about the serviceAccountToken data to project
@@ -12773,6 +12890,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is the rados user name. Default
                                     is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -12817,6 +12935,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   description: sslEnabled Flag enable/disable SSL
                                     communication with Gateway, default false
@@ -12942,6 +13061,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
@@ -13082,6 +13202,7 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     description: 'Selects a field of the pod: supports
                                       metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -13100,6 +13221,7 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     description: 'Selects a resource of the container:
                                       only resources limits and requests (limits.cpu,
@@ -13125,6 +13247,7 @@ spec:
                                     required:
                                     - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -13146,6 +13269,7 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
@@ -13177,6 +13301,7 @@ spec:
                                       be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -13195,6 +13320,7 @@ spec:
                                       defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -14277,6 +14403,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -14381,6 +14508,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -14391,6 +14519,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -14475,6 +14604,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -14520,6 +14650,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -14604,6 +14735,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -14662,6 +14794,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           dataSourceRef:
                             description: 'dataSourceRef specifies the object from
                               which to populate the volume with data, if a non-empty
@@ -14701,6 +14834,7 @@ spec:
                             - kind
                             - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           resources:
                             description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
@@ -14779,6 +14913,7 @@ spec:
                                   contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           storageClassName:
                             description: 'storageClassName is the name of the StorageClass
                               required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -14805,6 +14940,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   telemetry:
                     description: Telemetry defines the desired state for telemetry
                       resources in this datacenter. If telemetry configurations are
@@ -14921,6 +15057,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   certificatesSecretRef:
                     description: 'Certificates for Medusa if client encryption is
                       enabled in Cassandra. The secret must be in the same namespace
@@ -14933,6 +15070,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   containerImage:
                     description: MedusaContainerImage is the image characteristics
                       to use for Medusa containers. Leave nil to use a default image.
@@ -14960,6 +15098,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -15287,6 +15426,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       transferMaxBandwidth:
                         default: 50MB/s
                         description: Max upload bandwidth in MB/s. Defaults to 50
@@ -15408,6 +15548,7 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 weight:
                                   description: Weight associated with matching the
                                     corresponding nodeSelectorTerm, in the range 1-100.
@@ -15513,10 +15654,12 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             required:
                             - nodeSelectorTerms
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
                         description: Describes pod affinity scheduling rules (e.g.
@@ -15597,6 +15740,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -15654,6 +15798,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -15758,6 +15903,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -15814,6 +15960,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -15917,6 +16064,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -15974,6 +16122,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -16078,6 +16227,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -16134,6 +16284,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -16253,6 +16404,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   containerImage:
                     default:
                       name: cassandra-reaper
@@ -16284,6 +16436,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -16342,6 +16495,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -16566,6 +16720,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   keyspace:
                     default: reaper_db
                     description: The keyspace to use to store Reaper's state. Will
@@ -17067,6 +17222,17 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  secretsProvider:
+                    default: internal
+                    description: SecretsProvider defines whether the secrets used
+                      for credentials and certs will be backed by an external secret
+                      backend. This moves the responsibility of generating and storing
+                      secrets from the operators to the user and will rely on a mutating
+                      webhook to inject the secrets into the necessary resources
+                    enum:
+                    - internal
+                    - external
+                    type: string
                   securityContext:
                     description: SecurityContext applied to the Reaper main container.
                     properties:
@@ -17328,7 +17494,19 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
+              secretsProvider:
+                default: internal
+                description: SecretsProvider defines whether the secrets used for
+                  credentials and certs will be backed by an external secret backend
+                  (e.g. vault). This moves the responsibility of generating and storing
+                  secrets from the operators to the user and will rely on a mutating
+                  webhook to inject the secrets into the necessary resources
+                enum:
+                - internal
+                - external
+                type: string
               stargate:
                 description: Stargate defines the desired deployment characteristics
                   for Stargate in this K8ssandraCluster. If this is non-nil, Stargate
@@ -17442,6 +17620,7 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 weight:
                                   description: Weight associated with matching the
                                     corresponding nodeSelectorTerm, in the range 1-100.
@@ -17547,10 +17726,12 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             required:
                             - nodeSelectorTerms
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
                         description: Describes pod affinity scheduling rules (e.g.
@@ -17631,6 +17812,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -17688,6 +17870,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -17792,6 +17975,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -17848,6 +18032,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -17951,6 +18136,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -18008,6 +18194,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -18112,6 +18299,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -18168,6 +18356,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -18244,6 +18433,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   containerImage:
                     default:
                       repository: stargateio
@@ -18274,6 +18464,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -18632,6 +18823,17 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  secretsProvider:
+                    default: internal
+                    description: SecretsProvider defines whether the secrets used
+                      for credentials and certs will be backed by an external secret
+                      backend. This moves the responsibility of generating and storing
+                      secrets from the operators to the user and will rely on a mutating
+                      webhook to inject the secrets into the necessary resources
+                    enum:
+                    - internal
+                    - external
+                    type: string
                   serviceAccount:
                     default: default
                     description: ServiceAccount is the service account name to use
@@ -18888,6 +19090,7 @@ spec:
                                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           type: array
                         usersUpserted:
                           description: The timestamp at which managed cassandra users'
@@ -19018,9 +19221,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: cassandrabackups.medusa.k8ssandra.io
 spec:
@@ -495,6 +495,7 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -614,10 +615,12 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -715,6 +718,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -787,6 +791,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -911,6 +916,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -978,6 +984,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -1103,6 +1110,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -1175,6 +1183,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -1299,6 +1308,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -1366,6 +1376,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -1495,6 +1506,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -1515,6 +1527,7 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -1544,6 +1557,7 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -1566,6 +1580,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -1599,6 +1614,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -1618,6 +1634,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -2994,6 +3011,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -3014,6 +3032,7 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -3043,6 +3062,7 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -3065,6 +3085,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -3098,6 +3119,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -3117,6 +3139,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -4375,6 +4398,7 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                               initContainers:
                                 description: 'List of initialization containers belonging
@@ -4482,6 +4506,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -4502,6 +4527,7 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -4531,6 +4557,7 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -4553,6 +4580,7 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -4586,6 +4614,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -4605,6 +4634,7 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -6307,6 +6337,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     maxSkew:
                                       description: 'MaxSkew describes the degree to
                                         which pods may be unevenly distributed. When
@@ -6564,6 +6595,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         user:
                                           description: 'user is optional: User is
                                             the rados user name, default is admin
@@ -6603,6 +6635,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         volumeID:
                                           description: 'volumeID used to identify
                                             the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -6690,6 +6723,7 @@ spec:
                                             ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     csi:
                                       description: csi (Container Storage Interface)
                                         represents ephemeral storage that is handled
@@ -6726,6 +6760,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         readOnly:
                                           description: readOnly specifies a read-only
                                             configuration for the volume. Defaults
@@ -6790,6 +6825,7 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 description: 'Optional: mode bits
                                                   used to set permissions on this
@@ -6843,6 +6879,7 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                             - path
                                             type: object
@@ -6990,6 +7027,7 @@ spec:
                                                   - kind
                                                   - name
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 dataSourceRef:
                                                   description: 'dataSourceRef specifies
                                                     the object from which to populate
@@ -7047,6 +7085,7 @@ spec:
                                                   - kind
                                                   - name
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resources:
                                                   description: 'resources represents
                                                     the minimum resources the volume
@@ -7153,6 +7192,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 storageClassName:
                                                   description: 'storageClassName is
                                                     the name of the StorageClass required
@@ -7257,6 +7297,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                       - driver
                                       type: object
@@ -7465,6 +7506,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         targetPortal:
                                           description: targetPortal is iSCSI Target
                                             Portal. The Portal is either an IP or
@@ -7671,6 +7713,7 @@ spec:
                                                       keys must be defined
                                                     type: boolean
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               downwardAPI:
                                                 description: downwardAPI information
                                                   about the downwardAPI data to project
@@ -7707,6 +7750,7 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                         mode:
                                                           description: 'Optional:
                                                             mode bits used to set
@@ -7772,6 +7816,7 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
+                                                          x-kubernetes-map-type: atomic
                                                       required:
                                                       - path
                                                       type: object
@@ -7854,6 +7899,7 @@ spec:
                                                       must be defined
                                                     type: boolean
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               serviceAccountToken:
                                                 description: serviceAccountToken is
                                                   information about the serviceAccountToken
@@ -7989,6 +8035,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         user:
                                           description: 'user is the rados user name.
                                             Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -8035,6 +8082,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         sslEnabled:
                                           description: sslEnabled Flag enable/disable
                                             SSL communication with Gateway, default
@@ -8174,6 +8222,7 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         volumeName:
                                           description: volumeName is the human-readable
                                             name of the StorageOS volume.  Volume
@@ -8389,6 +8438,7 @@ spec:
                                       - kind
                                       - name
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     dataSourceRef:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
@@ -8436,6 +8486,7 @@ spec:
                                       - kind
                                       - name
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -8523,6 +8574,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     storageClassName:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
@@ -8586,6 +8638,7 @@ spec:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               dataSourceRef:
                                 description: 'dataSourceRef specifies the object from
                                   which to populate the volume with data, if a non-empty
@@ -8630,6 +8683,7 @@ spec:
                                 - kind
                                 - name
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resources:
                                 description: 'resources represents the minimum resources
                                   the volume should have. If RecoverVolumeExpansionFailure
@@ -8711,6 +8765,7 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               storageClassName:
                                 description: 'storageClassName is the name of the
                                   StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -8854,9 +8909,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrarestores.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrarestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: cassandrarestores.medusa.k8ssandra.io
 spec:
@@ -105,9 +105,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupjobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: medusabackupjobs.medusa.k8ssandra.io
 spec:
@@ -76,9 +76,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: medusabackups.medusa.k8ssandra.io
 spec:
@@ -63,9 +63,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: medusabackupschedules.medusa.k8ssandra.io
 spec:
@@ -103,9 +103,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: medusarestorejobs.medusa.k8ssandra.io
 spec:
@@ -83,9 +83,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: medusatasks.medusa.k8ssandra.io
 spec:
@@ -102,9 +102,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: reapers.reaper.k8ssandra.io
 spec:
@@ -150,6 +150,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 nodeSelectorTerm, in the range 1-100.
@@ -250,10 +251,12 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
                     description: Describes pod affinity scheduling rules (e.g. co-locate
@@ -330,6 +333,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -386,6 +390,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -484,6 +489,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -535,6 +541,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -635,6 +642,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -691,6 +699,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -789,6 +798,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -840,6 +850,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -958,6 +969,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               clientEncryptionStores:
                 description: Client encryption stores which are used by Cassandra
                   and Reaper.
@@ -972,6 +984,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   truststoreSecretRef:
                     description: ref to the secret that contains the truststore and
                       its password the expected format of the secret is a "truststore"
@@ -982,6 +995,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                 required:
                 - keystoreSecretRef
                 - truststoreSecretRef
@@ -1017,6 +1031,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1101,6 +1116,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1314,6 +1330,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               keyspace:
                 default: reaper_db
                 description: The keyspace to use to store Reaper's state. Will default
@@ -1796,6 +1813,17 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              secretsProvider:
+                default: internal
+                description: SecretsProvider defines whether the secrets used for
+                  credentials and certs will be backed by an external secret backend.
+                  This moves the responsibility of generating and storing secrets
+                  from the operators to the user and will rely on a mutating webhook
+                  to inject the secrets into the necessary resources
+                enum:
+                - internal
+                - external
+                type: string
               securityContext:
                 description: SecurityContext applied to the Reaper main container.
                 properties:
@@ -2054,6 +2082,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - datacenterRef
             type: object
@@ -2091,9 +2120,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/replication.k8ssandra.io_replicatedsecrets.yaml
+++ b/config/crd/bases/replication.k8ssandra.io_replicatedsecrets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: replicatedsecrets.replication.k8ssandra.io
 spec:
@@ -97,6 +97,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
             type: object
           status:
             description: ReplicatedSecretStatus defines the observed state of ReplicatedSecret
@@ -130,9 +131,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: stargates.stargate.k8ssandra.io
 spec:
@@ -158,6 +158,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 nodeSelectorTerm, in the range 1-100.
@@ -258,10 +259,12 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
                     description: Describes pod affinity scheduling rules (e.g. co-locate
@@ -338,6 +341,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -394,6 +398,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -492,6 +497,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -543,6 +549,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -643,6 +650,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -699,6 +707,7 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -797,6 +806,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -848,6 +858,7 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -935,6 +946,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               cassandraEncryption:
                 description: CassandraEncryption groups together encryption stores
                   that are passed to the Stargate pods, so that they can be mounted
@@ -954,6 +966,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -964,6 +977,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -982,6 +996,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -992,6 +1007,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -1027,6 +1043,7 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1049,6 +1066,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               heapSize:
                 anyOf:
                 - type: integer
@@ -1328,6 +1346,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     description: Weight associated with matching the
                                       corresponding nodeSelectorTerm, in the range
@@ -1434,10 +1453,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           description: Describes pod affinity scheduling rules (e.g.
@@ -1518,6 +1539,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1576,6 +1598,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         description: namespaces specifies a static
                                           list of namespace names that the term applies
@@ -1683,6 +1706,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
@@ -1739,6 +1763,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list
                                       of namespace names that the term applies to.
@@ -1844,6 +1869,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1902,6 +1928,7 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         description: namespaces specifies a static
                                           list of namespace names that the term applies
@@ -2009,6 +2036,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
@@ -2065,6 +2093,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list
                                       of namespace names that the term applies to.
@@ -2144,6 +2173,7 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
+                      x-kubernetes-map-type: atomic
                     containerImage:
                       default:
                         repository: stargateio
@@ -2174,6 +2204,7 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         registry:
                           default: docker.io
                           description: The Docker registry to use. Defaults to "docker.io",
@@ -2541,6 +2572,18 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
+                    secretsProvider:
+                      default: internal
+                      description: SecretsProvider defines whether the secrets used
+                        for credentials and certs will be backed by an external secret
+                        backend. This moves the responsibility of generating and storing
+                        secrets from the operators to the user and will rely on a
+                        mutating webhook to inject the secrets into the necessary
+                        resources
+                      enum:
+                      - internal
+                      - external
+                      type: string
                     serviceAccount:
                       default: default
                       description: ServiceAccount is the service account name to use
@@ -2808,6 +2851,17 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              secretsProvider:
+                default: internal
+                description: SecretsProvider defines whether the secrets used for
+                  credentials and certs will be backed by an external secret backend.
+                  This moves the responsibility of generating and storing secrets
+                  from the operators to the user and will rely on a mutating webhook
+                  to inject the secrets into the necessary resources
+                enum:
+                - internal
+                - external
+                type: string
               serviceAccount:
                 default: default
                 description: ServiceAccount is the service account name to use for
@@ -2984,9 +3038,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -66,10 +66,10 @@ func TestSecretController(t *testing.T) {
 }
 
 // copySecretsFromClusterToCluster Tests:
-// 	* Copy secret to another cluster (not existing one)
-// 	* Modify the secret in main cluster - see that it is updated to slave cluster also
-// 	* Modify the secret in the slave cluster - see that it is replaced by the main cluster data
-//	* Verify the status has been updated
+//   - Copy secret to another cluster (not existing one)
+//   - Modify the secret in main cluster - see that it is updated to slave cluster also
+//   - Modify the secret in the slave cluster - see that it is replaced by the main cluster data
+//   - Verify the status has been updated
 func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
 	// assert := assert.New(t)
@@ -195,10 +195,10 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 }
 
 // verifySecretIsDeleted checks that the finalizer functionality works
-// 	* Create secret and ReplicatedSecret
-//	* Verify it is copied to another cluster
-//  * Delete ReplicatedSecret from main cluster
-//  * Verify the secrets are deleted from the remote cluster (but not local)
+//   - Create secret and ReplicatedSecret
+//   - Verify it is copied to another cluster
+//   - Delete ReplicatedSecret from main cluster
+//   - Verify the secrets are deleted from the remote cluster (but not local)
 func verifySecretIsDeleted(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
 	require := require.New(t)
 	var empty struct{}

--- a/pkg/cassandra/config.go
+++ b/pkg/cassandra/config.go
@@ -67,6 +67,7 @@ func addStartRpc(template *DatacenterConfig) {
 
 // Handles the deprecated settings: HeapSize and HeapNewGenSize by copying their values, if any,
 // to the appropriate destination settings, iif these are nil.
+//
 //goland:noinspection GoDeprecation
 func handleDeprecatedJvmOptions(jvmOptions *api.JvmOptions) {
 	// Transfer the global heap size to specific keys

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -33,7 +33,7 @@ var DefaultJmxInitImage = images.Image{
 // is configured per DC.
 type SystemReplication map[string]int
 
-//// Replication provides a mapping of DCs to a mapping of keyspaces and their
+// // Replication provides a mapping of DCs to a mapping of keyspaces and their
 // replica counts. NetworkTopologyStrategy is assumed for all keyspaces.
 type Replication struct {
 	datacenters map[string]keyspacesReplication

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -653,6 +653,7 @@ func TestDatacentersReplication(t *testing.T) {
 }
 
 // GetDatacenterConfig returns a minimum viable DataCenterConfig.
+//
 //goland:noinspection GoDeprecation
 func GetDatacenterConfig() DatacenterConfig {
 	storageClass := "default"

--- a/pkg/telemetry/cassandra_metrics_filters_test.go
+++ b/pkg/telemetry/cassandra_metrics_filters_test.go
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-//Test_InjectCassandraTelemetryFilters tests that metrics filters from the CRD are correctly injected.
+// Test_InjectCassandraTelemetryFilters tests that metrics filters from the CRD are correctly injected.
 func Test_InjectCassandraTelemetryFilters(t *testing.T) {
 	dcConfig := &cassandra.DatacenterConfig{
 		PodTemplateSpec: &v1.PodTemplateSpec{
@@ -43,7 +43,7 @@ func Test_InjectCassandraTelemetryFilters(t *testing.T) {
 	assert.Equal(t, cassandraEnvVariables[0].Value, "deny:org.apache.cassandra.metrics.Table deny:org.apache.cassandra.metrics.table", "Expected METRIC_FILTERS env variable to be injected")
 }
 
-//Test_InjectCassandraTelemetryFiltersDefaults tests that default metrics filters are injected when no custom ones are defined.
+// Test_InjectCassandraTelemetryFiltersDefaults tests that default metrics filters are injected when no custom ones are defined.
 func Test_InjectCassandraTelemetryFiltersDefaults(t *testing.T) {
 	dcConfig := &cassandra.DatacenterConfig{
 		PodTemplateSpec: &v1.PodTemplateSpec{

--- a/pkg/telemetry/prom_cass_servicemonitor_test.go
+++ b/pkg/telemetry/prom_cass_servicemonitor_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//Test_NewCassServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
+// Test_NewCassServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
 func Test_NewCassServiceMonitor_SUCCESS(t *testing.T) {
 	logger := testlogr.NewTestLogger(t)
 	cfg := PrometheusResourcer{

--- a/pkg/telemetry/prom_reaper_servicemonitor_test.go
+++ b/pkg/telemetry/prom_reaper_servicemonitor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//Test_NewServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
+// Test_NewServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
 func Test_PrometheusResourcer_NewReaperServiceMonitor_SUCCESS(t *testing.T) {
 	logger := testlogr.NewTestLogger(t)
 	cfg := PrometheusResourcer{

--- a/pkg/telemetry/prom_stargate_servicemonitor_test.go
+++ b/pkg/telemetry/prom_stargate_servicemonitor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//Test_NewServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
+// Test_NewServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
 func Test_PrometheusResourcer_NewStargateServiceMonitor_SUCCESS(t *testing.T) {
 	logger := testlogr.NewTestLogger(t)
 	cfg := PrometheusResourcer{


### PR DESCRIPTION
**What this PR does**:
adding an external secrets flag to the K8ssandraCluster, Reaper, and Stargate CRD's

Adding these flags are the first step in implementing the new secrets backend (design doc). The controllers for each of these resources will use this flag to disable kubernetes secrets creation/storage for credentials and other secrets within the operator ecosystem

**Which issue(s) this PR fixes**:
Fixes #599 

**Checklist**
- [*] Changes manually tested
- [*] Automated Tests added/updated
- [*] Documentation added/updated
- [*] CHANGELOG.md updated (not required for documentation PRs)
- [*] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
