### PR TITLE
Create a mutating webhook for the internal secrets provider

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -82,6 +82,23 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp/k8ssandra-operator.tar
+      - name: Build secrets webhook image
+        id: docker_build_secrets_webhook
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: false
+          tags: k8ssandra/k8ssandra-secrets-webhook:latest,k8ssandra/k8ssandra-secrets-webhook:${{ steps.parse_image_tag.outputs.image_tag }}
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/k8ssandra-secrets-webhook.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Upload k8ssandra-secrets-webhook image
+        uses: actions/upload-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp/k8ssandra-secrets-webhook.tar
   kind_e2e_tests:
     runs-on: ubuntu-latest
     needs: [set_kind_node_version, build_image]
@@ -155,9 +172,15 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp
+      - name: Download k8ssandra-secrets-webhook image
+        uses: actions/download-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp
       - name: Load images
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
+          docker load --input /tmp/k8ssandra-secrets-webhook.tar
       - name: Setup kind cluster ( ${{ matrix.kind_node_version }} )
         run: make IMG="k8ssandra/k8ssandra-operator:${{ needs.build_image.outputs.image_tag }}" KIND_NODE_VERSION="${{ matrix.kind_node_version }}" create-kind-cluster kind-load-image cert-manager nginx-kind
       - name: Run e2e test ( ${{ matrix.e2e_test }} )

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -63,6 +63,23 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp/k8ssandra-operator.tar
+      - name: Build secrets webhook image
+        id: docker_build_secrets_webhook
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: false
+          tags: k8ssandra/k8ssandra-secrets-webhook:latest,k8ssandra/k8ssandra-secrets-webhook:${{ steps.parse_image_tag.outputs.image_tag }}
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/k8ssandra-secrets-webhook.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Upload k8ssandra-secrets-webhook image
+        uses: actions/upload-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp/k8ssandra-secrets-webhook.tar
   kind_e2e_tests:
     runs-on: ubuntu-latest
     needs: build_image
@@ -129,9 +146,15 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp
+      - name: Download k8ssandra-secrets-webhook image
+        uses: actions/download-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp
       - name: Load images
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
+          docker load --input /tmp/k8ssandra-secrets-webhook.tar
       - name: Setup kind clusters
         run: make IMG="k8ssandra/k8ssandra-operator:${{ needs.build_image.outputs.image_tag }}" create-kind-multicluster kind-load-image-multi cert-manager-multi nginx-kind-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )

--- a/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
@@ -62,6 +62,23 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp/k8ssandra-operator.tar
+      - name: Build secrets webhook image
+        id: docker_build_secrets_webhook
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile
+          context: .
+          push: false
+          tags: k8ssandra/k8ssandra-secrets-webhook:latest,k8ssandra/k8ssandra-secrets-webhook:${{ steps.parse_image_tag.outputs.image_tag }}
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/k8ssandra-secrets-webhook.tar
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Upload k8ssandra-secrets-webhook image
+        uses: actions/upload-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp/k8ssandra-secrets-webhook.tar
   kind_e2e_tests:
     runs-on: ubuntu-latest
     needs: build_image
@@ -107,9 +124,15 @@ jobs:
         with:
           name: k8ssandra-operator
           path: /tmp
+      - name: Download k8ssandra-secrets-webhook image
+        uses: actions/download-artifact@v2
+        with:
+          name: k8ssandra-secrets-webhook
+          path: /tmp
       - name: Load images
         run: |
           docker load --input /tmp/k8ssandra-operator.tar
