### PR TITLE
Fix invalid metrics names from MCAC and remove the localhost endpoint override from the new metrics agent

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -13,6 +13,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+
+* [BUGFIX] [#925](https://github.com/k8ssandra/k8ssandra-operator/issues/923) Fix invalid metrics names from MCAC and remove the localhost endpoint override from the new metrics agent
+
 ## v1.6.1 - 2023-03-22
 
 * [BUGFIX] [#923](https://github.com/k8ssandra/k8ssandra-operator/issues/923) Upgrade cass-operator to v1.15.0 in the helm chart

--- a/pkg/telemetry/cassandra_agent/cassandra_agent_config.go
+++ b/pkg/telemetry/cassandra_agent/cassandra_agent_config.go
@@ -25,8 +25,7 @@ var (
 	agentConfigLocation = "/opt/management-api/configs/metrics-collector.yaml"
 	defaultAgentConfig  = telemetryapi.CassandraAgentSpec{
 		Endpoint: &telemetryapi.Endpoint{
-			Port:    "9000",
-			Address: "127.0.0.1",
+			Port: "9000",
 		},
 		Relabels: []promapi.RelabelConfig{
 			{

--- a/pkg/telemetry/cassandra_agent/cassandra_agent_config.go
+++ b/pkg/telemetry/cassandra_agent/cassandra_agent_config.go
@@ -24,9 +24,6 @@ import (
 var (
 	agentConfigLocation = "/opt/management-api/configs/metrics-collector.yaml"
 	defaultAgentConfig  = telemetryapi.CassandraAgentSpec{
-		Endpoint: &telemetryapi.Endpoint{
-			Port: "9000",
-		},
 		Relabels: []promapi.RelabelConfig{
 			{
 				SourceLabels: []string{"table"},

--- a/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
+++ b/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
@@ -106,9 +106,7 @@ relabels:
   sourceLabels:
   - should_drop
 `
-	relabelsDefinedYaml = `endpoint:
-  port: "9000"
-relabels:
+	relabelsDefinedYaml = `relabels:
 - action: drop
   regex: (.*);(b.*)
   separator: ;

--- a/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
+++ b/pkg/telemetry/cassandra_agent/cassandra_agent_config_test.go
@@ -28,7 +28,6 @@ var (
 		DcName:        testCluster.Spec.Cassandra.Datacenters[0].Meta.Name,
 	}
 	allDefinedYaml string = `endpoint:
-  address: 127.0.0.1
   port: "10000"
 relabels:
 - action: drop
@@ -108,7 +107,6 @@ relabels:
   - should_drop
 `
 	relabelsDefinedYaml = `endpoint:
-  address: 127.0.0.1
   port: "9000"
 relabels:
 - action: drop
@@ -142,8 +140,7 @@ func getExampleTelemetrySpec() telemetryapi.TelemetrySpec {
 		},
 	}
 	tspec.Cassandra.Endpoint = &telemetryapi.Endpoint{
-		Address: "127.0.0.1",
-		Port:    "10000",
+		Port: "10000",
 	}
 	return *tspec
 }

--- a/pkg/telemetry/prom_cass_servicemonitor.go
+++ b/pkg/telemetry/prom_cass_servicemonitor.go
@@ -219,15 +219,29 @@ spec:
       sourceLabels:
       - mcac
       targetLabel: __name__
-    - regex: org\.apache\.cassandra\.metrics\.hints_service\.hints_delays\-(\w+)
+    - action: replace
+      regex: org\.apache\.cassandra\.metrics\.hints_service\.hint_delays[\-\.]([\w\.]+)
       replacement: ${1}
       sourceLabels:
-      - mcac
+        - mcac
       targetLabel: peer_ip
-    - regex: org\.apache\.cassandra\.metrics\.hints_service\.hints_delays\-(\w+)
-      replacement: mcac_hints_hints_delays
+    - action: replace
+      regex: org\.apache\.cassandra\.metrics\.hints_service\.hint_delays[\-\.]([\w\.]+)
+      replacement: mcac_hints_hint_delays
       sourceLabels:
-      - mcac
+        - mcac
+      targetLabel: __name__
+    - action: replace
+      regex: org\.apache\.cassandra\.metrics\.hints_service\.hints_created[\-\.]([\w\.]+)
+      replacement: ${1}
+      sourceLabels:
+        - mcac
+      targetLabel: peer_ip
+    - action: replace
+      regex: org\.apache\.cassandra\.metrics\.hints_service\.hints_created[\-\.]([\w\.]+)
+      replacement: mcac_hints_hint_created
+      sourceLabels:
+        - mcac
       targetLabel: __name__
     - regex: org\.apache\.cassandra\.metrics\.hints_service\.([^\-]+)
       replacement: mcac_hints_${1}
@@ -308,6 +322,10 @@ spec:
       targetLabel: __name__
     - action: labeldrop
       regex: prom_name
+    - action: drop
+      regex: (.*)\.+(.*)
+      sourceLabels:
+      - __name__
 `
 
 // Static configuration for ServiceMonitor's endpoints, when using modern metrics endpoints. This


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fix relabeling issues with service monitors that didn't get the per node hints metrics names right (expecting a `-` instead of a `.`).
The last hint relabeling rule would also overwrite the previous ones due to the same issue.

The new metrics endpoint was configured to listen on localhost, which prevents scraping using the pod IP. The endpoint override was removed so that the metrics agent can listen on `0.0.0.0`.

**Which issue(s) this PR fixes**:
Fixes #925

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
