### PR TITLE
Remove relabelling rules from service monitors when MCAC is disabled

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -18,6 +18,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#739](https://github.com/k8ssandra/k8ssandra-operator/issues/739) Add API for cluster-level tasks
 * [FEATURE] [#775](https://github.com/k8ssandra/k8ssandra-operator/issues/775) Add the ability to inject and configure a Vector agent sidecar in the Cassandra pods
 * [FEATURE] [#600](https://github.com/k8ssandra/k8ssandra-operator/issues/600) Disable secrets management and replication with the external secrets provider
+* [FEATURE] [#501](https://github.com/k8ssandra/k8ssandra-operator/issues/501) Allow configuring annotations and labels on services, statefulsets, deployments and pods
 * [ENHANCEMENT] [#817](https://github.com/k8ssandra/k8ssandra-operator/issues/817) Allow configuring the Vector agent sidecar in the CRD
 * [ENHANCEMENT] [#796](https://github.com/k8ssandra/k8ssandra-operator/issues/796) Enable smart token allocation by default for DSE
 * [ENHANCEMENT] [#765](https://github.com/k8ssandra/k8ssandra-operator/issues/765) Add GitHub workflow to test various k8s versions
@@ -25,8 +26,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#770](https://github.com/k8ssandra/k8ssandra-operator/issues/770) Update to Go 1.19 and Operator SDK 1.25.2
 * [ENHANCEMENT] [#525](https://github.com/k8ssandra/k8ssandra-operator/issues/525) Deep-merge cluster- and dc-level templates
 * [ENHANCEMENT] [#781](https://github.com/k8ssandra/k8ssandra-operator/issues/781) Expose perNodeConfigInitContainer.Image through CRD
+* [ENHANCEMENT] [#822](https://github.com/k8ssandra/k8ssandra-operator/issues/822) Remove relabelling rules from service monitors when MCAC is disabled
 * [BUGFIX] [#726](https://github.com/k8ssandra/k8ssandra-operator/issues/726) Don't propagate Cassandra tolerations to the Stargate deployment
 * [BUGFIX] [#778](https://github.com/k8ssandra/k8ssandra-operator/issues/778) Fix Stargate deployments on k8s clusters using a custom domain name
 * [TESTING] [#761](https://github.com/k8ssandra/k8ssandra-operator/issues/761) Stabilize integration and e2e tests
 * [TESTING] [#799](https://github.com/k8ssandra/k8ssandra-operator/issues/799) Fix GHA CI failures with Kustomize install being rate limited
-* [FEATURE] [#501](https://github.com/k8ssandra/k8ssandra-operator/issues/501) Allow configuring annotations and labels on services, statefulsets, deployments and pods

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -59,11 +59,11 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 	// Determine if we want a cleanup or a resource update.
 	if mergedSpec.IsPrometheusEnabled() {
 		logger.Info("Prometheus config found", "mergedSpec", mergedSpec)
-		desiredSM, err := cfg.NewCassServiceMonitor()
+		desiredSM, err := cfg.NewCassServiceMonitor(mergedSpec.IsMcacEnabled())
 		if err != nil {
 			return result.Error(err)
 		}
-		if err := cfg.UpdateResources(ctx, remoteClient, actualDc, &desiredSM); err != nil {
+		if err := cfg.UpdateResources(ctx, remoteClient, actualDc, desiredSM); err != nil {
 			return result.Error(err)
 		}
 	} else {

--- a/controllers/k8ssandra/vector.go
+++ b/controllers/k8ssandra/vector.go
@@ -31,7 +31,7 @@ func (r *K8ssandraClusterReconciler) reconcileVector(
 	}
 	if kc.Spec.Cassandra.Telemetry.IsVectorEnabled() {
 		// Create the vector toml config content
-		toml, err := telemetry.CreateCassandraVectorToml(ctx, kc.Spec.Cassandra.Telemetry, remoteClient, namespace)
+		toml, err := telemetry.CreateCassandraVectorToml(kc.Spec.Cassandra.Telemetry, dcConfig.McacEnabled)
 		if err != nil {
 			return result.Error(err)
 		}

--- a/pkg/telemetry/prom_cass_servicemonitor_test.go
+++ b/pkg/telemetry/prom_cass_servicemonitor_test.go
@@ -1,26 +1,82 @@
 package telemetry
 
 import (
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
 	"testing"
 
-	testlogr "github.com/go-logr/logr/testing"
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
 
-// Test_NewCassServiceMonitor_SUCCESS tests that a new service monitor is successfully returned.
-func Test_NewCassServiceMonitor_SUCCESS(t *testing.T) {
-	logger := testlogr.NewTestLogger(t)
-	cfg := PrometheusResourcer{
-		MonitoringTargetNS:   "test-namespace",
-		MonitoringTargetName: "test-dc-name",
-		Logger:               logger,
-		ServiceMonitorName:   "test-servicemonitor",
-		CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+func Test_NewCassServiceMonitor(t *testing.T) {
+	logger := testr.New(t)
+	tests := []struct {
+		name            string
+		cfg             PrometheusResourcer
+		legacyEndpoints bool
+		wantTargetPort  int32
+		wantErr         require.ErrorAssertionFunc
+	}{
+		{
+			name: "MCAC enabled",
+			cfg: PrometheusResourcer{
+				MonitoringTargetNS:   "test-namespace",
+				MonitoringTargetName: "test-dc-name",
+				Logger:               logger,
+				ServiceMonitorName:   "test-servicemonitor",
+				CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+			},
+			legacyEndpoints: true,
+			wantTargetPort:  CassandraMetricsPortLegacy,
+			wantErr:         require.NoError,
+		},
+		{
+			name: "MCAC disabled",
+			cfg: PrometheusResourcer{
+				MonitoringTargetNS:   "test-namespace",
+				MonitoringTargetName: "test-dc-name",
+				Logger:               logger,
+				ServiceMonitorName:   "test-servicemonitor",
+				CommonLabels:         map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+			},
+			legacyEndpoints: false,
+			wantTargetPort:  CassandraMetricsPortModern,
+			wantErr:         require.NoError,
+		},
+		{
+			name: "validation error",
+			cfg: PrometheusResourcer{
+				Logger:             logger,
+				ServiceMonitorName: "test-servicemonitor",
+				CommonLabels:       map[string]string{k8ssandraapi.K8ssandraClusterNameLabel: "test-cluster-name"},
+			},
+			wantErr: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.EqualError(t, err, "TelemetryConfig did not contain required fields to process into a TelemetryConfig, missing field MonitoringTargetNS", msgAndArgs...)
+			},
+		},
+		{
+			name: "labels error",
+			cfg: PrometheusResourcer{
+				MonitoringTargetNS:   "test-namespace",
+				MonitoringTargetName: "test-dc-name",
+				Logger:               logger,
+				ServiceMonitorName:   "test-servicemonitor",
+			},
+			wantErr: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.EqualError(t, err, "TelemetryConfig did not contain required fields to process into a TelemetryConfig, missing field PrometheusResourcer.CommonLabels[k8ssandraapi.K8ssandraClusterNameLabel]", msgAndArgs...)
+			},
+		},
 	}
-	actualSM, err := cfg.NewCassServiceMonitor()
-	if err != nil {
-		assert.Fail(t, "error creating new service monitor", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualSM, err := test.cfg.NewCassServiceMonitor(test.legacyEndpoints)
+			test.wantErr(t, err)
+			if err == nil {
+				assert.Len(t, actualSM.Spec.Endpoints, 1)
+				assert.Equal(t, "", actualSM.Spec.Endpoints[0].Port)
+				assert.Equal(t, test.wantTargetPort, actualSM.Spec.Endpoints[0].TargetPort.IntVal)
+			}
+		})
 	}
-	assert.Equal(t, "prometheus", actualSM.Spec.Endpoints[0].Port)
 }

--- a/pkg/telemetry/prometheus_resourcer.go
+++ b/pkg/telemetry/prometheus_resourcer.go
@@ -25,8 +25,14 @@ type PrometheusResourcer struct {
 }
 
 func (cfg PrometheusResourcer) validate() error {
-	if cfg.MonitoringTargetNS == "" || cfg.MonitoringTargetName == "" || cfg.ServiceMonitorName == "" {
-		return TelemetryConfigIncomplete{}
+	if cfg.MonitoringTargetNS == "" {
+		return TelemetryConfigIncomplete{"MonitoringTargetNS"}
+	}
+	if cfg.MonitoringTargetName == "" {
+		return TelemetryConfigIncomplete{"MonitoringTargetName"}
+	}
+	if cfg.ServiceMonitorName == "" {
+		return TelemetryConfigIncomplete{"ServiceMonitorName"}
 	}
 	return nil
 }
@@ -39,7 +45,7 @@ func (cfg PrometheusResourcer) UpdateResources(
 	desiredSM *promapi.ServiceMonitor,
 ) error {
 	if err := cfg.validate(); err != nil {
-		return TelemetryConfigIncomplete{}
+		return err
 	}
 	cfg.Logger.Info("checking whether Prometheus ServiceMonitor for Cassandra already exists")
 	// Logic to handle case where SM does not exist.

--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 	"text/template"
@@ -14,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -96,7 +94,7 @@ type VectorConfig struct {
 	ScrapeInterval int32
 }
 
-func CreateCassandraVectorToml(ctx context.Context, telemetrySpec *telemetry.TelemetrySpec, remoteClient client.Client, namespace string) (string, error) {
+func CreateCassandraVectorToml(telemetrySpec *telemetry.TelemetrySpec, mcacEnabled bool) (string, error) {
 	vectorConfigToml := `
 [sinks.console]
 type = "console"
@@ -111,6 +109,13 @@ target = "stdout"
 		vectorConfigToml = BuildCustomVectorToml(telemetrySpec)
 	}
 
+	var scrapePort int32
+	if mcacEnabled {
+		scrapePort = CassandraMetricsPortLegacy
+	} else {
+		scrapePort = CassandraMetricsPortModern
+	}
+
 	var scrapeInterval int32 = DefaultScrapeInterval
 	if telemetrySpec.Vector.ScrapeInterval != nil {
 		scrapeInterval = int32(telemetrySpec.Vector.ScrapeInterval.Seconds())
@@ -118,7 +123,7 @@ target = "stdout"
 
 	config := VectorConfig{
 		Sinks:          vectorConfigToml,
-		ScrapePort:     CassandraMetricsPort,
+		ScrapePort:     scrapePort,
 		ScrapeInterval: scrapeInterval,
 	}
 

--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -15,13 +15,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Default resources for Vector agent
 const (
-	// Default resources for Vector agent
 	DefaultVectorCpuRequest    = "100m"
 	DefaultVectorMemoryRequest = "128Mi"
 	DefaultVectorCpuLimit      = "2"
 	DefaultVectorMemoryLimit   = "2Gi"
 	DefaultScrapeInterval      = 30
+	// CassandraMetricsPortLegacy is the metrics port to scrape for the legacy MCAC stack (Metrics
+	// Collector for Apache Cassandra).
+	CassandraMetricsPortLegacy = 9103
+	// CassandraMetricsPortModern is the metrics port to scrape for the modern stack (metrics
+	// exposed by management-api).
+	CassandraMetricsPortModern = 9000
 )
 
 // InjectCassandraVectorAgent adds the Vector agent container to the Cassandra pods.

--- a/pkg/telemetry/vector_test.go
+++ b/pkg/telemetry/vector_test.go
@@ -1,13 +1,11 @@
 package telemetry
 
 import (
-	"context"
+	"github.com/go-logr/logr/testr"
 	"testing"
 
-	testlogr "github.com/go-logr/logr/testing"
 	telemetry "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +21,7 @@ func TestInjectCassandraVectorAgent(t *testing.T) {
 		PodTemplateSpec: corev1.PodTemplateSpec{},
 	}
 
-	logger := testlogr.NewTestLogger(t)
+	logger := testr.New(t)
 
 	err := InjectCassandraVectorAgent(telemetrySpec, dcConfig, "test", logger)
 	require.NoError(t, err)
@@ -38,9 +36,8 @@ func TestInjectCassandraVectorAgent(t *testing.T) {
 
 func TestCreateCassandraVectorTomlDefault(t *testing.T) {
 	telemetrySpec := &telemetry.TelemetrySpec{Vector: &telemetry.VectorSpec{Enabled: pointer.Bool(true)}}
-	fakeClient := test.NewFakeClientWRestMapper()
 
-	toml, err := CreateCassandraVectorToml(context.Background(), telemetrySpec, fakeClient, "k8ssandra-operator")
+	toml, err := CreateCassandraVectorToml(telemetrySpec, true)
 	if err != nil {
 		t.Errorf("CreateCassandraVectorToml() failed with %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Remove relabelling rules from service monitors when MCAC is disabled
* Change ServiceMonitor target port when MCAC is disabled

**Which issue(s) this PR fixes**:
Fixes #822

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