+          docker load --input /tmp/k8ssandra-secrets-webhook.tar
       - name: Setup kind clusters
         run: make IMG="k8ssandra/k8ssandra-operator:${{ needs.build_image.outputs.image_tag }}" NUM_CLUSTERS=3 NUM_WORKER_NODES=1,2,2 create-kind-multicluster kind-load-image-multi cert-manager-multi nginx-kind-multi
       - name: Run e2e test ( ${{ matrix.e2e_test }} )

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -28,3 +28,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests
 * [TESTING] [#799](https://github.com/k8ssandra/k8ssandra-operator/issues/799) Fix GHA CI failures with Kustomize install being rate limited
 * [FEATURE] [#501](https://github.com/k8ssandra/k8ssandra-operator/issues/501) Allow configuring annotations and labels on services, statefulsets, deployments and pods
+* [FEATURE] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/605) Create a mutating webhook for the internal secrets provider

--- a/cmd/secrets-webhook/Dockerfile
+++ b/cmd/secrets-webhook/Dockerfile
@@ -1,0 +1,23 @@
+# Build the webhook binary
+# run from the top-level directory with
+# docker build -t k8ssandra-secrets-webhook -f cmd/secrets-webhook/Dockerfile .
+FROM golang:1.19 as build
+
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV CGO_ENABLED=0
+
+WORKDIR /work
+COPY . /work
+
+# Build admission-webhook
+RUN --mount=type=cache,target=/root/.cache/go-build,sharing=private \
+  go build -o bin/admission-webhook ./cmd/secrets-webhook/main.go
+
+# ---
+FROM scratch AS run
+
+COPY --from=build /work/bin/admission-webhook /usr/local/bin/
+
+CMD ["admission-webhook"]
+

--- a/cmd/secrets-webhook/Makefile
+++ b/cmd/secrets-webhook/Makefile
@@ -1,0 +1,18 @@
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: test
+test: ## run unit tests
+	@echo "\n🛠️  Running unit tests..."
+	go test ./...
+
+.PHONY: build
+build: ## build binaries
+	@echo "\n🔧  Building Go binaries..."
+	GOOS=darwin GOARCH=amd64 go build -o bin/admission-webhook-darwin-amd64 .
+	GOOS=linux GOARCH=amd64 go build -o bin/admission-webhook-linux-amd64 .
+
+.PHONY: docker-build
+docker-build: ## build webhook docker image
+	@echo "\n📦 Building simple-kubernetes-webhook Docker image..."
+	cd ../.. && docker build -t k8ssandra-secrets-webhook -f cmd/secrets-webhook/Dockerfile .

--- a/cmd/secrets-webhook/admission/admission.go
+++ b/cmd/secrets-webhook/admission/admission.go
@@ -1,0 +1,90 @@
+package admission
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/k8ssandra/k8ssandra-operator/cmd/secrets-webhook/mutation"
+	"go.uber.org/zap"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Admitter is a container for admission business
+type Admitter struct {
+	Logger  *zap.Logger
+	Request *admissionv1.AdmissionRequest
+}
+
+// MutatePodReview takes an admission request and mutates the pod within,
+// it returns an admission review with mutations as a json patch (if any)
+func (a Admitter) MutatePodReview() (*admissionv1.AdmissionReview, error) {
+	pod, err := a.Pod()
+	if err != nil {
+		e := fmt.Sprintf("could not parse pod in admission review request: %v", err)
+		return reviewResponse(a.Request.UID, false, http.StatusBadRequest, e), err
+	}
+
+	m := mutation.NewMutator(a.Logger)
+	patch, err := m.MutatePodPatch(pod)
+	if err != nil {
+		e := fmt.Sprintf("could not mutate pod: %v", err)
+		return reviewResponse(a.Request.UID, false, http.StatusBadRequest, e), err
+	}
+
+	return patchReviewResponse(a.Request.UID, patch)
+}
+
+// Pod extracts a pod from an admission request
+func (a Admitter) Pod() (*corev1.Pod, error) {
+	if a.Request.Kind.Kind != "Pod" {
+		return nil, fmt.Errorf("only pods are supported here")
+	}
+
+	p := corev1.Pod{}
+	if err := json.Unmarshal(a.Request.Object.Raw, &p); err != nil {
+		return nil, err
+	}
+
+	return &p, nil
+}
+
+// reviewResponse creates an admission review for a bad request
+func reviewResponse(uid types.UID, allowed bool, httpCode int32,
+	reason string) *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     uid,
+			Allowed: allowed,
+			Result: &metav1.Status{
+				Code:    httpCode,
+				Message: reason,
+			},
+		},
+	}
+}
+
+// patchReviewResponse builds an admission review with given json patch
+func patchReviewResponse(uid types.UID, patch []byte) (*admissionv1.AdmissionReview, error) {
+	patchType := admissionv1.PatchTypeJSONPatch
+
+	return &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Response: &admissionv1.AdmissionResponse{
+			UID:       uid,
+			Allowed:   true,
+			PatchType: &patchType,
+			Patch:     patch,
+		},
+	}, nil
+}

