### PR TITLE
Add modified vector config

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -15,15 +15,15 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-* [CHANGE] [#907](https://github.com/k8ssandra/k8ssandra-operator/issues/907) Remove Vector sidecar, instead use cass-operator's server-system-logger Vector agent and only modify its config
+* [CHANGE] [#907](https://github.com/k8ssandra/k8ssandra-operator/issues/907) Update to cass-operator v1.15.0, remove Vector sidecar, instead use cass-operator's server-system-logger Vector agent and only modify its config
 * [CHANGE] [#846](https://github.com/k8ssandra/k8ssandra-operator/issues/846) Remove deprecated CassandraBackup and CassandraRestore APIs
 * [CHANGE] [#848](https://github.com/k8ssandra/k8ssandra-operator/issues/848) Perform Helm releases in the release workflow
+* [CHANGE] [#887](https://github.com/k8ssandra/k8ssandra-operator/issues/887) Fix CVE-2022-32149.
+* [CHANGE] [#891](https://github.com/k8ssandra/k8ssandra-operator/issues/848) Update golang.org/x/net to fix several CVEs.
 * [FEATURE] [#826](https://github.com/k8ssandra/k8ssandra-operator/issues/836) Support cass-operator DC name overrides
 * [FEATURE] [#815](https://github.com/k8ssandra/k8ssandra-operator/issues/815) Add configuration block to CRDs for new Cassandra metrics agent.
+* [FEATURE] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/598) Create a mutating webhook for the internal secrets provider
 * [ENHANCEMENT] [#831](https://github.com/k8ssandra/k8ssandra-operator/issues/831) Add CLUSTER_NAME, DATACENTER_NAME and RACK_NAME environment variables to the vector container
 * [ENHANCEMENT] [#859](https://github.com/k8ssandra/k8ssandra-operator/issues/859) Remove current usages of managed-by label
 * [BUGFIX] [#854](https://github.com/k8ssandra/k8ssandra-operator/issues/854) Use Patch() to update K8ssandraTask status.
 * [BUGFIX] [#906](https://github.com/k8ssandra/k8ssandra-operator/issues/906) Remove sources from Vector configuration that have no sink attached to them (with or without transformers)
-* [CHANGE] [#887](https://github.com/k8ssandra/k8ssandra-operator/issues/887) Fix CVE-2022-32149.
-* [CHANGE] [#891](https://github.com/k8ssandra/k8ssandra-operator/issues/848) Update golang.org/x/net to fix several CVEs.
-* [FEATURE] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/598) Create a mutating webhook for the internal secrets provider

--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [CHANGE] [#907](https://github.com/k8ssandra/k8ssandra-operator/issues/907) Remove Vector sidecar, instead use cass-operator's server-system-logger Vector agent and only modify its config
 * [CHANGE] [#846](https://github.com/k8ssandra/k8ssandra-operator/issues/846) Remove deprecated CassandraBackup and CassandraRestore APIs
 * [CHANGE] [#848](https://github.com/k8ssandra/k8ssandra-operator/issues/848) Perform Helm releases in the release workflow
 * [FEATURE] [#826](https://github.com/k8ssandra/k8ssandra-operator/issues/836) Support cass-operator DC name overrides
@@ -22,6 +23,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#831](https://github.com/k8ssandra/k8ssandra-operator/issues/831) Add CLUSTER_NAME, DATACENTER_NAME and RACK_NAME environment variables to the vector container
 * [ENHANCEMENT] [#859](https://github.com/k8ssandra/k8ssandra-operator/issues/859) Remove current usages of managed-by label
 * [BUGFIX] [#854](https://github.com/k8ssandra/k8ssandra-operator/issues/854) Use Patch() to update K8ssandraTask status.
+* [BUGFIX] [#906](https://github.com/k8ssandra/k8ssandra-operator/issues/906) Remove sources from Vector configuration that have no sink attached to them (with or without transformers)
 * [CHANGE] [#887](https://github.com/k8ssandra/k8ssandra-operator/issues/887) Fix CVE-2022-32149.
 * [CHANGE] [#891](https://github.com/k8ssandra/k8ssandra-operator/issues/848) Update golang.org/x/net to fix several CVEs.
 * [FEATURE] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/598) Create a mutating webhook for the internal secrets provider

--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.14.0
+- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.15.0
 
 components:
   - ../../components/cass-operator-image-config

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=ee0ebfd
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.15.0
 
 components:
   - ../../components/cass-operator-image-config

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.14.0
+- ../../../../cass-operator/config/deployments/default
+# - github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.14.0
 
 components:
   - ../../components/cass-operator-image-config

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../../../cass-operator/config/deployments/default
-# - github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.14.0
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=ee0ebfd
 
 components:
   - ../../components/cass-operator-image-config

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -80,7 +80,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 		}
 
 		// Inject Vector agent
-		if err = telemetry.InjectCassandraVectorAgent(kc.Spec.Cassandra.Telemetry, dcConfig, kc.SanitizedName(), dcLogger); err != nil {
+		if err = telemetry.InjectCassandraVectorAgentConfig(kc.Spec.Cassandra.Telemetry, dcConfig, kc.SanitizedName(), dcLogger); err != nil {
 			return nil, err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.37.7
-	github.com/k8ssandra/cass-operator v1.14.0
+	github.com/k8ssandra/cass-operator v1.15.0
 	github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/k8ssandra/cass-operator v1.14.0 h1:rQUTPAda4zcMzeBQI8FBCllxAMqhLOdWgruavcoZ88I=
-github.com/k8ssandra/cass-operator v1.14.0/go.mod h1:DOpeU4I43JAbCkdAF+1k3nZ1TIs119d2SQWExVpG4zw=
+github.com/k8ssandra/cass-operator v1.15.0 h1:8D3hzsP6LVvwl+11Nj4SpmxbCprYUCnpFrmJ872Py+4=
+github.com/k8ssandra/cass-operator v1.15.0/go.mod h1:DOpeU4I43JAbCkdAF+1k3nZ1TIs119d2SQWExVpG4zw=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5 h1:Dq0VdM960G3AbhYwFuaebmsE08IzOYHYhngUfDmWaAc=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5/go.mod h1:WsQymIaVT39xbcstZhdqynUS13AGzP2p6U9Hsk1oy5M=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -20,10 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const (
-	VectorContainerName = "vector-agent"
-)
-
 // SystemReplication represents the replication factor of the system_auth, system_traces,
 // and system_distributed keyspaces. This is applied to each datacenter. The replication
 // is configured per DC.
@@ -259,11 +255,9 @@ func UpdateCassandraContainer(p *corev1.PodTemplateSpec, f func(c *corev1.Contai
 	UpdateContainer(p, reconciliation.CassandraContainerName, f)
 }
 
-// UpdateVectorContainer finds the vector container, passes it to f, and then adds it
-// back to the PodTemplateSpec. The Container object is created if necessary before calling
-// f. Only the Name field is initialized.
-func UpdateVectorContainer(p *corev1.PodTemplateSpec, f func(c *corev1.Container)) {
-	UpdateContainer(p, VectorContainerName, f)
+// UpdateLoggerContainer updates the PodTemplateSpec part for server-system-logger
+func UpdateLoggerContainer(p *corev1.PodTemplateSpec, f func(c *corev1.Container)) {
+	UpdateContainer(p, reconciliation.SystemLoggerContainerName, f)
 }
 
 // UpdateContainer finds the container with the given name, passes it to f, and then adds it

--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -80,6 +80,10 @@ func CreateCassandraVectorToml(telemetrySpec *telemetry.TelemetrySpec, mcacEnabl
 	telemetrySpec.Vector.Components.Sinks = append(telemetrySpec.Vector.Components.Sinks, defaultSinks...)
 	telemetrySpec.Vector.Components.Transforms = append(telemetrySpec.Vector.Components.Transforms, defaultTransformers...)
 
+	sources, transformers := FilterUnusedPipelines(telemetrySpec.Vector.Components.Sources, telemetrySpec.Vector.Components.Transforms, telemetrySpec.Vector.Components.Sinks)
+	telemetrySpec.Vector.Components.Sources = sources
+	telemetrySpec.Vector.Components.Transforms = transformers
+
 	// Vector components are provided in the Telemetry spec, build the Vector sink config from them
 	vectorConfigToml := BuildCustomVectorToml(telemetrySpec)
 	return vectorConfigToml, nil

--- a/pkg/telemetry/vector_test.go
+++ b/pkg/telemetry/vector_test.go
@@ -8,7 +8,6 @@ import (
 	k8ssandra "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	telemetry "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/vector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,20 +30,15 @@ func TestInjectCassandraVectorAgent(t *testing.T) {
 
 	logger := testr.New(t)
 
-	err := InjectCassandraVectorAgent(telemetrySpec, dcConfig, "test", logger)
+	err := InjectCassandraVectorAgentConfig(telemetrySpec, dcConfig, "test", logger)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(dcConfig.PodTemplateSpec.Spec.Containers))
-	assert.Equal(t, "vector-agent", dcConfig.PodTemplateSpec.Spec.Containers[0].Name)
+	assert.Equal(t, "server-system-logger", dcConfig.PodTemplateSpec.Spec.Containers[0].Name)
 	assert.Equal(t, resource.MustParse(vector.DefaultVectorCpuLimit), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Limits.Cpu())
 	assert.Equal(t, resource.MustParse(vector.DefaultVectorCpuRequest), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Requests.Cpu())
 	assert.Equal(t, resource.MustParse(vector.DefaultVectorMemoryLimit), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Limits.Memory())
 	assert.Equal(t, resource.MustParse(vector.DefaultVectorMemoryRequest), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Requests.Memory())
-	assert.NotNil(t, utils.FindEnvVarInContainer(&dcConfig.PodTemplateSpec.Spec.Containers[0], "CLUSTER_NAME"))
-	assert.Equal(t, "test1", utils.FindEnvVarInContainer(&dcConfig.PodTemplateSpec.Spec.Containers[0], "CLUSTER_NAME").Value)
-	assert.NotNil(t, utils.FindEnvVarInContainer(&dcConfig.PodTemplateSpec.Spec.Containers[0], "DATACENTER_NAME"))
-	assert.Equal(t, "dc1", utils.FindEnvVarInContainer(&dcConfig.PodTemplateSpec.Spec.Containers[0], "DATACENTER_NAME").Value)
-	assert.NotNil(t, utils.FindEnvVarInContainer(&dcConfig.PodTemplateSpec.Spec.Containers[0], "RACK_NAME"))
 }
 
 func TestCreateCassandraVectorTomlDefault(t *testing.T) {

--- a/pkg/telemetry/vector_test.go
+++ b/pkg/telemetry/vector_test.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// InjectCassandraVectorAgent adds the Vector agent container to the Cassandra pods.
-// If the Vector agent is already present, it is not added again.
 func TestInjectCassandraVectorAgentConfig(t *testing.T) {
 	telemetrySpec := &telemetry.TelemetrySpec{Vector: &telemetry.VectorSpec{Enabled: pointer.Bool(true)}}
 	dcConfig := &cassandra.DatacenterConfig{
@@ -54,7 +52,18 @@ func TestCreateCassandraVectorTomlDefault(t *testing.T) {
 }
 
 func TestCreateCassandraVectorTomlMcacDisabled(t *testing.T) {
-	telemetrySpec := &telemetry.TelemetrySpec{Mcac: &telemetry.McacTelemetrySpec{Enabled: pointer.Bool(false)}, Vector: &telemetry.VectorSpec{Enabled: pointer.Bool(true)}}
+	telemetrySpec := &telemetry.TelemetrySpec{Mcac: &telemetry.McacTelemetrySpec{Enabled: pointer.Bool(false)},
+		Vector: &telemetry.VectorSpec{
+			Enabled: pointer.Bool(true),
+			Components: &telemetry.VectorComponentsSpec{
+				Sinks: []telemetry.VectorSinkSpec{
+					{
+						Name:   "metrics_output",
+						Inputs: []string{"cassandra_metrics"},
+					},
+				},
+			},
+		}}
 
 	toml, err := CreateCassandraVectorToml(telemetrySpec, false)
 	if err != nil {

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "v1.15.0-dev.6cf2453-20230227"
+	cassOperatorVersion       = "1.15.0-dev.ee0ebfd-20230307"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "1.15.0"
+	cassOperatorVersion       = "v1.15.0"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "1.15.0-dev.ee0ebfd-20230307"
+	cassOperatorVersion       = "1.15.0"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "v1.14.0"
+	cassOperatorVersion       = "v1.15.0-dev.6cf2453-20230227"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -712,7 +712,6 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 3))
 
 	// check that the Cassandra Vector container and config map exist
-	checkContainerPresence(t, ctx, f, dcKey, getPodTemplateSpecForCassandra, cassandra.VectorContainerName)
 	checkVectorAgentConfigMapPresence(t, ctx, f, dcKey, telemetry.VectorAgentConfigMapName)
 
 	stargateKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: dcPrefix + "-stargate"}}
@@ -838,7 +837,6 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dcKey.Name)
 	// Check that Cassandra Vector's configmap is deleted
 	checkVectorConfigMapDeleted(t, ctx, f, dcKey, telemetry.VectorAgentConfigMapName)
-	checkContainerDeleted(t, ctx, f, dcKey, getPodTemplateSpecForCassandra, cassandra.VectorContainerName)
 	// Check that Stargate Vector's configmap is deleted
 	checkStargateReady(t, f, ctx, stargateKey)
 	checkStargateK8cStatusReady(t, f, ctx, kcKey, dcKey)
@@ -1017,9 +1015,7 @@ func createMultiDatacenterCluster(t *testing.T, ctx context.Context, namespace s
 	checkDatacenterReady(t, ctx, dc2Key, f)
 	assertCassandraDatacenterK8cStatusReady(ctx, t, f, kcKey, dc1Key.Name, dc2Key.Name)
 
-	checkContainerPresence(t, ctx, f, dc1Key, getPodTemplateSpecForCassandra, cassandra.VectorContainerName)
 	checkVectorAgentConfigMapPresence(t, ctx, f, dc1Key, telemetry.VectorAgentConfigMapName)
-	checkContainerPresence(t, ctx, f, dc2Key, getPodTemplateSpecForCassandra, cassandra.VectorContainerName)
 	checkVectorAgentConfigMapPresence(t, ctx, f, dc2Key, telemetry.VectorAgentConfigMapName)
 
 	t.Log("retrieve database credentials")

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -709,7 +709,7 @@ func createSingleDatacenterCluster(t *testing.T, ctx context.Context, namespace 
 	dcPrefix := DcPrefix(t, f, dcKey)
 	require.NoError(checkMetricsFiltersAbsence(t, ctx, f, dcKey))
 	require.NoError(checkInjectedContainersPresence(t, ctx, f, dcKey))
-	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 3))
+	require.NoError(checkInjectedVolumePresence(t, ctx, f, dcKey, 4))
 
 	// check that the Cassandra Vector container and config map exist
 	checkVectorAgentConfigMapPresence(t, ctx, f, dcKey, telemetry.VectorAgentConfigMapName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Modifies to use the cass-operator's logger container's Vector instance instead of creating another container to the pod running Vector.

Also, removes all the Vector configurations that do not actually emit anything to a sink.

**Which issue(s) this PR fixes**:
Fixes #905
Fixes #907

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
