### PR TITLE
Always set the cassandra.yaml jvm option for the Stargate pod

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -13,6 +13,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## Unreleased
+
+* [BUGFIX] [#683](https://github.com/k8ssandra/k8ssandra-operator/issues/683) Fix Stargate not working when encryption is enabled but no cassandra.yaml config map is provided
+
 ## v1.3.0 - 2022-10-12
 
 * [FEATURE] [#657](https://github.com/k8ssandra/k8ssandra-operator/issues/657) Basic DSE Support

--- a/config/crd/bases/config.k8ssandra.io_clientconfigs.yaml
+++ b/config/crd/bases/config.k8ssandra.io_clientconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: clientconfigs.config.k8ssandra.io
 spec:
@@ -49,8 +49,13 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
             type: object
         type: object
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: k8ssandraclusters.k8ssandra.io
 spec:
@@ -140,7 +140,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -151,7 +150,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -757,7 +755,6 @@ spec:
                                     required:
                                     - key
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     description: 'Selects a field of the pod: supports
                                       metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -776,7 +773,6 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     description: 'Selects a resource of the container:
                                       only resources limits and requests (limits.cpu,
@@ -802,7 +798,6 @@ spec:
                                     required:
                                     - resource
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -824,7 +819,6 @@ spec:
                                     required:
                                     - key
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
@@ -856,7 +850,6 @@ spec:
                                       be defined
                                     type: boolean
                                 type: object
-                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -875,7 +868,6 @@ spec:
                                       defined
                                     type: boolean
                                 type: object
-                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -2613,7 +2605,6 @@ spec:
                                           required:
                                           - key
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: 'Selects a field of the pod:
                                             supports metadata.name, metadata.namespace,
@@ -2633,7 +2624,6 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: 'Selects a resource of the
                                             container: only resources limits and requests
@@ -2661,7 +2651,6 @@ spec:
                                           required:
                                           - resource
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace
@@ -2684,7 +2673,6 @@ spec:
                                           required:
                                           - key
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                   - name
@@ -2717,7 +2705,6 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend
                                         to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -2736,7 +2723,6 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -3932,7 +3918,6 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         description: 'dataSourceRef specifies the
                                           object from which to populate the volume
@@ -3982,7 +3967,6 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       resources:
                                         description: 'resources represents the minimum
                                           resources the volume should have. If RecoverVolumeExpansionFailure
@@ -4070,7 +4054,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
@@ -4243,7 +4226,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is optional: User is the
                                           rados user name, default is admin More info:
@@ -4282,7 +4264,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       volumeID:
                                         description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -4367,7 +4348,6 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   csi:
                                     description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
@@ -4403,7 +4383,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       readOnly:
                                         description: readOnly specifies a read-only
                                           configuration for the volume. Defaults to
@@ -4465,7 +4444,6 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -4517,7 +4495,6 @@ spec:
                                               required:
                                               - resource
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -4661,7 +4638,6 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               dataSourceRef:
                                                 description: 'dataSourceRef specifies
                                                   the object from which to populate
@@ -4717,7 +4693,6 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               resources:
                                                 description: 'resources represents
                                                   the minimum resources the volume
@@ -4819,7 +4794,6 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               storageClassName:
                                                 description: 'storageClassName is
                                                   the name of the StorageClass required
@@ -4923,7 +4897,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                     required:
                                     - driver
                                     type: object
@@ -5126,7 +5099,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       targetPortal:
                                         description: targetPortal is iSCSI Target
                                           Portal. The Portal is either an IP or ip_addr:port
@@ -5323,7 +5295,6 @@ spec:
                                                     be defined
                                                   type: boolean
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             downwardAPI:
                                               description: downwardAPI information
                                                 about the downwardAPI data to project
@@ -5357,7 +5328,6 @@ spec:
                                                         required:
                                                         - fieldPath
                                                         type: object
-                                                        x-kubernetes-map-type: atomic
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
@@ -5418,7 +5388,6 @@ spec:
                                                         required:
                                                         - resource
                                                         type: object
-                                                        x-kubernetes-map-type: atomic
                                                     required:
                                                     - path
                                                     type: object
@@ -5497,7 +5466,6 @@ spec:
                                                     must be defined
                                                   type: boolean
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             serviceAccountToken:
                                               description: serviceAccountToken is
                                                 information about the serviceAccountToken
@@ -5630,7 +5598,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is the rados user name.
                                           Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -5676,7 +5643,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       sslEnabled:
                                         description: sslEnabled Flag enable/disable
                                           SSL communication with Gateway, default
@@ -5809,7 +5775,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       volumeName:
                                         description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
@@ -5956,7 +5921,6 @@ spec:
                                           required:
                                           - key
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: 'Selects a field of the pod:
                                             supports metadata.name, metadata.namespace,
@@ -5976,7 +5940,6 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: 'Selects a resource of the
                                             container: only resources limits and requests
@@ -6004,7 +5967,6 @@ spec:
                                           required:
                                           - resource
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace
@@ -6027,7 +5989,6 @@ spec:
                                           required:
                                           - key
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                       type: object
                                   required:
                                   - name
@@ -6060,7 +6021,6 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend
                                         to each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -6079,7 +6039,6 @@ spec:
                                             must be defined
                                           type: boolean
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
                               image:
@@ -7237,7 +7196,6 @@ spec:
                                     uid?'
                                   type: string
                               type: object
-                              x-kubernetes-map-type: atomic
                             registry:
                               default: docker.io
                               description: The Docker registry to use. Defaults to
@@ -7498,7 +7456,6 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           weight:
                                             description: Weight associated with matching
                                               the corresponding nodeSelectorTerm,
@@ -7612,12 +7569,10 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
@@ -7710,7 +7665,6 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -7780,7 +7734,6 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -7900,7 +7853,6 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -7964,7 +7916,6 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -8085,7 +8036,6 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -8155,7 +8105,6 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -8275,7 +8224,6 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -8339,7 +8287,6 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -8425,7 +8372,6 @@ spec:
                                     uid?'
                                   type: string
                               type: object
-                              x-kubernetes-map-type: atomic
                             containerImage:
                               default:
                                 repository: stargateio
@@ -8461,7 +8407,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 registry:
                                   default: docker.io
                                   description: The Docker registry to use. Defaults
@@ -8801,7 +8746,6 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -8933,12 +8877,10 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -9044,7 +8986,6 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
-                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -9125,7 +9066,6 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
-                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -9260,7 +9200,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -9333,7 +9272,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -9469,7 +9407,6 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
-                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -9550,7 +9487,6 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
-                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -9685,7 +9621,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -9758,7 +9693,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -9850,7 +9784,6 @@ spec:
                                           kind, uid?'
                                         type: string
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   containerImage:
                                     default:
                                       repository: stargateio
@@ -9887,7 +9820,6 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       registry:
                                         default: docker.io
                                         description: The Docker registry to use. Defaults
@@ -10795,7 +10727,6 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         description: 'dataSourceRef specifies the
                                           object from which to populate the volume
@@ -10845,7 +10776,6 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       resources:
                                         description: 'resources represents the minimum
                                           resources the volume should have. If RecoverVolumeExpansionFailure
@@ -10933,7 +10863,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         description: 'storageClassName is the name
                                           of the StorageClass required by the claim.
@@ -10997,7 +10926,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -11043,7 +10971,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -11128,7 +11055,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -11308,7 +11234,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -11354,7 +11279,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -11439,7 +11363,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -11599,7 +11522,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is optional: User is the rados
                                     user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
@@ -11635,7 +11557,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -11715,7 +11636,6 @@ spec:
                                     or its keys must be defined
                                   type: boolean
                               type: object
-                              x-kubernetes-map-type: atomic
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
@@ -11749,7 +11669,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
@@ -11808,7 +11727,6 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       mode:
                                         description: 'Optional: mode bits used to
                                           set permissions on this file, must be an
@@ -11854,7 +11772,6 @@ spec:
                                         required:
                                         - resource
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -11986,7 +11903,6 @@ spec:
                                           - kind
                                           - name
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           description: 'dataSourceRef specifies the
                                             object from which to populate the volume
@@ -12037,7 +11953,6 @@ spec:
                                           - kind
                                           - name
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         resources:
                                           description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
@@ -12130,7 +12045,6 @@ spec:
                                                 ANDed.
                                               type: object
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           description: 'storageClassName is the name
                                             of the StorageClass required by the claim.
@@ -12229,7 +12143,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -12420,7 +12333,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   description: targetPortal is iSCSI Target Portal.
                                     The Portal is either an IP or ip_addr:port if
@@ -12603,7 +12515,6 @@ spec:
                                               the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         description: downwardAPI information about
                                           the downwardAPI data to project
@@ -12635,7 +12546,6 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   description: 'Optional: mode bits
                                                     used to set permissions on this
@@ -12691,7 +12601,6 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -12763,7 +12672,6 @@ spec:
                                               the Secret or its key must be defined
                                             type: boolean
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         description: serviceAccountToken is information
                                           about the serviceAccountToken data to project
@@ -12890,7 +12798,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 user:
                                   description: 'user is the rados user name. Default
                                     is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -12935,7 +12842,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   description: sslEnabled Flag enable/disable SSL
                                     communication with Gateway, default false
@@ -13061,7 +12967,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
@@ -13202,7 +13107,6 @@ spec:
                                     required:
                                     - key
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     description: 'Selects a field of the pod: supports
                                       metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -13221,7 +13125,6 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     description: 'Selects a resource of the container:
                                       only resources limits and requests (limits.cpu,
@@ -13247,7 +13150,6 @@ spec:
                                     required:
                                     - resource
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -13269,7 +13171,6 @@ spec:
                                     required:
                                     - key
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
@@ -13301,7 +13202,6 @@ spec:
                                       be defined
                                     type: boolean
                                 type: object
-                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -13320,7 +13220,6 @@ spec:
                                       defined
                                     type: boolean
                                 type: object
-                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -14403,7 +14302,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -14508,7 +14406,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -14519,7 +14416,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -14604,7 +14500,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 dataSourceRef:
                                   description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
@@ -14650,7 +14545,6 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 resources:
                                   description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
@@ -14735,7 +14629,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 storageClassName:
                                   description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
@@ -14794,7 +14687,6 @@ spec:
                             - kind
                             - name
                             type: object
-                            x-kubernetes-map-type: atomic
                           dataSourceRef:
                             description: 'dataSourceRef specifies the object from
                               which to populate the volume with data, if a non-empty
@@ -14834,7 +14726,6 @@ spec:
                             - kind
                             - name
                             type: object
-                            x-kubernetes-map-type: atomic
                           resources:
                             description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
@@ -14913,7 +14804,6 @@ spec:
                                   contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
-                            x-kubernetes-map-type: atomic
                           storageClassName:
                             description: 'storageClassName is the name of the StorageClass
                               required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -14940,7 +14830,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   telemetry:
                     description: Telemetry defines the desired state for telemetry
                       resources in this datacenter. If telemetry configurations are
@@ -15057,7 +14946,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   certificatesSecretRef:
                     description: 'Certificates for Medusa if client encryption is
                       enabled in Cassandra. The secret must be in the same namespace
@@ -15070,7 +14958,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   containerImage:
                     description: MedusaContainerImage is the image characteristics
                       to use for Medusa containers. Leave nil to use a default image.
@@ -15098,7 +14985,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -15426,7 +15312,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       transferMaxBandwidth:
                         default: 50MB/s
                         description: Max upload bandwidth in MB/s. Defaults to 50
@@ -15548,7 +15433,6 @@ spec:
                                         type: object
                                       type: array
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 weight:
                                   description: Weight associated with matching the
                                     corresponding nodeSelectorTerm, in the range 1-100.
@@ -15654,12 +15538,10 @@ spec:
                                         type: object
                                       type: array
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 type: array
                             required:
                             - nodeSelectorTerms
                             type: object
-                            x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
                         description: Describes pod affinity scheduling rules (e.g.
@@ -15740,7 +15622,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -15798,7 +15679,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -15903,7 +15783,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -15960,7 +15839,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -16064,7 +15942,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -16122,7 +15999,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -16227,7 +16103,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -16284,7 +16159,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -16404,7 +16278,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   containerImage:
                     default:
                       name: cassandra-reaper
@@ -16436,7 +16309,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -16495,7 +16367,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -16720,7 +16591,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   keyspace:
                     default: reaper_db
                     description: The keyspace to use to store Reaper's state. Will
@@ -17494,7 +17364,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                 type: object
               secretsProvider:
                 default: internal
@@ -17620,7 +17489,6 @@ spec:
                                         type: object
                                       type: array
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 weight:
                                   description: Weight associated with matching the
                                     corresponding nodeSelectorTerm, in the range 1-100.
@@ -17726,12 +17594,10 @@ spec:
                                         type: object
                                       type: array
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 type: array
                             required:
                             - nodeSelectorTerms
                             type: object
-                            x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
                         description: Describes pod affinity scheduling rules (e.g.
@@ -17812,7 +17678,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -17870,7 +17735,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -17975,7 +17839,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -18032,7 +17895,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -18136,7 +17998,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -18194,7 +18055,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       description: namespaces specifies a static list
                                         of namespace names that the term applies to.
@@ -18299,7 +18159,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -18356,7 +18215,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -18433,7 +18291,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   containerImage:
                     default:
                       repository: stargateio
@@ -18464,7 +18321,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       registry:
                         default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
@@ -19090,7 +18946,6 @@ spec:
                                 description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                 type: string
                             type: object
-                            x-kubernetes-map-type: atomic
                           type: array
                         usersUpserted:
                           description: The timestamp at which managed cassandra users'
@@ -19221,3 +19076,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrabackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: cassandrabackups.medusa.k8ssandra.io
 spec:
@@ -495,7 +495,6 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -615,12 +614,10 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -718,7 +715,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -791,7 +787,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -916,7 +911,6 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -984,7 +978,6 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -1110,7 +1103,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -1183,7 +1175,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -1308,7 +1299,6 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -1376,7 +1366,6 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
-                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -1506,7 +1495,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -1527,7 +1515,6 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -1557,7 +1544,6 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -1580,7 +1566,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -1614,7 +1599,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -1634,7 +1618,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -3011,7 +2994,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -3032,7 +3014,6 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -3062,7 +3043,6 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -3085,7 +3065,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -3119,7 +3098,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -3139,7 +3117,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -4398,7 +4375,6 @@ spec:
                                         kind, uid?'
                                       type: string
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 type: array
                               initContainers:
                                 description: 'List of initialization containers belonging
@@ -4506,7 +4482,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               fieldRef:
                                                 description: 'Selects a field of the
                                                   pod: supports metadata.name, metadata.namespace,
@@ -4527,7 +4502,6 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 description: 'Selects a resource of
                                                   the container: only resources limits
@@ -4557,7 +4531,6 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               secretKeyRef:
                                                 description: Selects a key of a secret
                                                   in the pod's namespace
@@ -4580,7 +4553,6 @@ spec:
                                                 required:
                                                 - key
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                             type: object
                                         required:
                                         - name
@@ -4614,7 +4586,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           prefix:
                                             description: An optional identifier to
                                               prepend to each key in the ConfigMap.
@@ -4634,7 +4605,6 @@ spec:
                                                   must be defined
                                                 type: boolean
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                         type: object
                                       type: array
                                     image:
@@ -6337,7 +6307,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     maxSkew:
                                       description: 'MaxSkew describes the degree to
                                         which pods may be unevenly distributed. When
@@ -6595,7 +6564,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         user:
                                           description: 'user is optional: User is
                                             the rados user name, default is admin
@@ -6635,7 +6603,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         volumeID:
                                           description: 'volumeID used to identify
                                             the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -6723,7 +6690,6 @@ spec:
                                             ConfigMap or its keys must be defined
                                           type: boolean
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     csi:
                                       description: csi (Container Storage Interface)
                                         represents ephemeral storage that is handled
@@ -6760,7 +6726,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         readOnly:
                                           description: readOnly specifies a read-only
                                             configuration for the volume. Defaults
@@ -6825,7 +6790,6 @@ spec:
                                                 required:
                                                 - fieldPath
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 description: 'Optional: mode bits
                                                   used to set permissions on this
@@ -6879,7 +6843,6 @@ spec:
                                                 required:
                                                 - resource
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                             required:
                                             - path
                                             type: object
@@ -7027,7 +6990,6 @@ spec:
                                                   - kind
                                                   - name
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 dataSourceRef:
                                                   description: 'dataSourceRef specifies
                                                     the object from which to populate
@@ -7085,7 +7047,6 @@ spec:
                                                   - kind
                                                   - name
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 resources:
                                                   description: 'resources represents
                                                     the minimum resources the volume
@@ -7192,7 +7153,6 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
-                                                  x-kubernetes-map-type: atomic
                                                 storageClassName:
                                                   description: 'storageClassName is
                                                     the name of the StorageClass required
@@ -7297,7 +7257,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                       required:
                                       - driver
                                       type: object
@@ -7506,7 +7465,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         targetPortal:
                                           description: targetPortal is iSCSI Target
                                             Portal. The Portal is either an IP or
@@ -7713,7 +7671,6 @@ spec:
                                                       keys must be defined
                                                     type: boolean
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               downwardAPI:
                                                 description: downwardAPI information
                                                   about the downwardAPI data to project
@@ -7750,7 +7707,6 @@ spec:
                                                           required:
                                                           - fieldPath
                                                           type: object
-                                                          x-kubernetes-map-type: atomic
                                                         mode:
                                                           description: 'Optional:
                                                             mode bits used to set
@@ -7816,7 +7772,6 @@ spec:
                                                           required:
                                                           - resource
                                                           type: object
-                                                          x-kubernetes-map-type: atomic
                                                       required:
                                                       - path
                                                       type: object
@@ -7899,7 +7854,6 @@ spec:
                                                       must be defined
                                                     type: boolean
                                                 type: object
-                                                x-kubernetes-map-type: atomic
                                               serviceAccountToken:
                                                 description: serviceAccountToken is
                                                   information about the serviceAccountToken
@@ -8035,7 +7989,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         user:
                                           description: 'user is the rados user name.
                                             Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -8082,7 +8035,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         sslEnabled:
                                           description: sslEnabled Flag enable/disable
                                             SSL communication with Gateway, default
@@ -8222,7 +8174,6 @@ spec:
                                                 kind, uid?'
                                               type: string
                                           type: object
-                                          x-kubernetes-map-type: atomic
                                         volumeName:
                                           description: volumeName is the human-readable
                                             name of the StorageOS volume.  Volume
@@ -8438,7 +8389,6 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     dataSourceRef:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
@@ -8486,7 +8436,6 @@ spec:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -8574,7 +8523,6 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     storageClassName:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
@@ -8638,7 +8586,6 @@ spec:
                                 - kind
                                 - name
                                 type: object
-                                x-kubernetes-map-type: atomic
                               dataSourceRef:
                                 description: 'dataSourceRef specifies the object from
                                   which to populate the volume with data, if a non-empty
@@ -8683,7 +8630,6 @@ spec:
                                 - kind
                                 - name
                                 type: object
-                                x-kubernetes-map-type: atomic
                               resources:
                                 description: 'resources represents the minimum resources
                                   the volume should have. If RecoverVolumeExpansionFailure
@@ -8765,7 +8711,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                                x-kubernetes-map-type: atomic
                               storageClassName:
                                 description: 'storageClassName is the name of the
                                   StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -8909,3 +8854,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_cassandrarestores.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_cassandrarestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: cassandrarestores.medusa.k8ssandra.io
 spec:
@@ -105,3 +105,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupjobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: medusabackupjobs.medusa.k8ssandra.io
 spec:
@@ -76,3 +76,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackups.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: medusabackups.medusa.k8ssandra.io
 spec:
@@ -63,3 +63,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: medusabackupschedules.medusa.k8ssandra.io
 spec:
@@ -103,3 +103,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: medusarestorejobs.medusa.k8ssandra.io
 spec:
@@ -83,3 +83,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: medusatasks.medusa.k8ssandra.io
 spec:
@@ -102,3 +102,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: reapers.reaper.k8ssandra.io
 spec:
@@ -150,7 +150,6 @@ spec:
                                     type: object
                                   type: array
                               type: object
-                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 nodeSelectorTerm, in the range 1-100.
@@ -251,12 +250,10 @@ spec:
                                     type: object
                                   type: array
                               type: object
-                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
-                        x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
                     description: Describes pod affinity scheduling rules (e.g. co-locate
@@ -333,7 +330,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -390,7 +386,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -489,7 +484,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -541,7 +535,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -642,7 +635,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -699,7 +691,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -798,7 +789,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -850,7 +840,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -969,7 +958,6 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
               clientEncryptionStores:
                 description: Client encryption stores which are used by Cassandra
                   and Reaper.
@@ -984,7 +972,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   truststoreSecretRef:
                     description: ref to the secret that contains the truststore and
                       its password the expected format of the secret is a "truststore"
@@ -995,7 +982,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                 required:
                 - keystoreSecretRef
                 - truststoreSecretRef
@@ -1031,7 +1017,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1116,7 +1101,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1330,7 +1314,6 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
               keyspace:
                 default: reaper_db
                 description: The keyspace to use to store Reaper's state. Will default
@@ -2082,7 +2065,6 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
             required:
             - datacenterRef
             type: object
@@ -2120,3 +2102,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/replication.k8ssandra.io_replicatedsecrets.yaml
+++ b/config/crd/bases/replication.k8ssandra.io_replicatedsecrets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: replicatedsecrets.replication.k8ssandra.io
 spec:
@@ -97,7 +97,6 @@ spec:
                       are ANDed.
                     type: object
                 type: object
-                x-kubernetes-map-type: atomic
             type: object
           status:
             description: ReplicatedSecretStatus defines the observed state of ReplicatedSecret
@@ -131,3 +130,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: stargates.stargate.k8ssandra.io
 spec:
@@ -158,7 +158,6 @@ spec:
                                     type: object
                                   type: array
                               type: object
-                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 nodeSelectorTerm, in the range 1-100.
@@ -259,12 +258,10 @@ spec:
                                     type: object
                                   type: array
                               type: object
-                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
-                        x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
                     description: Describes pod affinity scheduling rules (e.g. co-locate
@@ -341,7 +338,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -398,7 +394,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -497,7 +492,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -549,7 +543,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -650,7 +643,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -707,7 +699,6 @@ spec:
                                         The requirements are ANDed.
                                       type: object
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 namespaces:
                                   description: namespaces specifies a static list
                                     of namespace names that the term applies to. The
@@ -806,7 +797,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaceSelector:
                               description: A label query over the set of namespaces
                                 that the term applies to. The term is applied to the
@@ -858,7 +848,6 @@ spec:
                                     requirements are ANDed.
                                   type: object
                               type: object
-                              x-kubernetes-map-type: atomic
                             namespaces:
                               description: namespaces specifies a static list of namespace
                                 names that the term applies to. The term is applied
@@ -946,7 +935,6 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
               cassandraEncryption:
                 description: CassandraEncryption groups together encryption stores
                   that are passed to the Stargate pods, so that they can be mounted
@@ -966,7 +954,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -977,7 +964,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -996,7 +982,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                       truststoreSecretRef:
                         description: ref to the secret that contains the truststore
                           and its password the expected format of the secret is a
@@ -1007,7 +992,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                        x-kubernetes-map-type: atomic
                     required:
                     - keystoreSecretRef
                     - truststoreSecretRef
@@ -1043,7 +1027,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                    x-kubernetes-map-type: atomic
                   registry:
                     default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
@@ -1066,7 +1049,6 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-                x-kubernetes-map-type: atomic
               heapSize:
                 anyOf:
                 - type: integer
@@ -1346,7 +1328,6 @@ spec:
                                           type: object
                                         type: array
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   weight:
                                     description: Weight associated with matching the
                                       corresponding nodeSelectorTerm, in the range
@@ -1453,12 +1434,10 @@ spec:
                                           type: object
                                         type: array
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - nodeSelectorTerms
                               type: object
-                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           description: Describes pod affinity scheduling rules (e.g.
@@ -1539,7 +1518,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1598,7 +1576,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         description: namespaces specifies a static
                                           list of namespace names that the term applies
@@ -1706,7 +1683,6 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
@@ -1763,7 +1739,6 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list
                                       of namespace names that the term applies to.
@@ -1869,7 +1844,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1928,7 +1902,6 @@ spec:
                                               only "value". The requirements are ANDed.
                                             type: object
                                         type: object
-                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         description: namespaces specifies a static
                                           list of namespace names that the term applies
@@ -2036,7 +2009,6 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     description: A label query over the set of namespaces
                                       that the term applies to. The term is applied
@@ -2093,7 +2065,6 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
-                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     description: namespaces specifies a static list
                                       of namespace names that the term applies to.
@@ -2173,7 +2144,6 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
-                      x-kubernetes-map-type: atomic
                     containerImage:
                       default:
                         repository: stargateio
@@ -2204,7 +2174,6 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
-                          x-kubernetes-map-type: atomic
                         registry:
                           default: docker.io
                           description: The Docker registry to use. Defaults to "docker.io",
@@ -3038,3 +3007,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -312,12 +312,11 @@ func computeJvmOptions(template *api.StargateTemplate) string {
 	heapSize := computeHeapSize(template)
 	heapSizeInBytes := heapSize.Value()
 	jvmOptions := fmt.Sprintf("-XX:+CrashOnOutOfMemoryError -Xms%v -Xmx%v", heapSizeInBytes, heapSizeInBytes)
-	if template.CassandraConfigMapRef != nil {
-		jvmOptions += fmt.Sprintf(
-			" -Dstargate.unsafe.cassandra_config_path=%s",
-			cassandraConfigPath,
-		)
-	}
+	jvmOptions += fmt.Sprintf(
+		" -Dstargate.unsafe.cassandra_config_path=%s",
+		cassandraConfigPath,
+	)
+
 	return jvmOptions
 }
 

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -312,6 +312,8 @@ func computeJvmOptions(template *api.StargateTemplate) string {
 	heapSize := computeHeapSize(template)
 	heapSizeInBytes := heapSize.Value()
 	jvmOptions := fmt.Sprintf("-XX:+CrashOnOutOfMemoryError -Xms%v -Xmx%v", heapSizeInBytes, heapSizeInBytes)
+	// The config map with the cassandra.yaml will always be created, even if it's empty.
+	// We then can always set the jvm option pointing to it.
 	jvmOptions += fmt.Sprintf(
 		" -Dstargate.unsafe.cassandra_config_path=%s",
 		cassandraConfigPath,

--- a/test/testdata/fixtures/single-dc-encryption-stargate/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-encryption-stargate/k8ssandra.yaml
@@ -1,20 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cassandra-config
-data:
-  cassandra.yaml: |
-    concurrent_reads: 32
-    concurrent_writes: 32
-    concurrent_counter_writes: 32
-    cas_contention_timeout_in_ms: 10000
-    counter_write_request_timeout_in_ms: 10000
-    range_request_timeout_in_ms: 10000
-    read_request_timeout_in_ms: 10000
-    request_timeout_in_ms: 10000
-    truncate_request_timeout_in_ms: 60000
-    write_request_timeout_in_ms: 10000
----
 apiVersion: k8ssandra.io/v1alpha1
 kind: K8ssandraCluster
 metadata:
@@ -58,8 +41,6 @@ spec:
             failureThreshold: 20
             successThreshold: 1
             timeoutSeconds: 20
-          cassandraConfigMapRef:
-            name: cassandra-config
     serverEncryptionStores:
       keystoreSecretRef:
         name: server-encryption-stores


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The config map can be created by the operator itself in the case where encryption is turned on but no externally provided config map was present. In this case the jvm option wasn't added although it should have.
This resulted in Stargate failing to join the cluster when internode encryption is turned on, as it wouldn't get the encryption settings.

**Which issue(s) this PR fixes**:
Fixes #683

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
