### PR TITLE
Move jvm11 options to jvm8 for DSE

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -21,8 +21,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#728](https://github.com/k8ssandra/k8ssandra-operator/issues/728) Add token generation utility
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration
 * [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
-* [FEATURE] [#729](https://github.com/k8ssandra/k8ssandra-operator/issues/729) Compute initial tokens for clusters with low number of tokens
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
 * [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed
 * [TESTING] [#749](https://github.com/k8ssandra/k8ssandra-operator/issues/749) Add e2e test for distinct commit log and data volumes
 * [TESTING] [#747](https://github.com/k8ssandra/k8ssandra-operator/issues/747) Add e2e test and docs for JBOD support
+* [BUGFIX] [#755](https://github.com/k8ssandra/k8ssandra-operator/issues/755) Move jvm11 options to jvm8 for DSE

--- a/apis/k8ssandra/v1alpha1/cassandraconfig_types.go
+++ b/apis/k8ssandra/v1alpha1/cassandraconfig_types.go
@@ -200,7 +200,7 @@ type JvmOptions struct {
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm11-server.options.
 	// Corresponds to: -Dio.netty.tryReflectionSetAccessible=true.
 	// +optional
-	NettyTryReflectionSetAccessible *bool `json:"netty_try_reflection_set_accessible,omitempty" cass-config:">=4.x,dse@>=6.8.x:jvm11-server-options/io_netty_try_reflection_set_accessible"`
+	NettyTryReflectionSetAccessible *bool `json:"netty_try_reflection_set_accessible,omitempty" cass-config:">=4.x:jvm11-server-options/io_netty_try_reflection_set_accessible;dse@>=6.8.x:jvm8-server-options/io_netty_try_reflection_set_accessible"`
 
 	// Defaults to 1048576.
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm-server.options.
@@ -220,7 +220,7 @@ type JvmOptions struct {
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm11-server.options.
 	// Corresponds to: -Djdk.attach.allowAttachSelf=true.
 	// +optional
-	JdkAllowAttachSelf *bool `json:"jdk_allow_attach_self,omitempty" cass-config:">=4.x,dse@>=6.8.x:jvm11-server-options/jdk_attach_allow_attach_self"`
+	JdkAllowAttachSelf *bool `json:"jdk_allow_attach_self,omitempty" cass-config:">=4.x:jvm11-server-options/jdk_attach_allow_attach_self;dse@>=6.8.x:jvm8-server-options/jdk_attach_allow_attach_self"`
 
 	// CASSANDRA STARTUP OPTIONS
 
@@ -316,7 +316,7 @@ type JvmOptions struct {
 	// +kubebuilder:validation:Enum=G1GC;CMS;ZGC;Shenandoah;Graal;Custom
 	// +kubebuilder:default=G1GC
 	// +optional
-	GarbageCollector *string `json:"gc,omitempty" cass-config:"^3.11.x:jvm-options/garbage_collector;>=4.x,dse@>=6.8.x:jvm11-server-options/garbage_collector"`
+	GarbageCollector *string `json:"gc,omitempty" cass-config:"^3.11.x:jvm-options/garbage_collector;>=4.x:jvm11-server-options/garbage_collector;dse@>=6.8.x:jvm8-server-options/garbage_collector"`
 
 	// CMS
 
@@ -366,14 +366,14 @@ type JvmOptions struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	// +optional
-	G1RSetUpdatingPauseTimePercent *int `json:"gc_g1_rset_updating_pause_time_percent,omitempty" cass-config:"^3.11.x:jvm-options/g1r_set_updating_pause_time_percent;>=4.x,dse@>=6.8.x:jvm11-server-options/g1r_set_updating_pause_time_percent"`
+	G1RSetUpdatingPauseTimePercent *int `json:"gc_g1_rset_updating_pause_time_percent,omitempty" cass-config:"^3.11.x:jvm-options/g1r_set_updating_pause_time_percent;>=4.x:jvm11-server-options/g1r_set_updating_pause_time_percent;dse@>=6.8.x:jvm8-server-options/g1r_set_updating_pause_time_percent"`
 
 	// G1GC Max GC Pause in milliseconds. Defaults to 500. Can only be used when G1 garbage collector is used.
 	// Cass Config Builder: supported for Cassandra 3.11 in jvm.options.
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm11-server.options.
 	// Corresponds to: -XX:MaxGCPauseMillis.
 	// +optional
-	G1MaxGcPauseMs *int `json:"gc_g1_max_gc_pause_ms,omitempty" cass-config:"^3.11.x:jvm-options/max_gc_pause_millis;>=4.x,dse@>=6.8.x:jvm11-server-options/max_gc_pause_millis"`
+	G1MaxGcPauseMs *int `json:"gc_g1_max_gc_pause_ms,omitempty" cass-config:"^3.11.x:jvm-options/max_gc_pause_millis;>=4.x:jvm11-server-options/max_gc_pause_millis;dse@>=6.8.x:jvm8-server-options/max_gc_pause_millis"`
 
 	// Initiating Heap Occupancy Percentage. Can only be used when G1 garbage collector is used.
 	// Cass Config Builder: supported for Cassandra 3.11 in jvm.options.
@@ -382,14 +382,14 @@ type JvmOptions struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	// +optional
-	G1InitiatingHeapOccupancyPercent *int `json:"gc_g1_initiating_heap_occupancy_percent,omitempty" cass-config:"^3.11.x:jvm-options/initiating_heap_occupancy_percent;>=4.x,dse@>=6.8.x:jvm11-server-options/initiating_heap_occupancy_percent"`
+	G1InitiatingHeapOccupancyPercent *int `json:"gc_g1_initiating_heap_occupancy_percent,omitempty" cass-config:"^3.11.x:jvm-options/initiating_heap_occupancy_percent;>=4.x:jvm11-server-options/initiating_heap_occupancy_percent;dse@>=6.8.x:jvm8-server-options/initiating_heap_occupancy_percent"`
 
 	// Parallel GC Threads. Can only be used when G1 garbage collector is used.
 	// Cass Config Builder: supported for Cassandra 3.11 in jvm.options.
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm11-server.options.
 	// Corresponds to: -XX:ParallelGCThreads.
 	// +optional
-	G1ParallelGcThreads *int `json:"gc_g1_parallel_threads,omitempty" cass-config:"^3.11.x:jvm-options/parallel_gc_threads;>=4.x,dse@>=6.8.x:jvm11-server-options/parallel_gc_threads"`
+	G1ParallelGcThreads *int `json:"gc_g1_parallel_threads,omitempty" cass-config:"^3.11.x:jvm-options/parallel_gc_threads;>=4.x:jvm11-server-options/parallel_gc_threads;dse@>=6.8.x:jvm8-server-options/parallel_gc_threads"`
 
 	// Concurrent GC Threads. Can only be used when G1 garbage collector is used.
 	// Disabled by default.
@@ -397,7 +397,7 @@ type JvmOptions struct {
 	// Cass Config Builder: supported for Cassandra 4.0 in jvm11-server.options.
 	// Corresponds to: -XX:ConcGCThreads.
 	// +optional
-	G1ConcGcThreads *int `json:"gc_g1_conc_threads,omitempty" cass-config:"^3.11.x:jvm-options/conc_gc_threads;>=4.x,dse@>=6.8.x:jvm11-server-options/conc_gc_threads"`
+	G1ConcGcThreads *int `json:"gc_g1_conc_threads,omitempty" cass-config:"^3.11.x:jvm-options/conc_gc_threads;>=4.x:jvm11-server-options/conc_gc_threads;dse@>=6.8.x:jvm8-server-options/conc_gc_threads"`
 
 	// GC LOGGING OPTIONS (currently only available for Cassandra 3.11)
 

--- a/pkg/cassandra/config_test.go
+++ b/pkg/cassandra/config_test.go
@@ -199,8 +199,8 @@ func TestCreateJsonConfig(t *testing.T) {
 			serverType:    api.ServerDistributionDse,
 			cassandraConfig: api.CassandraConfig{
 				JvmOptions: api.JvmOptions{
-					GarbageCollector:             pointer.String("ZGC"),
-					AdditionalJvm11ServerOptions: []string{"-XX:+UseConcMarkSweepGC"},
+					GarbageCollector:            pointer.String("ZGC"),
+					AdditionalJvm8ServerOptions: []string{"-XX:+UseConcMarkSweepGC"},
 				},
 				DseYaml: unstructured.Unstructured{
 					"authentication_options": map[string]interface{}{
@@ -209,7 +209,7 @@ func TestCreateJsonConfig(t *testing.T) {
 				},
 			},
 			want: `{
-             "jvm11-server-options": {
+             "jvm8-server-options": {
                "garbage_collector": "ZGC",
 							 "additional-jvm-opts": ["-XX:+UseConcMarkSweepGC"]
              },
@@ -226,10 +226,9 @@ func TestCreateJsonConfig(t *testing.T) {
 			serverType:    api.ServerDistributionDse,
 			cassandraConfig: api.CassandraConfig{
 				JvmOptions: api.JvmOptions{
-					GarbageCollector:             pointer.String("ZGC"),
-					AdditionalJvm11ServerOptions: []string{"-XX:+UseConcMarkSweepGC"},
-					AdditionalJvm8ServerOptions:  []string{"-XX:ThreadPriorityPolicy=42"},
-					AdditionalJvmServerOptions:   []string{"-Dio.netty.maxDirectMemory=0"},
+					GarbageCollector:            pointer.String("ZGC"),
+					AdditionalJvm8ServerOptions: []string{"-XX:ThreadPriorityPolicy=42", "-XX:+UseConcMarkSweepGC"},
+					AdditionalJvmServerOptions:  []string{"-Dio.netty.maxDirectMemory=0"},
 				},
 				DseYaml: unstructured.Unstructured{
 					"authentication_options": map[string]interface{}{
@@ -242,12 +241,9 @@ func TestCreateJsonConfig(t *testing.T) {
 							"additional-jvm-opts": ["-Dio.netty.maxDirectMemory=0"]
 						},
 						 "jvm8-server-options": {
-							"additional-jvm-opts": ["-XX:ThreadPriorityPolicy=42"]
+							"garbage_collector": "ZGC",
+							"additional-jvm-opts": ["-XX:ThreadPriorityPolicy=42", "-XX:+UseConcMarkSweepGC"]
 						},
-            "jvm11-server-options": {
-              "garbage_collector": "ZGC",
-							"additional-jvm-opts": ["-XX:+UseConcMarkSweepGC"]
-            },
             "dse-yaml": {
               "authentication_options": {
 				        "enabled": true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Redirects jvm11-server.options entries to the jvm8-server.options file for DSE.

**Which issue(s) this PR fixes**:
Fixes #755

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
