### PR TITLE
Allow a developer to build the k8ssandra-operator for different target architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ COPY pkg/ pkg/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# Default the GOARCH to amd64, but allow for overide to a different arch at build time
+ARG ARCH=amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**What this PR does**:
This PR enables a developer to build the k8ssandra-operator for a different target architecture.

Added an ARG to Dockerfile that defaults to amd64 but can be changed at build time to compile the executable for a different target architecture.

**Which issue(s) this PR fixes**:
Addresses #693 for developers willing to build images from code and push to their own container registry

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
