### PR TITLE
Remove the cluster.local domain from the seed service URL in Stargate

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -19,6 +19,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#323](https://github.com/k8ssandra/k8ssandra/issues/323) Use Cassandra internals for JMX authentication
 * [ENHANCEMENT] [#770](https://github.com/k8ssandra/k8ssandra-operator/issues/770) Update to Go 1.19 and Operator SDK 1.25.2
 * [ENHANCEMENT] [#525](https://github.com/k8ssandra/k8ssandra-operator/issues/525) Deep-merge cluster- and dc-level templates
-* [BUGFIX] [#726](https://github.com/k8ssandra/k8ssandra-operator/issues/726) Don't propagate Cassandra tolerations to the Stargate deployment
-* [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests
 * [ENHANCEMENT] [#781](https://github.com/k8ssandra/k8ssandra-operator/issues/781) Expose perNodeConfigInitContainer.Image through CRD
+* [BUGFIX] [#726](https://github.com/k8ssandra/k8ssandra-operator/issues/726) Don't propagate Cassandra tolerations to the Stargate deployment
+* [BUGFIX] [#778](https://github.com/k8ssandra/k8ssandra-operator/issues/778) Fix Stargate deployments on k8s clusters using a custom domain name
+* [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -25,10 +25,6 @@ const (
 	cassandraConfigPath = "/config/cassandra.yaml"
 	cqlConfigPath       = "/config/" + CqlConfigName
 	cassandraConfigMap  = "cassandra-config"
-
-	// FIXME should this be customized? Cf. K8ssandra 1.x Helm chart template:
-	// "{{ .Values.clusterDomain | default \"cluster.local\" }}
-	clusterDomain = "cluster.local"
 )
 
 const (
@@ -225,7 +221,7 @@ func computeDNSPolicy(dc *cassdcapi.CassandraDatacenter) corev1.DNSPolicy {
 }
 
 func computeSeedServiceUrl(dc *cassdcapi.CassandraDatacenter) string {
-	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName) + "-seed-service." + dc.Namespace + ".svc." + clusterDomain
+	return cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName) + "-seed-service." + dc.Namespace + ".svc"
 }
 
 func computeClusterVersion(dc *cassdcapi.CassandraDatacenter) ClusterVersion {

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -1,9 +1,10 @@
 package stargate
 
 import (
-	"k8s.io/utils/pointer"
 	"strings"
 	"testing"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 
@@ -147,7 +148,7 @@ func testNewDeploymentsDefaultRackSingleReplica(t *testing.T) {
 
 	seed := utils.FindEnvVarInContainer(container, "SEED")
 	require.NotNil(t, seed, "failed to find SEED env var")
-	assert.Equal(t, "cluster1-seed-service.namespace1.svc.cluster.local", seed.Value)
+	assert.Equal(t, "cluster1-seed-service.namespace1.svc", seed.Value)
 
 	javaOpts := utils.FindEnvVarInContainer(container, "JAVA_OPTS")
 	require.NotNil(t, javaOpts, "failed to find JAVA_OPTS env var")
@@ -203,7 +204,7 @@ func testNewDeploymentsSingleRackManyReplicas(t *testing.T) {
 
 	seed := utils.FindEnvVarInContainer(container, "SEED")
 	require.NotNil(t, seed, "failed to find SEED env var")
-	assert.Equal(t, "cluster1-seed-service.namespace1.svc.cluster.local", seed.Value)
+	assert.Equal(t, "cluster1-seed-service.namespace1.svc", seed.Value)
 
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Removes the hardcoded `cluster.local` domain used for the seed service discovery in Stargate deployments.

**Which issue(s) this PR fixes**:
Fixes #778 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
