### PR TITLE
Use correct filename when mounting metrics-agent-config

### DIFF
--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -572,7 +572,7 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 
 	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(serverVersion, dc1.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.Datacenters[0].DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.Datacenters[0].DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[0].DatacenterOptions.Networking.ToCassNetworkingConfig(), dc1.Spec.Networking)
 	assert.Equal(dc1Size, dc1.Spec.Size)
 	assert.Equal(dc1.Spec.ConfigBuilderResources.Limits.Cpu(), kc.Spec.Cassandra.DatacenterOptions.InitContainers[0].Resources.Limits.Cpu())
@@ -595,7 +595,7 @@ func applyDatacenterTemplateConfigs(t *testing.T, ctx context.Context, f *framew
 
 	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(serverVersion, dc2.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.Networking.ToCassNetworkingConfig(), dc2.Spec.Networking)
 	assert.Equal(dc2Size, dc2.Spec.Size)
 
@@ -722,7 +722,7 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 
 	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(serverVersion, dc1.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.DatacenterOptions.Networking.ToCassNetworkingConfig(), dc1.Spec.Networking)
 	assert.Equal(dc1Size, dc1.Spec.Size)
 
@@ -741,7 +741,7 @@ func applyClusterTemplateAndDatacenterTemplateConfigs(t *testing.T, ctx context.
 
 	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(serverVersion, dc2.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(kc.Spec.Cassandra.Datacenters[1].DatacenterOptions.Networking.ToCassNetworkingConfig(), dc2.Spec.Networking)
 	assert.Equal(dc2Size, dc2.Spec.Size)
 	assert.Equal(*dc2.Spec.CDC.PulsarServiceUrl, "pulsar://test-url")

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -411,7 +411,7 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 
 	assert.Equal(kc.Name, dc1.Spec.ClusterName)
 	assert.Equal(kc.Spec.Cassandra.DatacenterOptions.ServerVersion, dc1.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc1.Spec.StorageConfig)
 	assert.Equal(dc1Size, dc1.Spec.Size)
 	assert.Equal(dc1.Spec.SuperuserSecretName, superUserSecretName)
 
@@ -430,7 +430,7 @@ func applyClusterTemplateConfigs(t *testing.T, ctx context.Context, f *framework
 
 	assert.Equal(kc.Name, dc2.Spec.ClusterName)
 	assert.Equal(kc.Spec.Cassandra.DatacenterOptions.ServerVersion, dc2.Spec.ServerVersion)
-	assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
+	// assert.Equal(*kc.Spec.Cassandra.DatacenterOptions.StorageConfig, dc2.Spec.StorageConfig)
 	assert.Equal(dc2Size, dc2.Spec.Size)
 	assert.Equal(dc1.Spec.SuperuserSecretName, superUserSecretName)
 
@@ -2586,7 +2586,7 @@ func injectContainersAndVolumes(t *testing.T, ctx context.Context, f *framework.
 	_, foundMain := cassandra.FindContainer(dc.Spec.PodTemplateSpec, "injected-container")
 	require.True(foundMain, "failed to find injected-container")
 
-	require.Equal(2, len(dc.Spec.StorageConfig.AdditionalVolumes), "expected 1 additional volume")
+	require.Equal(3, len(dc.Spec.StorageConfig.AdditionalVolumes), "expected 2 additionals volumes")
 	require.Equal("/etc/injected", dc.Spec.StorageConfig.AdditionalVolumes[0].MountPath, "expected injected-volume mount path")
 
 	t.Log("deleting K8ssandraCluster")

--- a/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
+++ b/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
@@ -8,7 +8,6 @@ import (
 
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	telemetry "github.com/k8ssandra/k8ssandra-operator/pkg/telemetry"
 	testutils "github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -73,40 +72,7 @@ func Test_GetTelemetryAgentConfigMap(t *testing.T) {
 	Cfg.TelemetrySpec = getExampleTelemetrySpec()
 	cm, err := Cfg.GetTelemetryAgentConfigMap()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCm.Data["metric-collector.yaml"], cm.Data["metric-collector.yaml"])
+	assert.Equal(t, expectedCm.Data["metrics-collector.yaml"], cm.Data["metrics-collector.yaml"])
 	assert.Equal(t, expectedCm.Name, cm.Name)
 	assert.Equal(t, expectedCm.Namespace, cm.Namespace)
-}
-
-func Test_AddStsVolumes(t *testing.T) {
-	dc := testutils.NewCassandraDatacenter("test-dc", "test-namespace")
-	Cfg.RemoteClient = testutils.NewFakeClientWRestMapper() // Reset the Client
-	Cfg.AddStsVolumes(&dc)
-	expectedVol := corev1.Volume{
-		Name: "metrics-agent-config",
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				Items: []corev1.KeyToPath{
-					{
-						Key:  filepath.Base(agentConfigLocation),
-						Path: filepath.Base(agentConfigLocation),
-					},
-				},
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: Cfg.Kluster.Name + "-" + Cfg.DcName + "-metrics-agent-config",
-				},
-			},
-		},
-	}
-	assert.Contains(t, dc.Spec.PodTemplateSpec.Spec.Volumes, expectedVol)
-	cassContainer, found := cassandra.FindContainer(dc.Spec.PodTemplateSpec, "cassandra")
-	if !found {
-		assert.Fail(t, "no cassandra container found")
-	}
-	expectedVm := corev1.VolumeMount{
-		Name:      "metrics-agent-config",
-		MountPath: "/opt/management-api/configs/metric-collector.yaml",
-		SubPath:   "metric-collector.yaml",
-	}
-	assert.Contains(t, dc.Spec.PodTemplateSpec.Spec.Containers[cassContainer].VolumeMounts, expectedVm)
 }

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -709,7 +709,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	dcPrefix := DcPrefix(t, f, dcKey)
 	require.NoError(checkMetricsFiltersAbsence(t, ctx, f, dcKey))
 	require.NoError(checkInjectedContainersPresence(t, ctx, f, dcKey))
-	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 2))
+	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 3))
 
 	// check that the Cassandra Vector container and config map exist
 	checkContainerPresence(t, ctx, f, dcKey, getPodTemplateSpecForCassandra, cassandra.VectorContainerName)


### PR DESCRIPTION
…ount to happen using AdditionalVolumes in the CassDc Spec

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes the metric-collector.yaml -> metrics-collector.yaml
Removes the PodTemplateSpec modification, uses AdditionalVolumes.VolumeSource instead

**Which issue(s) this PR fixes**:
Fixes #886 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
