### PR TITLE
Fix GHA CI failures with Kustomize install being rate limited

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -145,7 +145,7 @@ jobs:
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: Install kustomize
-        run: make kustomize
+        uses: imranismail/setup-kustomize@v2
       - name: Install Kind
         run: go get sigs.k8s.io/kind
       - name: Set up Docker Buildx

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -119,7 +119,7 @@ jobs:
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: Install kustomize
-        run: make kustomize
+        uses: imranismail/setup-kustomize@v2
       - name: Install Kind
         run: go get sigs.k8s.io/kind
       - name: Set up Docker Buildx

--- a/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_isolated_control_plane_e2e_tests.yaml
@@ -97,7 +97,7 @@ jobs:
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       - name: Install kustomize
-        run: make kustomize
+        uses: imranismail/setup-kustomize@v2
       - name: Install Kind
         run: go get sigs.k8s.io/kind
       - name: Set up Docker Buildx

--- a/.github/workflows/kuttl_tests.yaml
+++ b/.github/workflows/kuttl_tests.yaml
@@ -99,8 +99,7 @@ jobs:
       run: |
         docker load --input /tmp/k8ssandra-k8ssandra-operator.tar
     - name: Install kustomize
-      run: |
-        make kustomize
+      uses: imranismail/setup-kustomize@v2
     - name: Install kuttl
       run: |
         make install-kuttl

--- a/.github/workflows/version_tests.yaml
+++ b/.github/workflows/version_tests.yaml
@@ -93,8 +93,7 @@ jobs:
       run: |
         docker load --input /tmp/k8ssandra-k8ssandra-operator.tar
     - name: Install kustomize
-      run: |
-        make kustomize
+      uses: imranismail/setup-kustomize@v2
     - name: Install kuttl
       run: |
         make install-kuttl

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -25,3 +25,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#726](https://github.com/k8ssandra/k8ssandra-operator/issues/726) Don't propagate Cassandra tolerations to the Stargate deployment
 * [BUGFIX] [#778](https://github.com/k8ssandra/k8ssandra-operator/issues/778) Fix Stargate deployments on k8s clusters using a custom domain name
 * [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests
+* [TESTING] [#799](https://github.com/k8ssandra/k8ssandra-operator/issues/799) Fix GHA CI failures with Kustomize install being rate limited

--- a/test/kuttl/test-all-deployments/00-buildall.yaml
+++ b/test/kuttl/test-all-deployments/00-buildall.yaml
@@ -2,15 +2,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 
-- command: ../../../bin/kustomize build ../../../config/deployments/control-plane
+- command: kustomize build ../../../config/deployments/control-plane
   ignoreFailure: false 
-- command: ../../../bin/kustomize build ../../../config/deployments/control-plane/cluster-scope
+- command: kustomize build ../../../config/deployments/control-plane/cluster-scope
   ignoreFailure: false 
-- command: ../../../bin/kustomize build ../../../config/deployments/control-plane/cass-operator-dev 
+- command: kustomize build ../../../config/deployments/control-plane/cass-operator-dev 
   ignoreFailure: false 
-- command: ../../../bin/kustomize build ../../../config/deployments/data-plane
+- command: kustomize build ../../../config/deployments/data-plane
   ignoreFailure: false 
-- command: ../../../bin/kustomize build ../../../config/deployments/data-plane/cluster-scope
+- command: kustomize build ../../../config/deployments/data-plane/cluster-scope
   ignoreFailure: false 
-- command: ../../../bin/kustomize build ../../../config/deployments/data-plane/cass-operator-dev
+- command: kustomize build ../../../config/deployments/data-plane/cass-operator-dev
   ignoreFailure: false 

--- a/test/kuttl/test-cassandra-versions/01-k8ssandra-operator.yaml
+++ b/test/kuttl/test-cassandra-versions/01-k8ssandra-operator.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 
 - script: |
-    ../../../bin/kustomize build ../../../config/deployments/control-plane | kubectl apply --server-side --force-conflicts -f -
+    kustomize build ../../../config/deployments/control-plane | kubectl apply --server-side --force-conflicts -f -
   ignoreFailure: false 

--- a/test/kuttl/test-servicemonitors/01-k8ssandra-operator.yaml
+++ b/test/kuttl/test-servicemonitors/01-k8ssandra-operator.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 
 - script: |
-    ../../../bin/kustomize build ../../../config/deployments/control-plane | kubectl apply --server-side --force-conflicts -f -
+    kustomize build ../../../config/deployments/control-plane | kubectl apply --server-side --force-conflicts -f -
   ignoreFailure: false 

--- a/test/kuttl/test-user-defined-ns/01-k8ssandra-operator.yaml
+++ b/test/kuttl/test-user-defined-ns/01-k8ssandra-operator.yaml
@@ -4,5 +4,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: 
 - script: |
-    ../../../bin/kustomize build ../../../config/deployments/control-plane/cluster-scope | kubectl apply --server-side --force-conflicts -f -
+    kustomize build ../../../config/deployments/control-plane/cluster-scope | kubectl apply --server-side --force-conflicts -f -
   ignoreFailure: false 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Use an action which uses the default GITHUB_TOKEN to get higher rate limits when installing Kustomize.
This should stabilize CI flakes with rate limits kicking in fairly often lately.

**Which issue(s) this PR fixes**:
Fixes #799

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
