### PR TITLE
Handle auth for DSE clusters

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -21,6 +21,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#728](https://github.com/k8ssandra/k8ssandra-operator/issues/728) Add token generation utility
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration
 * [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
+* [BUGFIX] [#744](https://github.com/k8ssandra/k8ssandra-operator/issues/744) Handle auth for DSE clusters
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
 * [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed
 * [BUGFIX] [#758](https://github.com/k8ssandra/k8ssandra-operator/issues/758) Remove -jdk8 suffix for DSE images

--- a/pkg/cassandra/auth_test.go
+++ b/pkg/cassandra/auth_test.go
@@ -77,7 +77,7 @@ func TestApplyAuthSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := ApplyAuthSettings(tt.input, tt.authEnabled)
+			actual := ApplyAuthSettings(tt.input, tt.authEnabled, k8ssandraapi.ServerDistributionCassandra)
 			assert.Equal(t, tt.want, actual)
 		})
 	}

--- a/test/e2e/dse_test.go
+++ b/test/e2e/dse_test.go
@@ -52,6 +52,10 @@ func createSingleDseDatacenterCluster(t *testing.T, ctx context.Context, namespa
 		"SELECT server_id FROM system.local")
 	require.NoError(t, err, "failed to execute CQL query against DSE")
 	assert.Contains(t, output, "modified", "expected server_id to be modified")
+
+	output, err = f.ExecuteCqlNoAuth(f.DataPlaneContexts[0], namespace, DcPrefix(t, f, dcKey)+"-default-sts-0",
+		"SELECT server_id FROM system.local")
+	require.Error(t, err, "expected CQL query without auth to fail")
 }
 
 // createSingleDseSearchDatacenterCluster creates a K8ssandraCluster with one CassandraDatacenter running with search enabled

--- a/test/framework/cqlsh.go
+++ b/test/framework/cqlsh.go
@@ -50,3 +50,12 @@ func (f *E2eFramework) ExecuteCql(ctx context.Context, k8sContext, namespace, cl
 		query,
 	)
 }
+
+func (f *E2eFramework) ExecuteCqlNoAuth(k8sContext, namespace, pod, query string) (string, error) {
+	options := kubectl.Options{Context: k8sContext, Namespace: namespace}
+	return kubectl.Exec(options, pod,
+		f.cqlshBin,
+		"-e",
+		query,
+	)
+}

--- a/test/testdata/fixtures/single-dc-dse/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-dse/k8ssandra.yaml
@@ -3,6 +3,7 @@ kind: K8ssandraCluster
 metadata:
   name: test
 spec:
+  auth: true
   cassandra:
     serverVersion: 6.8.26
     serverType: dse
@@ -25,15 +26,7 @@ spec:
               requests:
                 storage: 5Gi
         config:
-          cassandraYaml:
-            authenticator: com.datastax.bdp.cassandra.auth.DseAuthenticator
-            authorizer: com.datastax.bdp.cassandra.auth.DseAuthorizer
-            role_manager: com.datastax.bdp.cassandra.auth.DseRoleManager
           dseYaml:
-            authentication_options:
-              enabled: true
-            authorization_options:
-              enabled: true
             server_id: server-id
           jvmOptions:
             heap_initial_size: 512Mi


### PR DESCRIPTION
**What this PR does**:
Set the proper configuration options when `spec.cassandra.serverType == dse` and `spec.auth == true`.

**Which issue(s) this PR fixes**:
#744 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