--- a/cmd/secrets-webhook/main.go
+++ b/cmd/secrets-webhook/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/k8ssandra/k8ssandra-operator/cmd/secrets-webhook/admission"
+	"go.uber.org/zap"
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+var logger = zap.NewExample()
+
+func main() {
+	logConfig := zap.NewProductionConfig()
+	lvl := zap.LevelFlag("log-level", zap.InfoLevel, "the log level")
+	logConfig.Level.SetLevel(*lvl)
+	logger, _ = logConfig.Build()
+
+	// handle our core application
+	http.HandleFunc("/mutate-pods", ServeMutatePods)
+	http.HandleFunc("/health", ServeHealth)
+
+	// start the server
+	// listens to clear text http on port 8080 unless TLS env var is set to "true"
+	if os.Getenv("TLS") == "true" {
+		cert := "/etc/admission-webhook/tls/tls.crt"
+		key := "/etc/admission-webhook/tls/tls.key"
+		logger.Info("Listening on port 443...")
+		logger.Fatal("%v", zap.Error(http.ListenAndServeTLS(":443", cert, key, nil)))
+	} else {
+		logger.Info("Listening on port 8080...")
+		logger.Info("%v", zap.Error(http.ListenAndServe(":8080", nil)))
+	}
+}
+
+// ServeHealth returns 200 when things are good
+func ServeHealth(w http.ResponseWriter, r *http.Request) {
+	log := logger.With(zap.String("uri", r.RequestURI))
+	log.Debug("healthy")
+	fmt.Fprint(w, "OK")
+}
+
+func ServeMutatePods(w http.ResponseWriter, r *http.Request) {
+	log := logger.With(zap.String("uri", r.RequestURI))
+	log.Info("received mutation request")
+
+	in, err := parseJsonRequest(*r)
+	if err != nil {
+		log.Error("bad request", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	adm := admission.Admitter{
+		Logger:  logger,
+		Request: in.Request,
+	}
+
+	out, err := adm.MutatePodReview()
+	if err != nil {
+		e := fmt.Sprintf("unable to generate admission response: %v", err)
+		log.Error(e)
+		http.Error(w, e, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	jout, err := json.Marshal(out)
+	if err != nil {
+		e := fmt.Sprintf("unable to marshal admission response: %v", err)
+		log.Error(e)
+		http.Error(w, e, http.StatusInternalServerError)
+		return
+	}
+
+	log.Debug("sending response", zap.ByteString("response", jout))
+	fmt.Fprintf(w, "%s", jout)
+}
+
+func parseJsonRequest(r http.Request) (*admissionv1.AdmissionReview, error) {
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		return nil, fmt.Errorf("invalid content-type %v, expected application/json.", contentType)
+	}
+
+	bodybuf := new(bytes.Buffer)
+	bodybuf.ReadFrom(r.Body)
+	body := bodybuf.Bytes()
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("admission request body is empty")
+	}
+
+	var a admissionv1.AdmissionReview
+
+	if err := json.Unmarshal(body, &a); err != nil {
+		return nil, fmt.Errorf("unable to parse admission review request: %v", err)
+	}
+
+	if a.Request == nil {
+		return nil, fmt.Errorf("unable to use admission request with nil Request field")
+	}
+
+	return &a, nil
+}

--- a/cmd/secrets-webhook/mutation/inject_secrets.go
+++ b/cmd/secrets-webhook/mutation/inject_secrets.go
@@ -1,0 +1,124 @@
+package mutation
+
+import (
+	"sort"
+	"strings"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// annotations should follow the format prefix-{secret}={mountPath}
+// e.g. k8ssandra.io/inject-secret-cassandraSuperuser=/etc/credentials/cassandra
+const secretNameAnnotationPrefix = "k8ssandra.io/inject-secret-"
+
+// injectEnv is a container for the mutation injecting secretss
+type injectSecrets struct {
+	Logger *zap.Logger
+}
+
+// injectSecrets implements the podMutator interface
+var _ podMutator = (*injectSecrets)(nil)
+
+// Name returns the struct name
+func (se injectSecrets) Name() string {
+	return "inject_secrets"
+}
+
+// Mutate returns a new mutated pod according to set secret rules
+func (se injectSecrets) Mutate(pod *corev1.Pod) (*corev1.Pod, error) {
+	se.Logger = se.Logger.With(zap.String("mutation", se.Name()))
+	mpod := pod.DeepCopy()
+
+	secretKeys := getSecretInjectionAnnotations(pod.ObjectMeta.Annotations)
+	if len(secretKeys) == 0 {
+		se.Logger.Info("no secret annotations exist")
+		return mpod, nil
+	}
+
+	for _, key := range secretKeys {
+		// get secret name from annotation, which is in the format
+		// inject-secrets-template-{secret}
+		secretName := key[len(secretNameAnnotationPrefix):]
+		mountPath := pod.ObjectMeta.Annotations[key]
+		se.Logger.Debug("creating volume and volume mount for secret",
+			zap.String("secret", secretName),
+			zap.String("secret path", mountPath),
+		)
+
+		volume := corev1.Volume{
+			Name: secretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		}
+		injectVolume(mpod, volume)
+
+		volumeMount := corev1.VolumeMount{
+			Name:      secretName,
+			MountPath: mountPath,
+		}
+		injectVolumeMount(mpod, volumeMount)
+		se.Logger.Debug("added volume and volumeMount to podSpec",
+			zap.String("secret", secretName),
+			zap.String("secret path", mountPath),
+		)
+	}
+
+	return mpod, nil
+}
+
+func injectVolume(pod *corev1.Pod, volume corev1.Volume) {
+	if !hasVolume(pod.Spec.Volumes, volume) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	}
+}
+
+func hasVolume(volumes []corev1.Volume, volume corev1.Volume) bool {
+	for _, v := range volumes {
+		if v.Name == volume.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func injectVolumeMount(pod *corev1.Pod, volumeMount corev1.VolumeMount) {
+	for i, container := range pod.Spec.Containers {
+		if !hasVolumeMount(container, volumeMount) {
+			pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, volumeMount)
+		}
+	}
+	for i, container := range pod.Spec.InitContainers {
+		if !hasVolumeMount(container, volumeMount) {
+			pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, volumeMount)
+		}
+	}
+}
+
+// hasVolumeMoujt returns true if environment variable exists false otherwise
+func hasVolumeMount(container corev1.Container, volumeMount corev1.VolumeMount) bool {
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == volumeMount.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// getSecretInjectionAnnotations retrieves the annotations that use the
+// secretNameAnnotation prefix and returns them in a sorted list
+func getSecretInjectionAnnotations(annotations map[string]string) []string {
+	// verify there is at least one injection annotation
+	var secretKeys []string
+	for a, _ := range annotations {
+		if strings.Contains(a, secretNameAnnotationPrefix) {
+			secretKeys = append(secretKeys, a)
+		}
+	}
+
+	sort.Strings(secretKeys)
+	return secretKeys
+}

--- a/cmd/secrets-webhook/mutation/inject_secrets_test.go
+++ b/cmd/secrets-webhook/mutation/inject_secrets_test.go
@@ -13,7 +13,7 @@ func TestInjectSecretsMutate(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
-				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+				"k8ssandra.io/inject-secret": `[{"secretName": "mySecret", "path": "/my/secret/path"}]`,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -39,7 +39,7 @@ func TestInjectSecretsMutate(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
-				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+				"k8ssandra.io/inject-secret": `[{"secretName": "mySecret", "path": "/my/secret/path"}]`,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -58,12 +58,14 @@ func TestInjectSecretsMutate(t *testing.T) {
 }
 
 func TestInjectSecretsMultiMutate(t *testing.T) {
+	injectionAnnotation := `[{"secretName": "mySecret", "path": "/my/secret/path"},
+	 {"secretName": "myOtherSecret", "path": "/my/other/secret/path"}]`
+
 	want := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
-				"k8ssandra.io/inject-secret-mySecret":      "/my/secret/path",
-				"k8ssandra.io/inject-secret-myOtherSecret": "/my/other/secret/path",
+				"k8ssandra.io/inject-secret": injectionAnnotation,
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -71,29 +73,29 @@ func TestInjectSecretsMultiMutate(t *testing.T) {
 				Name: "test",
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "myOtherSecret",
-						MountPath: "/my/other/secret/path",
-					},
-					{
 						Name:      "mySecret",
 						MountPath: "/my/secret/path",
+					},
+					{
+						Name:      "myOtherSecret",
+						MountPath: "/my/other/secret/path",
 					},
 				},
 			}},
 			Volumes: []corev1.Volume{
 				{
-					Name: "myOtherSecret",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "myOtherSecret",
-						},
-					},
-				},
-				{
 					Name: "mySecret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "mySecret",
+						},
+					},
+				},
+				{
+					Name: "myOtherSecret",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "myOtherSecret",
 						},
 					},
 				},
