### PR TITLE
Ensure that commonLabels from the telemetry spec are applied

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -14,7 +14,7 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-
+* [BUGFIX] [#808](https://github.com/k8ssandra/k8ssandra-operator/pull/808) Ensure that commonLabels are propagated to Prometheus ServiceMonitor resources.
 
 ## v1.4.1 - 2022-01-04
 
@@ -24,7 +24,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [ENHANCEMENT] [#766](https://github.com/k8ssandra/k8ssandra-operator/issues/766) Upgrade Reaper to v3.2.1
 * [ENHANCEMENT] [#740](https://github.com/k8ssandra/k8ssandra-operator/issues/740)  Expose ManagementApiAuth and pod SecurityGroup from the cassdc spec in k8ssandra-operator
-* [ENHANCEMENT] [#737](https://github.com/k8ssandra/k8ssandra-operator/issues/737) Support additional jvm options for the various options files 
+* [ENHANCEMENT] [#737](https://github.com/k8ssandra/k8ssandra-operator/issues/737) Support additional jvm options for the various options files
 * [FEATURE] [#599](https://github.com/k8ssandra/k8ssandra-operator/issues/599) Introduce a secrets provider setting in the CRD
 * [FEATURE] [#728](https://github.com/k8ssandra/k8ssandra-operator/issues/728) Add token generation utility
 * [FEATURE] [#724](https://github.com/k8ssandra/k8ssandra-operator/issues/724) Ability to provide per-node configuration

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,7 +14,7 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-* [BUGFIX] [#808](https://github.com/k8ssandra/k8ssandra-operator/pull/808) Ensure that commonLabels for telemetry configurations are propagated to Prometheus ServiceMonitor resources.
+* [BUGFIX] [#808](https://github.com/k8ssandra/k8ssandra-operator/pull/808) Ensure that commonLabels are propagated to Prometheus ServiceMonitor resources.
 * [FEATURE] [#775](https://github.com/k8ssandra/k8ssandra-operator/issues/775) Add the ability to inject and configure a Vector agent sidecar in the Cassandra pods
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
 * [ENHANCEMENT] [#796](https://github.com/k8ssandra/k8ssandra-operator/issues/796) Enable smart token allocation by default for DSE

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,7 +14,6 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-* [BUGFIX] [#808](https://github.com/k8ssandra/k8ssandra-operator/pull/808) Ensure that commonLabels are propagated to Prometheus ServiceMonitor resources.
 * [FEATURE] [#775](https://github.com/k8ssandra/k8ssandra-operator/issues/775) Add the ability to inject and configure a Vector agent sidecar in the Cassandra pods
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
 * [ENHANCEMENT] [#796](https://github.com/k8ssandra/k8ssandra-operator/issues/796) Enable smart token allocation by default for DSE

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -14,7 +14,7 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-
+* [BUGFIX] [#808](https://github.com/k8ssandra/k8ssandra-operator/pull/808) Ensure that commonLabels for telemetry configurations are propagated to Prometheus ServiceMonitor resources.
 * [FEATURE] [#775](https://github.com/k8ssandra/k8ssandra-operator/issues/775) Add the ability to inject and configure a Vector agent sidecar in the Cassandra pods
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
 * [ENHANCEMENT] [#796](https://github.com/k8ssandra/k8ssandra-operator/issues/796) Enable smart token allocation by default for DSE

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -32,7 +32,7 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 		MonitoringTargetName: actualDc.Name,
 		ServiceMonitorName:   kc.SanitizedName() + "-" + actualDc.Name + "-" + "cass-servicemonitor",
 		Logger:               logger,
-		CommonLabels:         mustLabels(kc.Name, kc.Namespace, actualDc.Name),
+		CommonLabels:         mustLabels(kc.Name, kc.Namespace, actualDc.Name, mergedSpec.Prometheus.CommonLabels),
 	}
 	logger.Info("merged TelemetrySpec constructed", "mergedSpec", mergedSpec, "cluster", kc.Name)
 	// Confirm telemetry config is valid (e.g. Prometheus is installed if it is requested.)
@@ -68,14 +68,13 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 }
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
-func mustLabels(klusterName string, klusterNamespace string, dcName string) map[string]string {
-	return map[string]string{
-		k8ssandraapi.ManagedByLabel:                 k8ssandraapi.NameLabelValue,
-		k8ssandraapi.PartOfLabel:                    k8ssandraapi.PartOfLabelValue,
-		k8ssandraapi.K8ssandraClusterNameLabel:      klusterName,
-		k8ssandraapi.DatacenterLabel:                dcName,
-		k8ssandraapi.K8ssandraClusterNamespaceLabel: klusterNamespace,
-		k8ssandraapi.ComponentLabel:                 k8ssandraapi.ComponentLabelTelemetry,
-		k8ssandraapi.CreatedByLabel:                 k8ssandraapi.CreatedByLabelValueK8ssandraClusterController,
-	}
+func mustLabels(klusterName string, klusterNamespace string, dcName string, additionalLabels map[string]string) map[string]string {
+	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
+	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
+	additionalLabels[k8ssandraapi.K8ssandraClusterNameLabel] = klusterName
+	additionalLabels[k8ssandraapi.DatacenterLabel] = dcName
+	additionalLabels[k8ssandraapi.K8ssandraClusterNamespaceLabel] = klusterNamespace
+	additionalLabels[k8ssandraapi.ComponentLabel] = k8ssandraapi.ComponentLabelTelemetry
+	additionalLabels[k8ssandraapi.CreatedByLabel] = k8ssandraapi.CreatedByLabelValueK8ssandraClusterController
+	return additionalLabels
 }

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -69,6 +69,9 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
 func mustLabels(klusterName string, klusterNamespace string, dcName string, additionalLabels map[string]string) map[string]string {
+	if additionalLabels == nil {
+		additionalLabels = make(map[string]string)
+	}
 	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
 	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
 	additionalLabels[k8ssandraapi.K8ssandraClusterNameLabel] = klusterName

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -4,6 +4,7 @@ package k8ssandra
 
 import (
 	"context"
+
 	"k8s.io/utils/pointer"
 
 	"testing"
@@ -52,7 +53,8 @@ func Test_reconcileCassandraDCTelemetry_TracksNamespaces(t *testing.T) {
 			DatacenterOptions: k8ssandraapi.DatacenterOptions{
 				Telemetry: &telemetryapi.TelemetrySpec{
 					Prometheus: &telemetryapi.PrometheusTelemetrySpec{
-						Enabled: pointer.Bool(true),
+						Enabled:      pointer.Bool(true),
+						CommonLabels: map[string]string{"test-label": "test"},
 					},
 				},
 			},
@@ -69,5 +71,6 @@ func Test_reconcileCassandraDCTelemetry_TracksNamespaces(t *testing.T) {
 		assert.Fail(t, "could not get actual ServiceMonitor after reconciling k8ssandra cluster", err)
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
-	assert.NotEqual(t, currentSM.Namespace, kc.Namespace)
+	assert.NotEqual(t, kc.Namespace, currentSM.Namespace)
+	assert.Equal(t, map[string]string{"test-label": "test"}, currentSM.Labels)
 }

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -72,5 +72,5 @@ func Test_reconcileCassandraDCTelemetry_TracksNamespaces(t *testing.T) {
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
 	assert.NotEqual(t, kc.Namespace, currentSM.Namespace)
-	assert.Contains(t, currentSM.Labels, map[string]string{"test-label": "test"})
+	assert.Contains(t, currentSM.Labels, "test-label")
 }

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -72,5 +72,5 @@ func Test_reconcileCassandraDCTelemetry_TracksNamespaces(t *testing.T) {
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
 	assert.NotEqual(t, kc.Namespace, currentSM.Namespace)
-	assert.Equal(t, map[string]string{"test-label": "test"}, currentSM.Labels)
+	assert.Contains(t, currentSM.Labels, map[string]string{"test-label": "test"})
 }

--- a/controllers/reaper/reaper_telemetry_reconciler.go
+++ b/controllers/reaper/reaper_telemetry_reconciler.go
@@ -82,7 +82,9 @@ func (r *ReaperReconciler) reconcileReaperTelemetry(
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
 func mustLabels(reaperName string, additionalLabels map[string]string) map[string]string {
-
+	if additionalLabels == nil {
+		additionalLabels = make(map[string]string)
+	}
 	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
 	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
 	additionalLabels[reaperapi.ReaperLabel] = reaperName

--- a/controllers/reaper/reaper_telemetry_reconciler.go
+++ b/controllers/reaper/reaper_telemetry_reconciler.go
@@ -36,12 +36,20 @@ func (r *ReaperReconciler) reconcileReaperTelemetry(
 	remoteClient client.Client,
 ) error {
 	logger.Info("reconciling telemetry", "reaper", thisReaper.Name)
+	var commonLabels map[string]string
+	if thisReaper.Spec.Telemetry == nil {
+		commonLabels = make(map[string]string)
+	} else if thisReaper.Spec.Telemetry.Prometheus == nil {
+		commonLabels = make(map[string]string)
+	} else {
+		commonLabels = thisReaper.Spec.Telemetry.Prometheus.CommonLabels
+	}
 	cfg := telemetry.PrometheusResourcer{
 		MonitoringTargetNS:   thisReaper.Namespace,
 		MonitoringTargetName: thisReaper.Name,
 		ServiceMonitorName:   GetReaperPromSMName(thisReaper.Name),
 		Logger:               logger,
-		CommonLabels:         mustLabels(thisReaper.Name, thisReaper.Spec.Telemetry.Prometheus.CommonLabels),
+		CommonLabels:         mustLabels(thisReaper.Name, commonLabels),
 	}
 	klusterName, ok := thisReaper.Labels[k8ssandraapi.K8ssandraClusterNameLabel]
 	if ok {

--- a/controllers/reaper/reaper_telemetry_reconciler.go
+++ b/controllers/reaper/reaper_telemetry_reconciler.go
@@ -41,7 +41,7 @@ func (r *ReaperReconciler) reconcileReaperTelemetry(
 		MonitoringTargetName: thisReaper.Name,
 		ServiceMonitorName:   GetReaperPromSMName(thisReaper.Name),
 		Logger:               logger,
-		CommonLabels:         mustLabels(thisReaper.Name),
+		CommonLabels:         mustLabels(thisReaper.Name, thisReaper.Spec.Telemetry.Prometheus.CommonLabels),
 	}
 	klusterName, ok := thisReaper.Labels[k8ssandraapi.K8ssandraClusterNameLabel]
 	if ok {
@@ -81,14 +81,14 @@ func (r *ReaperReconciler) reconcileReaperTelemetry(
 }
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
-func mustLabels(reaperName string) map[string]string {
-	return map[string]string{
-		k8ssandraapi.ManagedByLabel: k8ssandraapi.NameLabelValue,
-		k8ssandraapi.PartOfLabel:    k8ssandraapi.PartOfLabelValue,
-		reaperapi.ReaperLabel:       reaperName,
-		k8ssandraapi.ComponentLabel: k8ssandraapi.ComponentLabelTelemetry,
-		k8ssandraapi.CreatedByLabel: k8ssandraapi.CreatedByLabelValueK8ssandraClusterController,
-	}
+func mustLabels(reaperName string, additionalLabels map[string]string) map[string]string {
+
+	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
+	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
+	additionalLabels[reaperapi.ReaperLabel] = reaperName
+	additionalLabels[k8ssandraapi.ComponentLabel] = k8ssandraapi.ComponentLabelTelemetry
+	additionalLabels[k8ssandraapi.CreatedByLabel] = k8ssandraapi.CreatedByLabelValueK8ssandraClusterController
+	return additionalLabels
 }
 
 // GetReaperPromSMName gets the name for our ServiceMonitors based on cluster and DC name.

--- a/controllers/reaper/reaper_telemetry_reconciler_test.go
+++ b/controllers/reaper/reaper_telemetry_reconciler_test.go
@@ -55,5 +55,5 @@ func Test_reconcilereaperTelemetry_succeeds(t *testing.T) {
 		assert.Fail(t, "could not get actual ServiceMonitor after reconciling k8ssandra cluster", err)
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
-	assert.Equal(t, map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"}, currentSM)
+	assert.Contains(t, currentSM, map[string]string{"test-label": "test"})
 }

--- a/controllers/reaper/reaper_telemetry_reconciler_test.go
+++ b/controllers/reaper/reaper_telemetry_reconciler_test.go
@@ -37,7 +37,8 @@ func Test_reconcilereaperTelemetry_succeeds(t *testing.T) {
 	reaper := test.NewReaper("test-reaper", "test-reaper-namespace")
 	reaper.Spec.Telemetry = &telemetryapi.TelemetrySpec{
 		Prometheus: &telemetryapi.PrometheusTelemetrySpec{
-			Enabled: pointer.Bool(true),
+			Enabled:      pointer.Bool(true),
+			CommonLabels: map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"},
 		},
 	}
 	cfg := telemetry.PrometheusResourcer{

--- a/controllers/reaper/reaper_telemetry_reconciler_test.go
+++ b/controllers/reaper/reaper_telemetry_reconciler_test.go
@@ -4,8 +4,9 @@ package reaper
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	"testing"
+
+	"k8s.io/utils/pointer"
 
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 
@@ -44,7 +45,7 @@ func Test_reconcilereaperTelemetry_succeeds(t *testing.T) {
 		MonitoringTargetName: reaper.Name,
 		Logger:               testLogger,
 		ServiceMonitorName:   GetReaperPromSMName(reaper.Name),
-		CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+		CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"},
 	}
 	if err := r.reconcileReaperTelemetry(ctx, &reaper, testLogger, fakeClient); err != nil {
 		assert.Fail(t, "reconciliation failed", err)
@@ -54,4 +55,5 @@ func Test_reconcilereaperTelemetry_succeeds(t *testing.T) {
 		assert.Fail(t, "could not get actual ServiceMonitor after reconciling k8ssandra cluster", err)
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
+	assert.Equal(t, map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"}, currentSM)
 }

--- a/controllers/reaper/reaper_telemetry_reconciler_test.go
+++ b/controllers/reaper/reaper_telemetry_reconciler_test.go
@@ -55,5 +55,5 @@ func Test_reconcilereaperTelemetry_succeeds(t *testing.T) {
 		assert.Fail(t, "could not get actual ServiceMonitor after reconciling k8ssandra cluster", err)
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
-	assert.Contains(t, currentSM, map[string]string{"test-label": "test"})
+	assert.Contains(t, currentSM.Labels, "test-label")
 }

--- a/controllers/stargate/stargate_telemetry_reconciler.go
+++ b/controllers/stargate/stargate_telemetry_reconciler.go
@@ -23,12 +23,21 @@ func (r *StargateReconciler) reconcileStargateTelemetry(
 	remoteClient client.Client,
 ) (ctrl.Result, error) {
 	logger.Info("reconciling telemetry", "stargate", thisStargate.Name)
+	var commonLabels map[string]string
+	if thisStargate.Spec.Telemetry == nil {
+		commonLabels = make(map[string]string)
+	} else if thisStargate.Spec.Telemetry.Prometheus == nil {
+		commonLabels = make(map[string]string)
+	} else {
+		commonLabels = thisStargate.Spec.Telemetry.Prometheus.CommonLabels
+	}
+
 	cfg := telemetry.PrometheusResourcer{
 		MonitoringTargetNS:   thisStargate.Namespace,
 		MonitoringTargetName: thisStargate.Name,
 		ServiceMonitorName:   GetStargatePromSMName(thisStargate.Name),
 		Logger:               logger,
-		CommonLabels:         mustLabels(thisStargate.Name, thisStargate.Spec.Telemetry.Prometheus.CommonLabels),
+		CommonLabels:         mustLabels(thisStargate.Name, commonLabels),
 	}
 	klusterName, ok := thisStargate.Labels[k8ssandraapi.K8ssandraClusterNameLabel]
 	if ok {

--- a/controllers/stargate/stargate_telemetry_reconciler.go
+++ b/controllers/stargate/stargate_telemetry_reconciler.go
@@ -69,7 +69,9 @@ func (r *StargateReconciler) reconcileStargateTelemetry(
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
 func mustLabels(stargateName string, additionalLabels map[string]string) map[string]string {
-
+	if additionalLabels == nil {
+		additionalLabels = make(map[string]string)
+	}
 	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
 	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
 	additionalLabels[stargateapi.StargateLabel] = stargateName

--- a/controllers/stargate/stargate_telemetry_reconciler.go
+++ b/controllers/stargate/stargate_telemetry_reconciler.go
@@ -28,7 +28,7 @@ func (r *StargateReconciler) reconcileStargateTelemetry(
 		MonitoringTargetName: thisStargate.Name,
 		ServiceMonitorName:   GetStargatePromSMName(thisStargate.Name),
 		Logger:               logger,
-		CommonLabels:         mustLabels(thisStargate.Name),
+		CommonLabels:         mustLabels(thisStargate.Name, thisStargate.Spec.Telemetry.Prometheus.CommonLabels),
 	}
 	klusterName, ok := thisStargate.Labels[k8ssandraapi.K8ssandraClusterNameLabel]
 	if ok {
@@ -68,14 +68,15 @@ func (r *StargateReconciler) reconcileStargateTelemetry(
 }
 
 // mustLabels() returns the set of labels essential to managing the Prometheus resources. These should not be overwritten by the user.
-func mustLabels(stargateName string) map[string]string {
-	return map[string]string{
-		k8ssandraapi.ManagedByLabel: k8ssandraapi.NameLabelValue,
-		k8ssandraapi.PartOfLabel:    k8ssandraapi.PartOfLabelValue,
-		stargateapi.StargateLabel:   stargateName,
-		k8ssandraapi.ComponentLabel: k8ssandraapi.ComponentLabelTelemetry,
-		k8ssandraapi.CreatedByLabel: k8ssandraapi.CreatedByLabelValueK8ssandraClusterController,
-	}
+func mustLabels(stargateName string, additionalLabels map[string]string) map[string]string {
+
+	additionalLabels[k8ssandraapi.ManagedByLabel] = k8ssandraapi.NameLabelValue
+	additionalLabels[k8ssandraapi.PartOfLabel] = k8ssandraapi.PartOfLabelValue
+	additionalLabels[stargateapi.StargateLabel] = stargateName
+	additionalLabels[k8ssandraapi.ComponentLabel] = k8ssandraapi.ComponentLabelTelemetry
+	additionalLabels[k8ssandraapi.CreatedByLabel] = k8ssandraapi.CreatedByLabelValueK8ssandraClusterController
+	return additionalLabels
+
 }
 
 // GetStargatePromSMName gets the name for our ServiceMonitors based on cluster and DC name.

--- a/controllers/stargate/stargate_telemetry_reconciler_test.go
+++ b/controllers/stargate/stargate_telemetry_reconciler_test.go
@@ -4,8 +4,9 @@ package stargate
 
 import (
 	"context"
-	"k8s.io/utils/pointer"
 	"testing"
+
+	"k8s.io/utils/pointer"
 
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 
@@ -44,7 +45,7 @@ func Test_reconcileStargateTelemetry_succeeds(t *testing.T) {
 		MonitoringTargetName: stargate.Name,
 		Logger:               testLogger,
 		ServiceMonitorName:   GetStargatePromSMName(stargate.Name),
-		CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+		CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"},
 	}
 	_, err := r.reconcileStargateTelemetry(ctx, &stargate, testLogger, fakeClient)
 	if err != nil {
@@ -56,4 +57,5 @@ func Test_reconcileStargateTelemetry_succeeds(t *testing.T) {
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
 	assert.Equal(t, stargate.Name, currentSM.Spec.Endpoints[0].MetricRelabelConfigs[0].Replacement)
+	assert.Equal(t, map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"}, currentSM)
 }

--- a/controllers/stargate/stargate_telemetry_reconciler_test.go
+++ b/controllers/stargate/stargate_telemetry_reconciler_test.go
@@ -57,5 +57,5 @@ func Test_reconcileStargateTelemetry_succeeds(t *testing.T) {
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
 	assert.Equal(t, stargate.Name, currentSM.Spec.Endpoints[0].MetricRelabelConfigs[0].Replacement)
-	assert.Contains(t, currentSM.Labels, map[string]string{"test-label": "test"})
+	assert.Contains(t, currentSM.Labels, "test-label")
 }

--- a/controllers/stargate/stargate_telemetry_reconciler_test.go
+++ b/controllers/stargate/stargate_telemetry_reconciler_test.go
@@ -37,7 +37,8 @@ func Test_reconcileStargateTelemetry_succeeds(t *testing.T) {
 	stargate := test.NewStargate("test-stargate", "test-stargate-namespace")
 	stargate.Spec.Telemetry = &telemetryapi.TelemetrySpec{
 		Prometheus: &telemetryapi.PrometheusTelemetrySpec{
-			Enabled: pointer.Bool(true),
+			Enabled:      pointer.Bool(true),
+			CommonLabels: map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"},
 		},
 	}
 	cfg := telemetry.PrometheusResourcer{

--- a/controllers/stargate/stargate_telemetry_reconciler_test.go
+++ b/controllers/stargate/stargate_telemetry_reconciler_test.go
@@ -57,5 +57,5 @@ func Test_reconcileStargateTelemetry_succeeds(t *testing.T) {
 	}
 	assert.NotEmpty(t, currentSM.Spec.Endpoints)
 	assert.Equal(t, stargate.Name, currentSM.Spec.Endpoints[0].MetricRelabelConfigs[0].Replacement)
-	assert.Equal(t, map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name", "test-label": "test"}, currentSM)
+	assert.Contains(t, currentSM.Labels, map[string]string{"test-label": "test"})
 }

--- a/test/kuttl/test-servicemonitors/03-assert.yaml
+++ b/test/kuttl/test-servicemonitors/03-assert.yaml
@@ -11,16 +11,21 @@ kind: ServiceMonitor
 metadata:
   name: test-dc1-cass-servicemonitor
   namespace: k8ssandra-operator
+  labels:
+    test-label: gobbledegook
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: test-dc1-stargate-stargate-servicemonitor
   namespace: k8ssandra-operator
+  labels:
+    test-label: gobbledegook
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: test-dc1-reaper-reaper-servicemonitor
   namespace: k8ssandra-operator
-  
+  labels:
+    test-label: gobbledegook

--- a/test/kuttl/test-servicemonitors/config/single-node-k8ssandra/kustomization.yaml
+++ b/test/kuttl/test-servicemonitors/config/single-node-k8ssandra/kustomization.yaml
@@ -2,29 +2,35 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: k8ssandra-operator
 resources:
-- ../../../config/fixtures/k8ssandra-base
+  - ../../../config/fixtures/k8ssandra-base
 # take basic deployment, add stargate and reaper, and add telemetry for stargate, cassandra and reaper.
 patches:
-- patch: |-
-    - op: add
-      path: /spec/stargate
-      value:
-        size: 1
-        telemetry:
+  - patch: |-
+      - op: add
+        path: /spec/stargate
+        value:
+          size: 1
+          telemetry:
+            prometheus:
+              enabled: true
+              commonLabels:
+                test-label: gobbledegook
+          allowStargateOnDataNodes: true
+      - op: add
+        path: /spec/cassandra/telemetry
+        value:
           prometheus:
-            enabled: true
-        allowStargateOnDataNodes: true
-    - op: add
-      path: /spec/cassandra/telemetry
-      value:
-        prometheus:
-            enabled: true
-    - op: add
-      path: /spec/reaper
-      value:
-        telemetry:
-          prometheus:
-            enabled: true
-  target:
-    kind: K8ssandraCluster
-    name: test
+              enabled: true
+              commonLabels:
+                test-label: gobbledegook
+      - op: add
+        path: /spec/reaper
+        value:
+          telemetry:
+            prometheus:
+              enabled: true
+              commonLabels:
+                test-label: gobbledegook
+    target:
+      kind: K8ssandraCluster
+      name: test


### PR DESCRIPTION
**What this PR does**:

Currently, it seems that commonLabels defined in the telemetry spec are ignored by the reconciliation process and are replaced wholesale by the `mustLabels` functions which apply the default (and compulsory) labels. 

This PR ensures that any label in commonLabels which is not a compulsory label is also applied.

**Which issue(s) this PR fixes**:
Fixes #803 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
