### PR TITLE
Deprecate jmxInitContainerImage field (fixes #916)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [BUGFIX] [#914](https://github.com/k8ssandra/k8ssandra-operator/issues/914) Don't parse logs by default when Vector telemetry is enabled.
+* [BUGFIX] [#916](https://github.com/k8ssandra/k8ssandra-operator/issues/916) Deprecate jmxInitContainerImage field.

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -339,11 +339,8 @@ type DatacenterOptions struct {
 	// +optional
 	Racks []cassdcapi.Rack `json:"racks,omitempty"`
 
-	// The image to use in each Cassandra pod for the (short-lived) init container that enables JMX remote
-	// authentication on Cassandra pods. This is only useful when authentication is enabled in the cluster.
-	// The default is "busybox:1.34.1".
-	// +optional
-	// +kubebuilder:default={name:"busybox",tag:"1.34.1"}
+	// Deprecated: JMX security is now based on CQL roles. We don't need an init container to configure JMX
+	// authentication anymore. The value of this field will be ignored.
 	JmxInitContainerImage *images.Image `json:"jmxInitContainerImage,omitempty"`
 
 	// SoftPodAntiAffinity sets whether multiple Cassandra instances can be scheduled on the same node.

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -9178,14 +9178,10 @@ spec:
                             type: object
                           type: array
                         jmxInitContainerImage:
-                          default:
-                            name: busybox
-                            tag: 1.34.1
-                          description: The image to use in each Cassandra pod for
-                            the (short-lived) init container that enables JMX remote
-                            authentication on Cassandra pods. This is only useful
-                            when authentication is enabled in the cluster. The default
-                            is "busybox:1.34.1".
+                          description: 'Deprecated: JMX security is now based on CQL
+                            roles. We don''t need an init container to configure JMX
+                            authentication anymore. The value of this field will be
+                            ignored.'
                           properties:
                             name:
                               description: The image name to use.
@@ -21953,13 +21949,9 @@ spec:
                       type: object
                     type: array
                   jmxInitContainerImage:
-                    default:
-                      name: busybox
-                      tag: 1.34.1
-                    description: The image to use in each Cassandra pod for the (short-lived)
-                      init container that enables JMX remote authentication on Cassandra
-                      pods. This is only useful when authentication is enabled in
-                      the cluster. The default is "busybox:1.34.1".
+                    description: 'Deprecated: JMX security is now based on CQL roles.
+                      We don''t need an init container to configure JMX authentication
+                      anymore. The value of this field will be ignored.'
                     properties:
                       name:
                         description: The image name to use.


### PR DESCRIPTION
**What this PR does**:
Deprecate jmxInitContainerImage field

**Which issue(s) this PR fixes**:
Fixes #916

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
