### PR TITLE
K8SSAND-1895: Add GitHub workflow to test various k8s versions

### DIFF
--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind_node_version: ["v1.21.14", "v1.22.15", "v1.23.6", "v1.24.7", "v1.26.0"]
+        kind_node_version: ["v1.21.14", "v1.22.15", "v1.23.6", "v1.24.7", "1.25.3", "v1.26.0"]
     uses: ./.github/workflows/kind_e2e_tests.yaml
     with:
       kind_node_version: ${{ matrix.kind_node_version }}

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -3,6 +3,7 @@ name: K8s version test
 on:
   schedule:
     - cron: '0 12 * * 0' # Every Sunday at noon UTC
+  workflow_dispatch:
 jobs:
   run-e2e-tests:
     strategy:

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -1,0 +1,14 @@
+# Runs the single-cluster e2e tests with various versions of Kubernetes, to ensure backward compatibility.
+name: K8s version test
+on:
+  schedule:
+    - cron: '0 12 * * 0' # Every Sunday at noon UTC
+jobs:
+  run-e2e-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        kind_node_version: ["v1.22.15", "v1.23.6", "v1.24.7"]
+    uses: ./.github/workflows/kind_e2e_tests.yaml
+    with:
+      kind_node_version: ${{ matrix.kind_node_version }}

--- a/.github/workflows/k8s_matrix_test.yaml
+++ b/.github/workflows/k8s_matrix_test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind_node_version: ["v1.22.15", "v1.23.6", "v1.24.7"]
+        kind_node_version: ["v1.21.14", "v1.22.15", "v1.23.6", "v1.24.7", "v1.26.0"]
     uses: ./.github/workflows/kind_e2e_tests.yaml
     with:
       kind_node_version: ${{ matrix.kind_node_version }}

--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -15,7 +15,27 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'CHANGELOG/**'
+  workflow_call:
+    inputs:
+      kind_node_version:
+        required: true
+        type: string
 jobs:
+  set_kind_node_version:
+    runs-on: ubuntu-latest
+    outputs:
+      kind_node_version: ${{ steps.input_or_default.outputs.kind_node_version }}
+    steps:
+      - id: input_or_default
+        name: Set Kind node version from workflow input or default
+        env:
+          DEFAULT_KIND_NODE_VERSION: v1.25.3
+        run: |
+          if [[ -z "${{ inputs.kind_node_version }}" ]]; then
+            echo '::set-output name=kind_node_version::${{ env.DEFAULT_KIND_NODE_VERSION }}'
+          else
+            echo '::set-output name=kind_node_version::${{ inputs.kind_node_version }}'
+          fi
   build_image:
     name: Build Image
     runs-on: ubuntu-latest
@@ -64,9 +84,10 @@ jobs:
           path: /tmp/k8ssandra-operator.tar
   kind_e2e_tests:
     runs-on: ubuntu-latest
-    needs: build_image
+    needs: [set_kind_node_version, build_image]
     strategy:
       matrix:
+        kind_node_version: ["${{ needs.set_kind_node_version.outputs.kind_node_version }}"]
         e2e_test:
           - CreateSingleDatacenterCluster
           - CreateStargateAndDatacenter
@@ -137,8 +158,8 @@ jobs:
       - name: Load images
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
-      - name: Setup kind cluster
-        run: make IMG="k8ssandra/k8ssandra-operator:${{ needs.build_image.outputs.image_tag }}" create-kind-cluster kind-load-image cert-manager nginx-kind
+      - name: Setup kind cluster ( ${{ matrix.kind_node_version }} )
+        run: make IMG="k8ssandra/k8ssandra-operator:${{ needs.build_image.outputs.image_tag }}" KIND_NODE_VERSION="${{ matrix.kind_node_version }}" create-kind-cluster kind-load-image cert-manager nginx-kind
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         run: |
           e2e_test="TestOperator/${{ matrix.e2e_test }}"

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -16,6 +16,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
+* [ENHANCEMENT] [#765](https://github.com/k8ssandra/k8ssandra-operator/issues/765) Add GitHub workflow to test various k8s versions
 * [ENHANCEMENT] [#323](https://github.com/k8ssandra/k8ssandra/issues/323) Use Cassandra internals for JMX authentication
 * [ENHANCEMENT] [#770](https://github.com/k8ssandra/k8ssandra-operator/issues/770) Update to Go 1.19 and Operator SDK 1.25.2
 * [ENHANCEMENT] [#525](https://github.com/k8ssandra/k8ssandra-operator/issues/525) Deep-merge cluster- and dc-level templates

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ NUM_CLUSTERS = 2
 # It can either be a single number or a comma-separated list of numbers, one per cluster.
 NUM_WORKER_NODES = 4
 
+# The version of the Kind image to run end-to-end tests.
+KIND_NODE_VERSION = v1.25.3
+
 ifeq ($(DEPLOYMENT), )
 	DEPLOY_TARGET =
 else
@@ -264,10 +267,10 @@ cleanup:
 	done
 
 create-kind-cluster:
-	scripts/setup-kind-multicluster.sh --clusters 1 --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
+	scripts/setup-kind-multicluster.sh --clusters 1 --kind-node-version $(KIND_NODE_VERSION) --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
 
 create-kind-multicluster:
-	scripts/setup-kind-multicluster.sh --clusters $(NUM_CLUSTERS) --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
+	scripts/setup-kind-multicluster.sh --clusters $(NUM_CLUSTERS) --kind-node-version $(KIND_NODE_VERSION) --kind-worker-nodes $(NUM_WORKER_NODES) --output-file $(KIND_KUBECONFIG)
 
 kind-load-image:
 	kind load docker-image --name $(KIND_CLUSTER) ${IMG}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add weekly workflow that runs the single-cluster e2e tests with old Kubernetes versions.

**Which issue(s) this PR fixes**:
Fixes #765

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
