### PR TITLE
Add e2e test for using separate commitlog and data volumes

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -23,4 +23,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
   [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
 * [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed
+* [TESTING] [#749](https://github.com/k8ssandra/k8ssandra-operator/issues/749) Add e2e test for distinct commit log and data volumes
 * [TESTING] [#747](https://github.com/k8ssandra/k8ssandra-operator/issues/747) Add e2e test and docs for JBOD support

--- a/docs/separate-commitlog-volume.md
+++ b/docs/separate-commitlog-volume.md
@@ -1,0 +1,41 @@
+# Using separate volumes for commit log and data
+
+In order to use a separate volume for the commit log, create an additional volume through `.spec.cassandra.datacenters[].extraVolumes.pvcs` and reference the mount path in the `commitlog_directory` Cassandra setting.
+Extra PVCs created this way are managed by the statefulset controller.  
+For example:
+
+```yaml
+spec:
+  cassandra:
+    serverVersion: 4.0.6
+    clusterName: "Test cluster"
+    datacenters:
+      - metadata:
+          name: dc1
+        k8sContext: kind-k8ssandra-0
+        size: 3
+        storageConfig:
+          cassandraDataVolumeClaimSpec:
+            storageClassName: standard
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 5Gi
+        extraVolumes:
+          pvcs:
+            - name: commitlog-vol
+              mountPath: "/etc/commitlog"
+              pvcSpec:
+                storageClassName: standard
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+        config:
+          cassandraYaml:
+            commitlog_directory: "/etc/commitlog"
+```
+
+In the above example, the default `/var/lib/cassandra/data` directory will be created in the mandatory PVC defined by `.spec.cassandra.datacenters[].storageConfig.cassandraDataVolumeClaimSpec` and will host the Cassandra data folders. The `/etc/commitlog` directory will be mounted in the additional PVC defined by `.spec.cassandra.datacenters[].extraVolumes.pvcs` and will host the commit log files, as configured under `.spec.cassandra.datacenters[].config.cassandraYaml.commitlog_directory`.

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -700,7 +700,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	dcPrefix := DcPrefix(t, f, dcKey)
 	require.NoError(checkMetricsFiltersPresence(t, ctx, f, dcKey))
 	require.NoError(checkInjectedContainersPresence(t, ctx, f, dcKey))
-	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey))
+	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 2))
 
 	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-stargate"}}
 	checkStargateReady(t, f, ctx, stargateKey)
@@ -1825,7 +1825,7 @@ func checkInjectedContainersPresence(t *testing.T, ctx context.Context, f *frame
 	return nil
 }
 
-func checkInjectedVolumePresence(t *testing.T, ctx context.Context, f *framework.E2eFramework, dcKey framework.ClusterKey) error {
+func checkInjectedVolumePresence(t *testing.T, ctx context.Context, f *framework.E2eFramework, dcKey framework.ClusterKey, nbVolumes int) error {
 	t.Logf("check that volumes were injected in %s cass pods in cluster %s", dcKey.Name, dcKey.K8sContext)
 	cassdc := &cassdcapi.CassandraDatacenter{}
 	err := f.Get(ctx, dcKey, cassdc)
@@ -1833,7 +1833,7 @@ func checkInjectedVolumePresence(t *testing.T, ctx context.Context, f *framework
 		return err
 	}
 
-	require.Equal(t, 1, len(cassdc.Spec.StorageConfig.AdditionalVolumes), "expected 1 additional volume")
+	require.Equal(t, nbVolumes, len(cassdc.Spec.StorageConfig.AdditionalVolumes), "expected a different number of additional volume")
 	require.Equal(t, "/etc/extra", cassdc.Spec.StorageConfig.AdditionalVolumes[0].MountPath, "expected busybox-vol mount path")
 
 	_, found := cassandra.FindVolume(cassdc.Spec.PodTemplateSpec, "busybox-vol")

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -4,13 +4,13 @@ metadata:
   name: test
 spec:
   cassandra:
-    serverVersion: 3.11.11
+    serverVersion: 4.0.6
     clusterName: "Weird Cluster Name"
     datacenters:
       - metadata:
           name: dc1
         k8sContext: kind-k8ssandra-0
-        size: 1
+        size: 3
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard
@@ -51,11 +51,21 @@ spec:
                 resources:
                   requests:
                     storage: 1Gi
+            - name: commitlog-vol
+              mountPath: "/etc/commitlog"
+              pvcSpec:
+                storageClassName: standard
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 100Mi
         config:
           cassandraYaml:
             data_file_directories:
               - /var/lib/cassandra/data
               - /etc/extra/data
+            commitlog_directory: "/etc/commitlog"
           jvmOptions:
             heap_initial_size: 512Mi
             heap_max_size: 512Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modify an e2e test for separate commit logs and data volumes.

**Which issue(s) this PR fixes**:
Fixes #749 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
