### PR TITLE
Don't parse logs by default when Vector telemetry is enabled (fixes #914)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [BUGFIX] [#914](https://github.com/k8ssandra/k8ssandra-operator/issues/914) Don't parse logs by default when Vector telemetry is enabled.

--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -119,6 +119,9 @@ timeout_ms = 10000
 
 	sources = append(sources, systemLogInput, metricsInput)
 
+	// We provide this transform out of the box because it's likely to be a common need for users who extend the
+	// configuration; however by default we don't use it, it will be filtered out unless it's referenced by one of the
+	// user components.
 	systemLogParser := telemetry.VectorTransformSpec{
 		Name:   "parse_cassandra_log",
 		Type:   "remap",
@@ -158,7 +161,7 @@ if err == null {
 	systemLogSink := telemetry.VectorSinkSpec{
 		Name:   "console_log",
 		Type:   "console",
-		Inputs: []string{"parse_cassandra_log"},
+		Inputs: []string{"systemlog"},
 		Config: `target = "stdout"
 encoding.codec = "text"
 `,


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #914

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
