### PR TITLE
Disable secrets management and replication with the external secrets …

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,4 +14,4 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-
+* [FEATURE] [#599](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -77,8 +77,16 @@ type K8ssandraClusterSpec struct {
 	SecretsProvider string `json:"secretsProvider,omitempty"`
 }
 
+// IsAuthEnabled returns true if auth is not specified by the user (auth by default)
+// or if the user has explicilty set Auth to true in the cluster spec
 func (in K8ssandraClusterSpec) IsAuthEnabled() bool {
 	return in.Auth == nil || *in.Auth
+}
+
+// UseExternalSecrets defines whether the user has specified if credentials and
+// certs will be backed by an external secrets store
+func (in K8ssandraClusterSpec) UseExternalSecrets() bool {
+	return in.SecretsProvider != "" && in.SecretsProvider == "external"
 }
 
 // K8ssandraClusterStatus defines the observed state of K8ssandraCluster

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -140,6 +140,12 @@ type ReaperTemplate struct {
 	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 }
 
+// UseExternalSecrets defines whether the user has specified if credentials and
+// certs will be backed by an external secrets store
+func (in ReaperTemplate) UseExternalSecrets() bool {
+	return in.SecretsProvider != "" && in.SecretsProvider == "external"
+}
+
 // AutoScheduling includes options to configure the auto scheduling of repairs for new clusters.
 type AutoScheduling struct {
 

--- a/apis/stargate/v1alpha1/stargate_types.go
+++ b/apis/stargate/v1alpha1/stargate_types.go
@@ -122,6 +122,12 @@ type StargateTemplate struct {
 	SecretsProvider string `json:"secretsProvider,omitempty"`
 }
 
+// UseExternalSecrets defines whether the user has specified if credentials and
+// certs will be backed by an external secrets store
+func (in StargateTemplate) UseExternalSecrets() bool {
+	return in.SecretsProvider != "" && in.SecretsProvider == "external"
+}
+
 // StargateClusterTemplate defines global rules to apply to all Stargate pods in all datacenters in the cluster.
 // These rules will be merged with rules defined at datacenter level in a StargateDatacenterTemplate; dc-level rules
 // have precedence over cluster-level ones.

--- a/controllers/k8ssandra/auth_test.go
+++ b/controllers/k8ssandra/auth_test.go
@@ -296,15 +296,11 @@ func createSingleDcClusterAuthExternalSecrets(t *testing.T, ctx context.Context,
 				}},
 			},
 			Stargate: &stargateapi.StargateClusterTemplate{
-				StargateTemplate: stargateapi.StargateTemplate{
-					SecretsProvider: "external",
-				},
-				Size: 1,
+				StargateTemplate: stargateapi.StargateTemplate{},
+				Size:             1,
 			},
 			Reaper: &reaperapi.ReaperClusterTemplate{
-				ReaperTemplate: reaperapi.ReaperTemplate{
-					SecretsProvider: "external",
-				},
+				ReaperTemplate: reaperapi.ReaperTemplate{},
 			},
 			SecretsProvider: "external",
 		},

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -58,7 +58,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 	// Reconcile CassandraDatacenter objects only
 	for idx, dcConfig := range sortDatacentersByPriority(dcConfigs) {
 
-		if !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcConfig.K8sContext) {
+		if !kc.Spec.UseExternalSecrets() && !secret.HasReplicatedSecrets(ctx, r.Client, kcKey, dcConfig.K8sContext) {
 			// ReplicatedSecret has not replicated yet, wait until it has
 			logger.Info("Waiting for replication to complete")
 			return result.RequeueSoon(r.DefaultDelay), actualDcs

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -28,6 +28,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 	for _, dcTemplate := range kc.Spec.Cassandra.Datacenters {
 
 		dcConfig := cassandra.Coalesce(kc.CassClusterName(), kc.Spec.Cassandra.DeepCopy(), dcTemplate.DeepCopy())
+		dcConfig.ExternalSecrets = kc.Spec.UseExternalSecrets()
 
 		dcKey := types.NamespacedName{Namespace: utils.FirstNonEmptyString(dcConfig.Meta.Namespace, kcKey.Namespace), Name: dcConfig.Meta.Name}
 		dcLogger := logger.WithValues("CassandraDatacenter", dcKey, "K8SContext", dcConfig.K8sContext)
@@ -47,7 +48,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 			return nil, err
 		}
 
-		_ = cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled())
+		_ = cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled(), kc.Spec.UseExternalSecrets())
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on
 		// unauthenticated clusters.