@@ -105,8 +107,7 @@ func TestInjectSecretsMultiMutate(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test",
 			Annotations: map[string]string{
-				"k8ssandra.io/inject-secret-mySecret":      "/my/secret/path",
-				"k8ssandra.io/inject-secret-myOtherSecret": "/my/other/secret/path",
+				"k8ssandra.io/inject-secret": injectionAnnotation,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/cmd/secrets-webhook/mutation/inject_secrets_test.go
+++ b/cmd/secrets-webhook/mutation/inject_secrets_test.go
@@ -1,0 +1,125 @@
+package mutation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInjectSecretsMutate(t *testing.T) {
+	want := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test",
+			Annotations: map[string]string{
+				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "mySecret",
+					MountPath: "/my/secret/path",
+				}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "mySecret",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "mySecret",
+					},
+				},
+			}},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test",
+			Annotations: map[string]string{
+				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+			}},
+		},
+	}
+
+	got, err := injectSecrets{Logger: logger()}.Mutate(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestInjectSecretsMultiMutate(t *testing.T) {
+	want := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test",
+			Annotations: map[string]string{
+				"k8ssandra.io/inject-secret-mySecret":      "/my/secret/path",
+				"k8ssandra.io/inject-secret-myOtherSecret": "/my/other/secret/path",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "myOtherSecret",
+						MountPath: "/my/other/secret/path",
+					},
+					{
+						Name:      "mySecret",
+						MountPath: "/my/secret/path",
+					},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{
+					Name: "myOtherSecret",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "myOtherSecret",
+						},
+					},
+				},
+				{
+					Name: "mySecret",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "mySecret",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test",
+			Annotations: map[string]string{
+				"k8ssandra.io/inject-secret-mySecret":      "/my/secret/path",
+				"k8ssandra.io/inject-secret-myOtherSecret": "/my/other/secret/path",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+			}},
+		},
+	}
+
+	got, err := injectSecrets{Logger: logger()}.Mutate(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, want, got)
+}

