### PR TITLE
Add appsv1 to fakeclient

### DIFF
--- a/pkg/test/fakeclient.go
+++ b/pkg/test/fakeclient.go
@@ -9,6 +9,7 @@ import (
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +33,7 @@ func NewFakeClient(initRuntimeObjs ...runtime.Object) (client.Client, error) {
 	utilruntime.Must(reaperapi.AddToScheme(testScheme))
 	utilruntime.Must(stargateapi.AddToScheme(testScheme))
 	utilruntime.Must(corev1.AddToScheme(testScheme))
+	utilruntime.Must(appsv1.AddToScheme(testScheme))
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithRuntimeObjects(initRuntimeObjs...).


### PR DESCRIPTION
**What this PR does**:

While calling this function from another project, I discovered that it doesn't have the appsv1 group included in its scheme. This causes hard to understand errors in tests.

**Which issue(s) this PR fixes**:
Fixes #900

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