--- a/controllers/k8ssandra/reaper.go
+++ b/controllers/k8ssandra/reaper.go
@@ -100,6 +100,7 @@ func (r *K8ssandraClusterReconciler) reconcileReaper(
 	actualReaper := &reaperapi.Reaper{}
 
 	if reaperTemplate != nil {
+		reaperTemplate.SecretsProvider = kc.Spec.SecretsProvider
 
 		logger.Info("Reaper present for DC " + actualDc.Name)
 

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -54,7 +54,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
 	if kc.Spec.Reaper != nil {
 		// Reaper secrets are only required when authentication is enabled on the cluster
-		if kc.Spec.IsAuthEnabled() && !kc.Spec.Reaper.UseExternalSecrets() {
+		if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
 			logger.Info("Reconciling Reaper user secrets")
 			var cassandraUserSecretRef corev1.LocalObjectReference
 			var jmxUserSecretRef corev1.LocalObjectReference
@@ -87,7 +87,7 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 				return result.Error(err)
 			}
 			logger.Info("Reaper user secrets successfully reconciled")
-		} else if kc.Spec.IsAuthEnabled() && kc.Spec.Reaper.UseExternalSecrets() {
+		} else if kc.Spec.IsAuthEnabled() && kc.Spec.UseExternalSecrets() {
 			// Auth is enabled in the cluster, but the SecretsProvider is set to external, so no secret need to
 			// be reconciled. Secrets will be injected into the Reaper pod by the mutating webhook configured by
 			// the user to retrieve secrets from the external secret store of their choice.

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -17,6 +17,12 @@ import (
 )
 
 func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	// If secrets provider is set to external, the CQL user will be created by a kubernetes job and does not need to be set
+	// in the cassdc settings
+	if kc.Spec.UseExternalSecrets() {
+		return result.Continue()
+	}
+
 	// Note that we always create a superuser secret, even when authentication is globally disabled on the cluster.
 	// This is because cass-operator would create a DC-specific superuser if we don't create a cluster-wide one here,
 	// and also because if we don't create the secret when the K8ssandraCluster is created, then it would be impossible
@@ -48,7 +54,7 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
 	if kc.Spec.Reaper != nil {
 		// Reaper secrets are only required when authentication is enabled on the cluster
-		if kc.Spec.IsAuthEnabled() {
+		if kc.Spec.IsAuthEnabled() && !kc.Spec.Reaper.UseExternalSecrets() {
 			logger.Info("Reconciling Reaper user secrets")
 			var cassandraUserSecretRef corev1.LocalObjectReference
 			var jmxUserSecretRef corev1.LocalObjectReference
@@ -81,6 +87,11 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 				return result.Error(err)
 			}
 			logger.Info("Reaper user secrets successfully reconciled")
+		} else if kc.Spec.IsAuthEnabled() && kc.Spec.Reaper.UseExternalSecrets() {
+			// Auth is enabled in the cluster, but the SecretsProvider is set to external, so no secret need to
+			// be reconciled. Secrets will be injected into the Reaper pod by the mutating webhook configured by
+			// the user to retrieve secrets from the external secret store of their choice.
+			logger.Info("Auth is enabled and SecretsProvider is 'external': skipping Reaper user secret reconciliation")
 		} else {
 			// Auth is disabled in the cluster, so no Reaper secrets need to be reconciled. Note that, if auth was
 			// previously enabled, Reaper secrets may have been created, but they are now useless; we don't delete them
@@ -93,6 +104,10 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 }
 
 func (r *K8ssandraClusterReconciler) reconcileReplicatedSecret(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	if kc.Spec.UseExternalSecrets() {
+		return result.Continue()
+	}
+
 	if err := secret.ReconcileReplicatedSecret(ctx, r.Client, r.Scheme, kc, logger); err != nil {
 		logger.Error(err, "Failed to reconcile ReplicatedSecret")
 		return result.Error(err)

--- a/controllers/k8ssandra/stargate.go
+++ b/controllers/k8ssandra/stargate.go
@@ -43,6 +43,7 @@ func (r *K8ssandraClusterReconciler) reconcileStargate(
 
 	if stargateTemplate != nil {
 		logger.Info("Reconcile Stargate")
+		stargateTemplate.SecretsProvider = kc.Spec.SecretsProvider
 		desiredStargate := stargate.NewStargate(stargateKey, kc, stargateTemplate, actualDc, dcTemplate, logger)
 		annotations.AddHashAnnotation(desiredStargate)
 

--- a/controllers/reaper/reaper_controller.go
+++ b/controllers/reaper/reaper_controller.go
@@ -169,7 +169,7 @@ func (r *ReaperReconciler) reconcileDeployment(
 	var keystorePassword *string
 	var truststorePassword *string
 
-	if actualReaper.Spec.ClientEncryptionStores != nil {
+	if actualReaper.Spec.ClientEncryptionStores != nil && !actualReaper.Spec.UseExternalSecrets() {
 		if password, err := cassandra.ReadEncryptionStorePassword(ctx, actualReaper.Namespace, r.Client, actualReaper.Spec.ClientEncryptionStores, encryption.StoreNameKeystore); err != nil {
 			return ctrl.Result{RequeueAfter: r.DefaultDelay}, err
 		} else {
@@ -377,7 +377,7 @@ func (r *ReaperReconciler) collectAuthVarsForType(ctx context.Context, actualRea
 		envVars = []*corev1.EnvVar{reaper.EnableAuthVar}
 	}
 
-	if len(secretRef.Name) > 0 {
+	if len(secretRef.Name) > 0 && !actualReaper.Spec.UseExternalSecrets() {
 		secretKey := types.NamespacedName{Namespace: actualReaper.Namespace, Name: secretRef.Name}
 		if secret, err := r.getSecret(ctx, secretKey); err != nil {
 			logger.Error(err, "Failed to get Cassandra authentication secret", authType, secretKey)

--- a/pkg/cassandra/auth.go
+++ b/pkg/cassandra/auth.go
@@ -13,7 +13,7 @@ import (
 const JmxInitContainer = "jmx-credentials"
 
 // ApplyAuth modifies the dc config depending on whether auth is enabled in the cluster or not.
-func ApplyAuth(dcConfig *DatacenterConfig, authEnabled bool) error {
+func ApplyAuth(dcConfig *DatacenterConfig, authEnabled bool, useExternalSecrets bool) error {
 
 	if dcConfig.PodTemplateSpec == nil {
 		return errors.New("PodTemplateSpec was nil, cannot add auth settings")
@@ -41,7 +41,7 @@ func ApplyAuth(dcConfig *DatacenterConfig, authEnabled bool) error {
 	// file in each Cassandra pod. This means that it will be possible to use the superuser credentials to authenticate
 	// any JMX client.
 	// TODO use Cassandra internals for JMX authentication, see https://github.com/k8ssandra/k8ssandra/issues/323
-	if authEnabled {
+	if authEnabled && !useExternalSecrets {
 		image := dcConfig.JmxInitContainerImage.ApplyDefaults(DefaultJmxInitImage)
 		dcConfig.PodTemplateSpec.Spec.ImagePullSecrets = images.CollectPullSecrets(image)
 		UpdateInitContainer(dcConfig.PodTemplateSpec, JmxInitContainer, func(c *corev1.Container) {

--- a/pkg/cassandra/encryption.go
+++ b/pkg/cassandra/encryption.go
@@ -21,35 +21,43 @@ const (
 // the datacenter config template.
 func HandleEncryptionOptions(template *DatacenterConfig) error {
 	if ClientEncryptionEnabled(template) {
-		if err := checkMandatoryEncryptionFields(template.ClientEncryptionStores); err != nil {
-			return err
+		if template.ExternalSecrets {
+			// enables encryption options, but doesn't set keystore/trustore path and passwords
+			enableEncyptionOptions(template)
 		} else {
+			if err := checkMandatoryEncryptionFields(template.ClientEncryptionStores); err != nil {
+				return err
+			}
 			// Create the volume and mount for the keystore
 			addVolumesForEncryption(template, encryption.StoreTypeClient, *template.ClientEncryptionStores)
 			// Add JMX encryption jvm options
 			addJmxEncryptionOptions(template)
+
+			keystorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameKeystore), encryption.StoreNameKeystore)
+			truststorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameTruststore), encryption.StoreNameTruststore)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/keystore", keystorePath)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/truststore", truststorePath)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/keystore_password", template.ClientKeystorePassword)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/truststore_password", template.ClientTruststorePassword)
 		}
-		keystorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameKeystore), encryption.StoreNameKeystore)
-		truststorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameTruststore), encryption.StoreNameTruststore)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/keystore", keystorePath)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/truststore", truststorePath)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/keystore_password", template.ClientKeystorePassword)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("client_encryption_options/truststore_password", template.ClientTruststorePassword)
 	}
 
 	if ServerEncryptionEnabled(template) {
-		if err := checkMandatoryEncryptionFields(template.ServerEncryptionStores); err != nil {
-			return err
-		} else {
+		if !template.ExternalSecrets {
+			if err := checkMandatoryEncryptionFields(template.ServerEncryptionStores); err != nil {
+				return err
+			}
+
 			// Create the volume and mount for the keystore
 			addVolumesForEncryption(template, encryption.StoreTypeServer, *template.ServerEncryptionStores)
+
+			keystorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeServer, encryption.StoreNameKeystore), encryption.StoreNameKeystore)
+			truststorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeServer, encryption.StoreNameTruststore), encryption.StoreNameTruststore)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/keystore", keystorePath)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/truststore", truststorePath)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/keystore_password", template.ServerKeystorePassword)
+			template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/truststore_password", template.ServerTruststorePassword)
 		}
-		keystorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeServer, encryption.StoreNameKeystore), encryption.StoreNameKeystore)
-		truststorePath := fmt.Sprintf("%s/%s", StoreMountFullPath(encryption.StoreTypeServer, encryption.StoreNameTruststore), encryption.StoreNameTruststore)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/keystore", keystorePath)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/truststore", truststorePath)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/keystore_password", template.ServerKeystorePassword)
-		template.CassandraConfig.CassandraYaml.PutIfAbsent("server_encryption_options/truststore_password", template.ServerTruststorePassword)
 	}
 	return nil
 }
@@ -161,6 +169,11 @@ func ServerEncryptionEnabled(template *DatacenterConfig) bool {
 }
 
 func ReadEncryptionStoresSecrets(ctx context.Context, klusterKey types.NamespacedName, template *DatacenterConfig, remoteClient client.Client, logger logr.Logger) error {
+	if template.ExternalSecrets {
+		logger.Info("ExternalSecrets enabled, operator will not verify existence of encryption stores secrets")
+		return nil
+	}
+
 	if ClientEncryptionEnabled(template) {
 		if err := checkMandatoryEncryptionFields(template.ClientEncryptionStores); err != nil {
 			return err
@@ -242,12 +255,16 @@ func ReadEncryptionStorePassword(ctx context.Context, namespace string, remoteCl
 
 // Add JVM options required for turning on encryption
 func addJmxEncryptionOptions(template *DatacenterConfig) {
-	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl=true")
-	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
+	enableEncyptionOptions(template)
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.keyStore=%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameKeystore), encryption.StoreNameKeystore))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.trustStore=%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameTruststore), encryption.StoreNameTruststore))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.keyStorePassword=%s", template.ClientKeystorePassword))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.trustStorePassword=%s", template.ClientTruststorePassword))
+}
+
+func enableEncyptionOptions(template *DatacenterConfig) {
+	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl=true")
+	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 }
 
 func addOptionIfMissing(template *DatacenterConfig, option string) {

--- a/pkg/cassandra/encryption.go
+++ b/pkg/cassandra/encryption.go
@@ -23,7 +23,7 @@ func HandleEncryptionOptions(template *DatacenterConfig) error {
 	if ClientEncryptionEnabled(template) {
 		if template.ExternalSecrets {
 			// enables encryption options, but doesn't set keystore/trustore path and passwords
-			enableEncyptionOptions(template)
+			enableEncryptionOptions(template)
 		} else {
 			if err := checkMandatoryEncryptionFields(template.ClientEncryptionStores); err != nil {
 				return err
@@ -255,14 +255,14 @@ func ReadEncryptionStorePassword(ctx context.Context, namespace string, remoteCl
 
 // Add JVM options required for turning on encryption
 func addJmxEncryptionOptions(template *DatacenterConfig) {
-	enableEncyptionOptions(template)
+	enableEncryptionOptions(template)
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.keyStore=%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameKeystore), encryption.StoreNameKeystore))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.trustStore=%s/%s", StoreMountFullPath(encryption.StoreTypeClient, encryption.StoreNameTruststore), encryption.StoreNameTruststore))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.keyStorePassword=%s", template.ClientKeystorePassword))
 	addOptionIfMissing(template, fmt.Sprintf("-Djavax.net.ssl.trustStorePassword=%s", template.ClientTruststorePassword))
 }
 
-func enableEncyptionOptions(template *DatacenterConfig) {
+func enableEncryptionOptions(template *DatacenterConfig) {
 	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl=true")
 	addOptionIfMissing(template, "-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 }

--- a/pkg/reaper/datacenter.go
+++ b/pkg/reaper/datacenter.go
@@ -11,7 +11,7 @@ func AddReaperSettingsToDcConfig(reaperTemplate *reaperapi.ReaperClusterTemplate
 		dcConfig.PodTemplateSpec = &corev1.PodTemplateSpec{}
 	}
 	enableRemoteJmxAccess(dcConfig)
-	if authEnabled && !reaperTemplate.UseExternalSecrets() {
+	if authEnabled && !dcConfig.ExternalSecrets {
 		cassandra.AddCqlUser(reaperTemplate.CassandraUserSecretRef, dcConfig, DefaultUserSecretName(dcConfig.Cluster))
 		enableJmxAuth(reaperTemplate, dcConfig)
 	}

--- a/pkg/reaper/datacenter.go
+++ b/pkg/reaper/datacenter.go
@@ -11,7 +11,7 @@ func AddReaperSettingsToDcConfig(reaperTemplate *reaperapi.ReaperClusterTemplate
 		dcConfig.PodTemplateSpec = &corev1.PodTemplateSpec{}
 	}
 	enableRemoteJmxAccess(dcConfig)
-	if authEnabled {
+	if authEnabled && !reaperTemplate.UseExternalSecrets() {
 		cassandra.AddCqlUser(reaperTemplate.CassandraUserSecretRef, dcConfig, DefaultUserSecretName(dcConfig.Cluster))
 		enableJmxAuth(reaperTemplate, dcConfig)
 	}

--- a/pkg/reaper/datacenter_test.go
+++ b/pkg/reaper/datacenter_test.go
@@ -366,6 +366,32 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 			client.ObjectKey{Namespace: "ns1", Name: "k8c"},
 			false,
 		},
+		{
+			"default auth, external secrets",
+			&reaperapi.ReaperClusterTemplate{
+				ReaperTemplate: reaperapi.ReaperTemplate{
+					SecretsProvider: "external",
+				},
+			},
+			&cassandra.DatacenterConfig{
+				Meta:    api.EmbeddedObjectMeta{Name: "dc1"},
+				Cluster: "cluster1",
+			},
+			&cassandra.DatacenterConfig{
+				Meta:    api.EmbeddedObjectMeta{Name: "dc1"},
+				Cluster: "cluster1",
+				PodTemplateSpec: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: reconciliation.CassandraContainerName,
+							Env:  []corev1.EnvVar{{Name: "LOCAL_JMX", Value: "no"}},
+						}},
+					},
+				},
+			},
+			client.ObjectKey{Namespace: "ns1", Name: "k8c"},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reaper/datacenter_test.go
+++ b/pkg/reaper/datacenter_test.go
@@ -369,17 +369,17 @@ func TestAddReaperSettingsToDcConfig(t *testing.T) {
 		{
 			"default auth, external secrets",
 			&reaperapi.ReaperClusterTemplate{
-				ReaperTemplate: reaperapi.ReaperTemplate{
-					SecretsProvider: "external",
-				},
+				ReaperTemplate: reaperapi.ReaperTemplate{},
 			},
 			&cassandra.DatacenterConfig{
-				Meta:    api.EmbeddedObjectMeta{Name: "dc1"},
-				Cluster: "cluster1",
+				Meta:            api.EmbeddedObjectMeta{Name: "dc1"},
+				Cluster:         "cluster1",
+				ExternalSecrets: true,
 			},
 			&cassandra.DatacenterConfig{
-				Meta:    api.EmbeddedObjectMeta{Name: "dc1"},
-				Cluster: "cluster1",
+				Meta:            api.EmbeddedObjectMeta{Name: "dc1"},
+				Cluster:         "cluster1",
+				ExternalSecrets: true,
 				PodTemplateSpec: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -48,7 +48,7 @@ func NewReaper(
 			ClientEncryptionStores: kc.Spec.Cassandra.ClientEncryptionStores,
 		},
 	}
-	if kc.Spec.IsAuthEnabled() && !kc.Spec.Reaper.UseExternalSecrets() {
+	if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
 		// if auth is enabled in this cluster, the k8ssandra controller will automatically create two secrets for
 		// Reaper: one for CQL connections, one for JMX connections. Here we assume that these secrets exist. If the
 		// secrets were specified by the user they should be already present in desiredReaper.Spec; otherwise, we assume

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -48,7 +48,7 @@ func NewReaper(
 			ClientEncryptionStores: kc.Spec.Cassandra.ClientEncryptionStores,
 		},
 	}
-	if kc.Spec.IsAuthEnabled() {
+	if kc.Spec.IsAuthEnabled() && !kc.Spec.Reaper.UseExternalSecrets() {
 		// if auth is enabled in this cluster, the k8ssandra controller will automatically create two secrets for
 		// Reaper: one for CQL connections, one for JMX connections. Here we assume that these secrets exist. If the
 		// secrets were specified by the user they should be already present in desiredReaper.Spec; otherwise, we assume

--- a/pkg/stargate/stargate.go
+++ b/pkg/stargate/stargate.go
@@ -35,12 +35,12 @@ func NewStargate(
 	cassandraEncryption := stargateapi.CassandraEncryption{}
 	dcConfig := cassandra.Coalesce(kc.SanitizedName(), kc.Spec.Cassandra, &dcTemplate)
 
-	if cassandra.ClientEncryptionEnabled(dcConfig) {
+	if cassandra.ClientEncryptionEnabled(dcConfig) && !stargateTemplate.UseExternalSecrets() {
 		logger.Info("Client encryption enabled, setting it up in Stargate")
 		cassandraEncryption.ClientEncryptionStores = kc.Spec.Cassandra.ClientEncryptionStores
 	}
 
-	if cassandra.ServerEncryptionEnabled(dcConfig) {
+	if cassandra.ServerEncryptionEnabled(dcConfig) && !stargateTemplate.UseExternalSecrets() {
 		logger.Info("Server encryption enabled, setting it up in Stargate")
 		cassandraEncryption.ServerEncryptionStores = kc.Spec.Cassandra.ServerEncryptionStores
 	}


### PR DESCRIPTION
…provider

**What this PR does**:

- disables the creation and mounting of superuser secrets for cassandra, medusa, and reaper when SecretsProvider == external for each configuration
- disables the creation of secrets for client/server encryption settings for all applications
- adds unit tests to verify the secrets do not exist

**Which issue(s) this PR fixes**:
Fixes #600 

**Checklist**
- [*] Changes manually tested
- [*] Automated Tests added/updated
- [*] Documentation added/updated
- [*] CHANGELOG.md updated (not required for documentation PRs)
- [*] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
