### PR TITLE
Allow for CORS to be enabled on Reaper

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#815](https://github.com/k8ssandra/k8ssandra-operator/issues/815) Add configuration block to CRDs for new Cassandra metrics agent.
 * [ENHANCEMENT] [#859](https://github.com/k8ssandra/k8ssandra-operator/issues/859) Remove current usages of managed-by label
 * [BUGFIX] [#854](https://github.com/k8ssandra/k8ssandra-operator/issues/854) Use Patch() to update K8ssandraTask status.
+* [ENHANCEMENT] [#773](https://github.com/k8ssandra/k8ssandra-operator/issues/773) Allow for CORS to be enabled on Reaper

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -136,6 +136,11 @@ type ReaperTemplate struct {
 	// +optional
 	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 
+	// If Cross-origin requests should be properly supported by the server when made via a browser.
+	// +optional
+	// +kubebuilder:default=false
+	EnableCors bool `json:"enableCors,omitempty"`
+
 	// labels and annotations for Reaper resources
 	// +optional
 	ResourceMeta *meta.ResourceMeta `json:"metadata,omitempty"`
@@ -264,11 +269,6 @@ type ReaperSpec struct {
 	// +optional
 	// +kubebuilder:default=false
 	SkipSchemaMigration bool `json:"skipSchemaMigration,omitempty"`
-
-	// If Cross-origin requests should be properly supported by the server when made via a browser.
-	// +optional
-	// +kubebuilder:default=false
-	EnableCors bool `json:"enableCors,omitempty"`
 }
 
 // ReaperProgress is a word summarizing the state of a Reaper resource.

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -264,6 +264,11 @@ type ReaperSpec struct {
 	// +optional
 	// +kubebuilder:default=false
 	SkipSchemaMigration bool `json:"skipSchemaMigration,omitempty"`
+
+	// If Cross-origin requests should be properly supported by the server when made via a browser.
+	// +optional
+	// +kubebuilder:default=false
+	EnableCors bool `json:"enableCors,omitempty"`
 }
 
 // ReaperProgress is a word summarizing the state of a Reaper resource.

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -27175,6 +27175,11 @@ spec:
                     - PER_DC
                     - SINGLE
                     type: string
+                  enableCors:
+                    default: false
+                    description: If Cross-origin requests should be properly supported
+                      by the server when made via a browser.
+                    type: boolean
                   heapSize:
                     anyOf:
                     - type: integer

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1120,6 +1120,11 @@ spec:
                 required:
                 - name
                 type: object
+              enableCors:
+                default: false
+                description: If Cross-origin requests should be properly supported
+                  by the server when made via a browser.
+                type: boolean
               heapSize:
                 anyOf:
                 - type: integer

--- a/pkg/reaper/deployment.go
+++ b/pkg/reaper/deployment.go
@@ -151,6 +151,13 @@ func NewDeployment(reaper *api.Reaper, dc *cassdcapi.CassandraDatacenter, keysto
 		})
 	}
 
+	if reaper.Spec.EnableCors {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "REAPER_ENABLE_CROSS_ORIGIN",
+			Value: "true",
+		})
+	}
+
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
 	// if client encryption is turned on, we need to mount the keystore and truststore volumes

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -297,9 +297,9 @@ func TestLivenessProbe(t *testing.T) {
 func TestEnableCors(t *testing.T) {
 	reaper := newTestReaper()
 
-	deployment = NewDeployment(reaper, newTestDatacenter(), nil, nil)
-	podSpec = deployment.Spec.Template.Spec
-	container = podSpec.Containers[0]
+	deployment := NewDeployment(reaper, newTestDatacenter(), nil, nil)
+	podSpec := deployment.Spec.Template.Spec
+	container := podSpec.Containers[0]
 	envVar := utils.FindEnvVar(container.Env, "REAPER_ENABLE_CROSS_ORIGIN")
 	assert.Nil(t, envVar)
 
@@ -307,7 +307,7 @@ func TestEnableCors(t *testing.T) {
 	deployment = NewDeployment(reaper, newTestDatacenter(), nil, nil)
 	podSpec = deployment.Spec.Template.Spec
 	container = podSpec.Containers[0]
-	envVar := utils.FindEnvVar(container.Env, "REAPER_ENABLE_CROSS_ORIGIN")
+	envVar = utils.FindEnvVar(container.Env, "REAPER_ENABLE_CROSS_ORIGIN")
 	assert.Nil(t, envVar)
 
 	reaper.Spec.EnableCors = true

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -294,6 +294,32 @@ func TestLivenessProbe(t *testing.T) {
 	assert.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].LivenessProbe)
 }
 
+func TestEnableCors(t *testing.T) {
+	reaper := newTestReaper()
+
+	deployment = NewDeployment(reaper, newTestDatacenter(), nil, nil)
+	podSpec = deployment.Spec.Template.Spec
+	container = podSpec.Containers[0]
+	envVar := utils.FindEnvVar(container.Env, "REAPER_ENABLE_CROSS_ORIGIN")
+	assert.Nil(t, envVar)
+
+	reaper.Spec.EnableCors = false
+	deployment = NewDeployment(reaper, newTestDatacenter(), nil, nil)
+	podSpec = deployment.Spec.Template.Spec
+	container = podSpec.Containers[0]
+	envVar := utils.FindEnvVar(container.Env, "REAPER_ENABLE_CROSS_ORIGIN")
+	assert.Nil(t, envVar)
+
+	reaper.Spec.EnableCors = true
+	deployment = NewDeployment(reaper, newTestDatacenter(), nil, nil)
+	podSpec = deployment.Spec.Template.Spec
+	container = podSpec.Containers[0]
+	assert.Contains(t, container.Env, corev1.EnvVar{
+		Name:  "REAPER_ENABLE_CROSS_ORIGIN",
+		Value: "true",
+	})
+}
+
 func TestImages(t *testing.T) {
 	// Note: nil images are normally not possible due to the kubebuilder markers on the CRD spec
 	t.Run("nil images", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:
* Adds a flag `EnableCors` to allow for CORS to be enabled within Reaper.

**Which issue(s) this PR fixes**:
Fixes #773 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
