### PR TITLE
Upgrade cass-operator to v1.15.0 in the helm chart

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#923](https://github.com/k8ssandra/k8ssandra-operator/issues/923) Upgrade cass-operator to v1.15.0 in the helm chart
+
 ## v1.6.0 - 2023-03-10
 
 * [CHANGE] [#907](https://github.com/k8ssandra/k8ssandra-operator/issues/907) Update to cass-operator v1.15.0, remove Vector sidecar, instead use cass-operator's server-system-logger Vector agent and only modify its config

--- a/charts/k8ssandra-operator/Chart.lock
+++ b/charts/k8ssandra-operator/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.29.0
 - name: cass-operator
   repository: https://helm.k8ssandra.io
-  version: 0.40.0
-digest: sha256:85b90cede39b55c895eb70915ce532f5bcbecb59ee7d27c5886bc22f25e651bc
-generated: "2023-02-07T09:20:13.646671+01:00"
+  version: 0.41.0
+digest: sha256:ae663d8acc49d912cf6b5fbb976180a46980219751452893bbca0204b8f346ea
+generated: "2023-03-22T14:56:52.418208+01:00"

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.29.0
     repository: https://helm.k8ssandra.io
   - name: cass-operator
-    version: 0.40.0
+    version: 0.41.0
     repository: https://helm.k8ssandra.io
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Upgrade the cass-operator subchart to v1.15.0 (v0.41.0 chart version)

**Which issue(s) this PR fixes**:
Fixes #923 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
