### PR TITLE
Stabilize tests

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,4 +14,6 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
 * [FEATURE] [#599](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
+* [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests

--- a/controllers/k8ssandra/remove_dc_test.go
+++ b/controllers/k8ssandra/remove_dc_test.go
@@ -86,7 +86,7 @@ func deleteDcWithUserKeyspacesFails(ctx context.Context, t *testing.T, f *framew
 func deleteDcWithUserKeyspacesSucceeds(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster) {
 	require := require.New(t)
 
-	replication := map[string]int{"dc1": 3}
+	replication := map[string]int{"dc1": 3, "dc2": 3}
 	updatedReplication := map[string]int{"dc1": 3}
 
 	// We need a version of the map with string values because GetKeyspaceReplication returns

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -167,15 +167,6 @@ func createMultiReaper(t *testing.T, ctx context.Context, namespace string, f *f
 		username, password := retrieveCredentials(t, f, ctx, secretKey)
 		testReaperApi(t, ctx, f.DataPlaneContexts[1], DcClusterName(t, f, dc2Key), "reaper_ks", username, password)
 	})
-
-	replication := map[string]int{"dc1": 1, "dc2": 1}
-
-	t.Run("TestStargateApi[0]", func(t *testing.T) {
-		testStargateApis(t, f, ctx, f.DataPlaneContexts[0], namespace, dc1Prefix, username, password, false, replication)
-	})
-	t.Run("TestStargateApi[1]", func(t *testing.T) {
-		testStargateApis(t, f, ctx, f.DataPlaneContexts[1], namespace, dc2Prefix, username, password, false, replication)
-	})
 }
 
 func createMultiReaperWithEncryption(t *testing.T, ctx context.Context, namespace string, f *framework.E2eFramework) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
 
 	reaperclient "github.com/k8ssandra/reaper-client-go/reaper"
 	"gopkg.in/resty.v1"
@@ -667,8 +668,8 @@ func cleanUp(t *testing.T, f *framework.E2eFramework, opts *e2eTestOpts) error {
 		t.Logf("failed to dump cluster info: %v", err)
 	}
 
-	timeout := 3 * time.Minute
-	interval := 10 * time.Second
+	timeout := 10 * time.Minute
+	interval := 15 * time.Second
 
 	if !opts.skipK8ssandraClusterCleanup {
 		if err := f.DeleteK8ssandraClusters(opts.sutNamespace, timeout, interval); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Stabilizes the tests:

- integration tests: fixed a mock used in dc deletion tests that didn't provide the right replication settings. I guess there was timing variance which made both replication necessary in some cases (most likely under resource constraints).
- e2e tests: some gRPC calls to Stargate were transiently failing (especially a read operation). I've added some retries around that specific call.
- e2e tests: The "CreateMultiReaper" test was running tests against the Stargate APIs, which is out of scope and was adding flakiness.

I managed to get multiple successful runs in a row for multi e2e tests: https://github.com/adejanovski/k8ssandra-operator/actions/runs/3547051093

and integration tests as well: https://github.com/adejanovski/k8ssandra-operator/actions/runs/3540916373

**Which issue(s) this PR fixes**:
Fixes #761
Fixes #762


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
