### PR TITLE
Don't reference DCs in system ks replication settings before they exist (fixes #829)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#829](https://github.com/k8ssandra/k8ssandra-operator/issues/829) Don't reference DCs in system ks replication settings before they exist
+
 ## v1.5.0 - 2023-02-03
 * [FEATURE] [#783](https://github.com/k8ssandra/k8ssandra-operator/issues/783) Allow disabling MCAC
 * [FEATURE] [#739](https://github.com/k8ssandra/k8ssandra-operator/issues/739) Add API for cluster-level tasks

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -259,12 +259,8 @@ func (r *K8ssandraClusterReconciler) setStatusForDatacenter(kc *api.K8ssandraClu
 
 func datacenterAddedToExistingCluster(kc *api.K8ssandraCluster, dcName string) bool {
 	_, found := kc.Status.Datacenters[dcName]
-	if kc.Spec.Cassandra.ServerType == api.ServerDistributionDse {
-		// Only request rebuild for the datacenter if it's not already in the cluster and if we have at least one datacenter already initialized.
-		return !found && len(kc.Status.Datacenters) > 0
-	} else {
-		return kc.Status.GetConditionStatus(api.CassandraInitialized) == corev1.ConditionTrue && !found
-	}
+	// Only request rebuild for the datacenter if it's not already in the cluster and if we have at least one datacenter already initialized.
+	return !found && len(kc.Status.Datacenters) > 0
 }
 
 func getSourceDatacenterName(targetDc *cassdcapi.CassandraDatacenter, kc *api.K8ssandraCluster) (string, error) {

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -55,7 +55,9 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 		// unauthenticated clusters.
 		// DSE doesn't support replicating to unexisting datacenters, even through the system property,
 		// which is why we're doing this for Cassandra only.
-		if kc.Spec.Cassandra.ServerType == api.ServerDistributionCassandra {
+		// We only set this for the first DC. For subsequent DCs, the replication will be altered and a rebuild
+		// triggered.
+		if kc.Spec.Cassandra.ServerType == api.ServerDistributionCassandra && len(dcConfigs) == 0 {
 			cassandra.ApplySystemReplication(dcConfig, systemReplication)
 		}
 

--- a/controllers/k8ssandra/medusa_reconciler_test.go
+++ b/controllers/k8ssandra/medusa_reconciler_test.go
@@ -177,6 +177,11 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 		return f.UpdateDatacenterGeneration(ctx, t, dc2Key)
 	}, timeout, interval, "failed to update dc2 generation")
 
+	t.Log("check that dc2 was rebuilt")
+	verifyRebuildTaskCreated(ctx, t, f, dc2Key, dc1Key)
+	rebuildTaskKey := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, "dc2-rebuild")
+	setRebuildTaskFinished(ctx, t, f, rebuildTaskKey, dc2Key)
+
 	checkMedusaObjectsCompliance(t, f, dc2, kc)
 
 	t.Log("check that the K8ssandraCluster status is updated")

--- a/controllers/k8ssandra/reaper_test.go
+++ b/controllers/k8ssandra/reaper_test.go
@@ -155,6 +155,11 @@ func createMultiDcClusterWithReaper(t *testing.T, ctx context.Context, f *framew
 	err = f.SetDatacenterStatusReady(ctx, dc2Key)
 	require.NoError(err, "failed to update dc2 status to ready")
 
+	t.Log("check that dc2 was rebuilt")
+	verifyRebuildTaskCreated(ctx, t, f, dc2Key, dc1Key)
+	rebuildTaskKey := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, "dc2-rebuild")
+	setRebuildTaskFinished(ctx, t, f, rebuildTaskKey, dc2Key)
+
 	t.Log("check that reaper reaper1 is created")
 	require.Eventually(f.ReaperExists(ctx, reaper1Key), timeout, interval)
 

--- a/controllers/k8ssandra/stop_dc_test.go
+++ b/controllers/k8ssandra/stop_dc_test.go
@@ -99,6 +99,11 @@ func stopDcTestSetup(t *testing.T, f *framework.Framework, ctx context.Context, 
 	err = f.SetDatacenterStatusReady(ctx, dc2Key)
 	require.NoError(t, err, "failed to set dc2 status ready")
 
+	t.Log("check that dc2 was rebuilt")
+	verifyRebuildTaskCreated(ctx, t, f, dc2Key, dc1Key)
+	rebuildTaskKey := framework.NewClusterKey(f.DataPlaneContexts[1], kc.Namespace, "dc2-rebuild")
+	setRebuildTaskFinished(ctx, t, f, rebuildTaskKey, dc2Key)
+
 	t.Log("wait for the CassandraInitialized condition to be set")
 	require.Eventually(t, func() bool {
 		err := f.Client.Get(ctx, kcKey, kc)

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -92,7 +92,6 @@ type DatacenterConfig struct {
 	Size                      int32
 	Stopped                   bool
 	Resources                 *corev1.ResourceRequirements
-	SystemReplication         SystemReplication
 	StorageConfig             *cassdcapi.StorageConfig
 	Racks                     []cassdcapi.Rack
 	CassandraConfig           api.CassandraConfig

--- a/pkg/cassandra/util.go
+++ b/pkg/cassandra/util.go
@@ -33,23 +33,6 @@ func DatacenterStopping(dc *cassdcapi.CassandraDatacenter) bool {
 	return dc.GetConditionStatus(cassdcapi.DatacenterStopped) == corev1.ConditionTrue && dc.Status.CassandraOperatorProgress == cassdcapi.ProgressUpdating
 }
 
-// GetDatacentersForSystemReplication determines the DCs that should be included for
-// replication. This function should only be used for system keyspaces. Replication for
-// system keyspaces is initially set through the management-api, not CQL. This allows us
-// to specify non-existent DCs for replication even though Cassandra 4 does not allow that.
-// That cannot be done when configuring replication through CQL which is why this func
-// should only be used for system keyspaces.
-func GetDatacentersForSystemReplication(kc *api.K8ssandraCluster) []api.CassandraDatacenterTemplate {
-	if kc.Spec.Cassandra.ServerType == api.ServerDistributionDse {
-		return kc.GetInitializedDatacenters()
-	}
-	if initialized := kc.Status.GetConditionStatus(api.CassandraInitialized) == corev1.ConditionTrue; initialized {
-		return kc.GetInitializedDatacenters()
-	} else {
-		return kc.Spec.Cassandra.Datacenters
-	}
-}
-
 // ComputeReplication computes the desired replication for each dc, taking into account the desired maximum replication
 // per dc.
 func ComputeReplication(maxReplicationPerDc int, datacenters ...*cassdcapi.CassandraDatacenter) map[string]int {


### PR DESCRIPTION
**What this PR does**:
Only reference the first DC in the `k8ssandra.io/initial-system-replication` annotation. This avoids referencing non-existing DCs ahead of time (which doesn't work with Cassandra 4.1). We alter system keyspaces after each DC gets added.

**Which issue(s) this PR fixes**:
Fixes #829

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
