### PR TITLE
Remove -jdk8 suffix for DSE images

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -23,6 +23,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
 * [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed
+* [BUGFIX] [#758](https://github.com/k8ssandra/k8ssandra-operator/issues/758) Remove -jdk8 suffix for DSE images
 * [TESTING] [#749](https://github.com/k8ssandra/k8ssandra-operator/issues/749) Add e2e test for distinct commit log and data volumes
 * [TESTING] [#747](https://github.com/k8ssandra/k8ssandra-operator/issues/747) Add e2e test and docs for JBOD support
 * [BUGFIX] [#755](https://github.com/k8ssandra/k8ssandra-operator/issues/755) Move jvm11 options to jvm8 for DSE

--- a/config/components/cass-operator-image-config/image_config.yaml
+++ b/config/components/cass-operator-image-config/image_config.yaml
@@ -19,4 +19,3 @@ defaults:
     repository: "k8ssandra/cass-management-api"
   dse:
     repository: "datastax/dse-mgmtapi-6_8"
-    suffix: "-jdk8"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Point to the unsuffixed images as the jdk8 ones don't have a suffix anymore.

**Which issue(s) this PR fixes**:
Fixes #758 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