--- a/cmd/secrets-webhook/mutation/mutation.go
+++ b/cmd/secrets-webhook/mutation/mutation.go
@@ -1,0 +1,68 @@
+package mutation
+
+import (
+	"encoding/json"
+
+	"github.com/wI2L/jsondiff"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Mutator is a container for mutation
+type Mutator struct {
+	Logger *zap.Logger
+}
+
+// NewMutator returns an initialised instance of Mutator
+func NewMutator(logger *zap.Logger) *Mutator {
+	return &Mutator{Logger: logger}
+}
+
+// podMutators is an interface used to group functions mutating pods
+type podMutator interface {
+	Mutate(*corev1.Pod) (*corev1.Pod, error)
+	Name() string
+}
+
+// MutatePodPatch returns a json patch containing all the mutations needed for
+// a given pod
+func (m *Mutator) MutatePodPatch(pod *corev1.Pod) ([]byte, error) {
+	var podName string
+	if pod.Name != "" {
+		podName = pod.Name
+	} else {
+		if pod.ObjectMeta.GenerateName != "" {
+			podName = pod.ObjectMeta.GenerateName
+		}
+	}
+	log := m.Logger.With(zap.String("pod_name", podName))
+
+	// list of all mutations to be applied to the pod
+	mutations := []podMutator{
+		injectSecrets{Logger: log},
+	}
+
+	mpod := pod.DeepCopy()
+
+	// apply all mutations
+	for _, m := range mutations {
+		var err error
+		mpod, err = m.Mutate(mpod)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// generate json patch
+	patch, err := jsondiff.Compare(pod, mpod)
+	if err != nil {
+		return nil, err
+	}
+
+	patchb, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	return patchb, nil
+}

--- a/cmd/secrets-webhook/mutation/mutation_test.go
+++ b/cmd/secrets-webhook/mutation/mutation_test.go
@@ -39,7 +39,7 @@ func pod() *corev1.Pod {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "lifespan",
 			Annotations: map[string]string{
-				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+				"k8ssandra.io/inject-secret": `[{"secretName": "mySecret", "path": "/my/secret/path"}]`,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/cmd/secrets-webhook/mutation/mutation_test.go
+++ b/cmd/secrets-webhook/mutation/mutation_test.go
@@ -1,0 +1,72 @@
+package mutation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMutatePodPatch(t *testing.T) {
+	m := NewMutator(logger())
+	got, err := m.MutatePodPatch(pod())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := patch()
+	g := string(got)
+	assert.Equal(t, p, g)
+}
+
+func BenchmarkMutatePodPatch(b *testing.B) {
+	m := NewMutator(logger())
+	pod := pod()
+
+	for i := 0; i < b.N; i++ {
+		_, err := m.MutatePodPatch(pod)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func pod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "lifespan",
+			Annotations: map[string]string{
+				"k8ssandra.io/inject-secret-mySecret": "/my/secret/path",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "lifespan",
+				Image: "busybox",
+			}},
+		},
+	}
+}
+
+func patch() string {
+	patch := `[
+		{"op":"add","path":"/spec/containers/0/volumeMounts","value":[
+			{"mountPath":"/my/secret/path","name":"mySecret"}]},
+		{"op":"add","path":"/spec/volumes","value":[
+			{"name":"mySecret","secret":{"secretName":"mySecret"}}]}
+]`
+
+	patch = strings.ReplaceAll(patch, "\n", "")
+	patch = strings.ReplaceAll(patch, "\t", "")
+	patch = strings.ReplaceAll(patch, " ", "")
+
+	return patch
+}
+
+func logger() *zap.Logger {
+	logger, _ := zap.NewDevelopment()
+	return logger.With(zap.String("logger", "test"))
+}

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -23,3 +23,19 @@ spec:
     kind: Issuer
     name: k8ssandra-operator-selfsigned-issuer
   secretName: k8ssandra-operator-webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: k8ssandra-secrets-serving-cert
+  namespace: system
+spec:
+  # $(SECRETS_SERVICE_NAME) and $(SECRETS_SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SECRETS_SERVICE_NAME_K8S).$(SECRETS_SERVICE_NAMESPACE_K8S).svc
+  - $(SECRETS_SERVICE_NAME_K8S).$(SECRETS_SERVICE_NAMESPACE_K8S).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: k8ssandra-operator-selfsigned-issuer
+  secretName: k8ssandra-secrets-webhook-server-cert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
+- ../secrets-webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -65,6 +66,21 @@ vars:
     group: cert-manager.io
     version: v1
     name: k8ssandra-operator-serving-cert # this name should match the one in certificate.yaml
+    # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: SECRETS_CERTIFICATE_NAMESPACE_K8S # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: k8ssandra-secrets-serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SECRETS_CERTIFICATE_NAME_K8S
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: k8ssandra-secrets-serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE_K8S # namespace of the service
   objref:
     kind: Service
@@ -77,3 +93,15 @@ vars:
     kind: Service
     version: v1
     name: k8ssandra-operator-webhook-service
+- name: SECRETS_SERVICE_NAMESPACE_K8S # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: k8ssandra-secrets-webhook
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SECRETS_SERVICE_NAME_K8S
+  objref:
+    kind: Service
+    version: v1
+    name: k8ssandra-secrets-webhook

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -13,3 +13,11 @@ metadata:
   name: k8ssandra-operator-validating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE_K8S)/$(CERTIFICATE_NAME_K8S)
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: k8ssandra-secrets-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: $(SECRETS_CERTIFICATE_NAMESPACE_K8S)/$(SECRETS_CERTIFICATE_NAME_K8S)

--- a/config/secrets-webhook/deployment.yaml
+++ b/config/secrets-webhook/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: k8ssandra-secrets-webhook
+  name: k8ssandra-secrets-webhook
+  namespace: k8ssandra-operator 
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8ssandra-secrets-webhook
+  template:
+    metadata:
+      labels:
+        app: k8ssandra-secrets-webhook
+    spec:
+      containers:
+        - image: k8ssandra/k8ssandra-secrets-webhook:latest
+          imagePullPolicy: Never
+          name: k8ssandra-secrets-webhook
+          env:
+            - name: TLS
+              value: "true"
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/admission-webhook/tls"
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: k8ssandra-secrets-webhook-server-cert
+            
+

--- a/config/secrets-webhook/kustomization.yaml
+++ b/config/secrets-webhook/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- manifests.yaml
+- service.yaml
+- deployment.yaml

--- a/config/secrets-webhook/manifests.yaml
+++ b/config/secrets-webhook/manifests.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: k8ssandra-secrets-webhook
+webhooks:
+  - name: k8ssandra-secrets-webhook.k8ssandra.io
+    objectSelector: 
+      matchLabels:
+        k8ssandra.secrets/mutate: "inject"
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+        scope: "*"
+    clientConfig:
+      service:
+        namespace: k8ssandra-operator
+        name: k8ssandra-secrets-webhook
+        path: /mutate-pods
+        port: 443
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    timeoutSeconds: 2

--- a/config/secrets-webhook/service.yaml
+++ b/config/secrets-webhook/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8ssandra-secrets-webhook
+  name: k8ssandra-secrets-webhook
+  namespace: k8ssandra-operator 
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+      name: https
+  selector:
+    app: k8ssandra-secrets-webhook
+

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,10 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/tidwall/gjson v1.14.3 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/wI2L/jsondiff v0.3.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -681,6 +681,13 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/testcontainers/testcontainers-go v0.11.1 h1:FiYsB83LSGbiawoV8TpAZGfcCUbtaeeg1SXqEKUxh08=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -689,6 +696,8 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238/go.mod h1:JwQJCMWpUDqjZrB5jpw0f5VbN7U95zxFy1ZDpoEarGo=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/wI2L/jsondiff v0.3.0 h1:iTzQ9u/d86GE9RsBzVHX88f2EA1vQUboHwLhSQFc1s4=
+github.com/wI2L/jsondiff v0.3.0/go.mod h1:y1IMzNNjlSsk3IUoJdRJO7VRBtzMvRgyo4Vu0LdHpTc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
**What this PR does**:
Creates a webhook that, as a default, creates volumes and volume mounts on created/updated pods for secrets that are specified via a specific annotation. 

For example, a pod with the annotation `k8ssandra.io/inject-secret-cassandraSuperuser=[{"secretName": "cassandraSuperUser", "path": "/etc/credentials/cassandra"}]` will create a volume for the `cassandraSuperuser` secret and mount the secret to the path `/etc/credentials/cassandra` on each container for the pod. Pods will only be eligible for mutation by the webhook if they have the following match label: `k8ssandra.secrets/mutate: "inject"`.  This will mount secrets in the default Kubernetes style, which will create a single file for each key/value pair in the Secret (e.g. there will be `username` file and `password` file for credential sets).

The following manifest can be used to test the secrets-webhook after setting up a cluster with operators via kind:

```
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
type: Opaque
data:
  USER_NAME: YWRtaW4=
  PASSWORD: MWYyZDFlMmU2N2Rm

---
apiVersion: k8ssandra.io/v1alpha1
kind: K8ssandraCluster
metadata:
  name: demo
spec:
  secretsProvider: external
  cassandra:
    metadata:
      pods:
        labels:
          k8ssandra.secrets/mutate: "inject"
        annotations:
          k8ssandra.io/inject-secret: "[{\"secretName\": \"mysecret\", \"path\": \"/my/secret/path\"}]"
    serverVersion: "4.0.1"
    serverImage: k8ssandra/cass-management-api:4.0.1
    storageConfig:
      cassandraDataVolumeClaimSpec:
        storageClassName: standard
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 5Gi
    config:
      jvmOptions:
        heapSize: 512Mi
    datacenters:
      - metadata:
          name: dc1
        size: 3
  medusa:
    storageProperties:
      storageProvider: local
      bucketName: k8ssandra-medusa
      prefix: test
      podStorage:
        storageClassName: standard
        accessModes:
          - ReadWriteOnce
        size: 100Mi
  reaper:
    autoScheduling:
      enabled: false
 ```

Verify that when pods are started, they have the new Volumes and VolumeMounts and that the secrets are written to files in the `/my/secret/path` directory.

```
cassandra@demo-dc1-default-sts-2:/my/secret/path$ pwd
/my/secret/path
cassandra@demo-dc1-default-sts-2:/my/secret/path$ ls
PASSWORD  USER_NAME
```

**Which issue(s) this PR fixes**:
Fixes #605 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
