### PR TITLE
Fix removal of DC that is local to the control plane

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -89,6 +89,7 @@ jobs:
           - CreateSingleDseGraphDatacenterCluster
           - ChangeDseWorkload
           - PerNodeConfig/UserDefined
+          - RemoveLocalDcFromCluster
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -21,6 +21,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#728](https://github.com/k8ssandra/k8ssandra-operator/issues/728) Add token generation utility
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration
 * [FEATURE] [#718](https://github.com/k8ssandra/k8ssandra-operator/issues/718) Make keystore-password, keystore, truststore keys in secret configurable
+* [BUGFIX] [#642](https://github.com/k8ssandra/k8ssandra-operator/issues/642) Fix removal of DC that is local to the control plane
 * [BUGFIX] [#744](https://github.com/k8ssandra/k8ssandra-operator/issues/744) Handle auth for DSE clusters
 * [BUGFIX] [#722](https://github.com/k8ssandra/k8ssandra-operator/issues/722) Enable client-side CQL encryption in Stargate if it is configured on the cluster
 * [BUGFIX] [#714](https://github.com/k8ssandra/k8ssandra-operator/issues/714) Don't restart whole Cassandra 4 DC when Stargate is added or removed

--- a/controllers/k8ssandra/cleanup.go
+++ b/controllers/k8ssandra/cleanup.go
@@ -222,7 +222,7 @@ func (r *K8ssandraClusterReconciler) findStargateForDeletion(
 	stargateName := kcKey.Name + "-" + dcName + "-stargate"
 
 	if remoteClient == nil {
-		for _, remoteClient := range r.ClientCache.GetRemoteClients() {
+		for _, remoteClient := range r.ClientCache.GetAllClients() {
 			err := remoteClient.List(ctx, stargateList, options)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to find Stargate (%s) for DC (%s) deletion: %v", stargateName, dcName, err)
@@ -261,7 +261,7 @@ func (r *K8ssandraClusterReconciler) findReaperForDeletion(
 	reaperName := kcKey.Name + "-" + dcName + "-reaper"
 
 	if remoteClient == nil {
-		for _, remoteClient := range r.ClientCache.GetRemoteClients() {
+		for _, remoteClient := range r.ClientCache.GetAllClients() {
 			err := remoteClient.List(ctx, reaperList, options)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to find Reaper (%s) for DC (%s) deletion: %v", reaperName, dcName, err)
@@ -298,7 +298,7 @@ func (r *K8ssandraClusterReconciler) findDcForDeletion(
 	dcList := &cassdcapi.CassandraDatacenterList{}
 
 	if remoteClient == nil {
-		for _, remoteClient := range r.ClientCache.GetRemoteClients() {
+		for _, remoteClient := range r.ClientCache.GetAllClients() {
 			err := remoteClient.List(ctx, dcList, options)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to CassandraDatacenter (%s) for DC (%s) deletion: %v", dcName, dcName, err)
@@ -310,16 +310,14 @@ func (r *K8ssandraClusterReconciler) findDcForDeletion(
 			}
 		}
 	} else {
-		for _, remoteClient := range r.ClientCache.GetRemoteClients() {
-			err := remoteClient.List(ctx, dcList, options)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to find CassandraDatacenter (%s) for deletion: %v", dcName, err)
-			}
+		err := remoteClient.List(ctx, dcList, options)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to find CassandraDatacenter (%s) for deletion: %v", dcName, err)
+		}
 
-			for _, dc := range dcList.Items {
-				if dc.Name == dcName {
-					return &dc, remoteClient, nil
-				}
+		for _, dc := range dcList.Items {
+			if dc.Name == dcName {
+				return &dc, remoteClient, nil
 			}
 		}
 	}

--- a/pkg/clientcache/cache.go
+++ b/pkg/clientcache/cache.go
@@ -61,6 +61,16 @@ func (c *ClientCache) GetRemoteClients() map[string]client.Client {
 	return c.remoteClients
 }
 
+// GetAllClients returns all the remote clients, plus the local one.
+func (c *ClientCache) GetAllClients() []client.Client {
+	clients := make([]client.Client, 0, len(c.remoteClients)+1)
+	for _, remoteClient := range c.remoteClients {
+		clients = append(clients, remoteClient)
+	}
+	clients = append(clients, c.localClient)
+	return clients
+}
+
 // AddClient adds a new remoteClient with the name k8sContextName
 func (c *ClientCache) AddClient(k8sContextName string, cli client.Client) {
 	c.remoteClients[k8sContextName] = cli

--- a/test/testdata/fixtures/remove-local-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/remove-local-dc/k8ssandra.yaml
@@ -1,0 +1,41 @@
+apiVersion: k8ssandra.io/v1alpha1
+kind: K8ssandraCluster
+metadata:
+  name: test
+spec:
+  cassandra:
+    serverVersion: "4.0.1"
+    storageConfig:
+      cassandraDataVolumeClaimSpec:
+        storageClassName: standard
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 256Mi
+    config:
+      cassandraYaml:
+        auto_snapshot: false
+        memtable_flush_writers: 1
+        commitlog_segment_size_in_mb: 2
+        concurrent_compactors: 1
+        compaction_throughput_mb_per_sec: 0
+        sstable_preemptive_open_interval_in_mb: 0
+        key_cache_size_in_mb: 0
+        prepared_statements_cache_size_mb: 1
+        slow_query_log_timeout_in_ms: 0
+        counter_cache_size_in_mb: 0
+        concurrent_reads: 2
+        concurrent_writes: 2
+        concurrent_counter_writes: 2
+      jvmOptions:
+        heapSize: 512Mi
+    networking:
+      hostNetwork: true
+    datacenters:
+      - metadata:
+          name: dc1
+        size: 1
+      - metadata:
+          name: dc2
+        size: 1

--- a/test/testdata/fixtures/remove-local-dc/kustomization.yaml
+++ b/test/testdata/fixtures/remove-local-dc/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - k8ssandra.yaml


### PR DESCRIPTION
**What this PR does**:
Fix the DC deletion code so that it works even when the DC is "local", i.e. in the control plane itself.

**Which issue(s) this PR fixes**:
Fixes #642

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
