### PR TITLE
More ConfigMap refactoring + handle edge case

### DIFF
--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/go-logr/logr"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
 	cassandra "github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	medusa "github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/reconciliation"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/secret"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -96,39 +94,8 @@ func (r *K8ssandraClusterReconciler) reconcileMedusaConfigMap(
 	logger.Info("Reconciling Medusa configMap on namespace : " + namespace)
 	if kc.Spec.Medusa != nil {
 		medusaIni := medusa.CreateMedusaIni(kc)
-		configMapKey := client.ObjectKey{
-			Namespace: kc.Namespace,
-			Name:      fmt.Sprintf("%s-medusa", kc.SanitizedName()),
-		}
-
-		logger := logger.WithValues("MedusaConfigMap", configMapKey)
 		desiredConfigMap := medusa.CreateMedusaConfigMap(namespace, kc.SanitizedName(), medusaIni)
-		// Compute a hash which will allow to compare desired and actual configMaps
-		annotations.AddHashAnnotation(desiredConfigMap)
-		actualConfigMap := &corev1.ConfigMap{}
-
-		if err := remoteClient.Get(ctx, configMapKey, actualConfigMap); err != nil {
-			if errors.IsNotFound(err) {
-				if err := remoteClient.Create(ctx, desiredConfigMap); err != nil {
-					logger.Error(err, "Failed to create Medusa ConfigMap")
-					return result.Error(err)
-				}
-			}
-		}
-
-		actualConfigMap = actualConfigMap.DeepCopy()
-
-		if !annotations.CompareHashAnnotations(actualConfigMap, desiredConfigMap) {
-			logger.Info("Updating configMap on namespace " + actualConfigMap.ObjectMeta.Namespace)
-			resourceVersion := actualConfigMap.GetResourceVersion()
-			desiredConfigMap.DeepCopyInto(actualConfigMap)
-			actualConfigMap.SetResourceVersion(resourceVersion)
-			if err := remoteClient.Update(ctx, actualConfigMap); err != nil {
-				logger.Error(err, "Failed to update Medusa ConfigMap resource")
-				return result.Error(err)
-			}
-			return result.RequeueSoon(r.DefaultDelay)
-		}
+		reconciliation.ReconcileConfigMap(ctx, remoteClient, r.DefaultDelay, *desiredConfigMap)
 	}
 	logger.Info("Medusa ConfigMap successfully reconciled")
 	return result.Continue()

--- a/controllers/stargate/stargate_controller.go
+++ b/controllers/stargate/stargate_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/reconciliation"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	stargateutil "github.com/k8ssandra/k8ssandra-operator/pkg/stargate"
 	"gopkg.in/yaml.v2"
@@ -441,35 +442,11 @@ func (r *StargateReconciler) reconcileStargateConfigMap(
 	desiredConfigMap := stargate.CreateStargateConfigMap(namespace, cassandraYaml, cqlYaml, dc)
 	// Compute a hash which will allow to compare desired and actual configMaps
 	annotations.AddHashAnnotation(desiredConfigMap)
-	actualConfigMap := &corev1.ConfigMap{}
-
-	if err = r.Get(ctx, configMapKey, actualConfigMap); err != nil {
-		if errors.IsNotFound(err) {
-			if err = controllerutil.SetControllerReference(stargateObject, desiredConfigMap, r.Scheme); err != nil {
-				return ctrl.Result{}, err
-			}
-			logger.Info("Stargate configMap doesn't exist, creating it")
-			if err := r.Create(ctx, desiredConfigMap); err != nil {
-				logger.Error(err, "Failed to create Stargate ConfigMap")
-				return ctrl.Result{}, err
-			} else {
-				actualConfigMap = desiredConfigMap
-			}
-		}
+	if err = controllerutil.SetControllerReference(stargateObject, desiredConfigMap, r.Scheme); err != nil {
+		return ctrl.Result{}, err
 	}
 
-	actualConfigMap = actualConfigMap.DeepCopy()
-
-	if !annotations.CompareHashAnnotations(actualConfigMap, desiredConfigMap) {
-		resourceVersion := actualConfigMap.GetResourceVersion()
-		desiredConfigMap.DeepCopyInto(actualConfigMap)
-		actualConfigMap.SetResourceVersion(resourceVersion)
-		if err = r.Update(ctx, actualConfigMap); err != nil {
-			logger.Error(err, "Failed to update Stargate ConfigMap resource")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: r.DefaultDelay}, nil
-	}
+	reconciliation.ReconcileConfigMap(ctx, r.Client, r.DefaultDelay, *desiredConfigMap)
 	logger.Info("Stargate ConfigMap successfully reconciled")
 	return ctrl.Result{}, nil
 }

--- a/pkg/reconciliation/configmaps.go
+++ b/pkg/reconciliation/configmaps.go
@@ -26,6 +26,11 @@ func ReconcileConfigMap(ctx context.Context, kClient client.Client, requeueDelay
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err := kClient.Create(ctx, &desiredObject); err != nil {
+				if errors.IsAlreadyExists(err) {
+					// the read from the local cache didn't catch that the resource was created
+					// already; simply requeue until the cache is up-to-date
+					dcLogger.Info("Reaper Vector Agent configuration already exists, requeueing")
+					return result.RequeueSoon(requeueDelay)
 				return result.Error(err)
 			}
 			return result.RequeueSoon(requeueDelay)


### PR DESCRIPTION
**What this PR does**:

More refactoring for ConfigMaps to address PR feedback from #866. Uses the new reconciliation function for Stargate and Medusa ConfigMaps.

Also fixes a potential edge case where timing issues might prevent creation of a ConfigMap when the call to `Get` fails with a not found, but the call to `Create` then fails with an "already exists" error. 

This logic was not previously used in every reconciliation, so was missed when building the general reconciler.

**Which issue(s) this PR fixes**:
Fixes #843

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
