### PR TITLE
Trigger an error if MCAC is disabled but the Cassandra version doesn't support the new metrics endpoint

### DIFF
--- a/CHANGELOG/CHANGELOG-1.6.md
+++ b/CHANGELOG/CHANGELOG-1.6.md
@@ -16,6 +16,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [BUGFIX] [#925](https://github.com/k8ssandra/k8ssandra-operator/issues/923) Fix invalid metrics names from MCAC and remove the localhost endpoint override from the new metrics agent
+* [BUGFIX] [#929](https://github.com/k8ssandra/k8ssandra-operator/issues/929) Error out if the Cassandra version doesn't support the new metrics endpoint but MCAC is disabled
 
 ## v1.6.1 - 2023-03-22
 

--- a/docs/content/en/tasks/monitor/metrics-endpoints/_index.md
+++ b/docs/content/en/tasks/monitor/metrics-endpoints/_index.md
@@ -20,6 +20,8 @@ spec:
         enabled: false
 ```
 
+**Note:** The new metrics endpoint is only available for Cassandra 3.11.13 and above in the 3.11 branch, and Cassandra 4.0.4 and above in the 4.0 branch.  
+  
 While MCAC can work with Kubernetes, it wasn’t designed for it. Over the past couple years, we listed some inefficiencies and pain points which eventually led to a redesign.
 
 ### collectd

--- a/pkg/telemetry/validation.go
+++ b/pkg/telemetry/validation.go
@@ -2,11 +2,13 @@ package telemetry
 
 import (
 	"errors"
+	"reflect"
+
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,4 +39,11 @@ func IsPromInstalled(client client.Client, logger logr.Logger) (bool, error) {
 		return true, nil
 	}
 	return false, errors.New("something unexpected happened when determining whether prometheus is installed")
+}
+
+// IsNewMetricsEndpointAvailable returns true if the new metrics endpoint is available, false otherwise.
+// It is available since Cassandra 3.11.13 in the 3.11 branch and since 4.0.4 in the 4.0 branch.
+func IsNewMetricsEndpointAvailable(serverVersion string) bool {
+	semVersion := semver.MustParse(serverVersion)
+	return (semVersion.GreaterThan(semver.MustParse("3.11.12")) && semVersion.LessThan(semver.MustParse("4.0.0"))) || semVersion.GreaterThan(semver.MustParse("4.0.3"))
 }

--- a/pkg/telemetry/validation_test.go
+++ b/pkg/telemetry/validation_test.go
@@ -1,10 +1,11 @@
 package telemetry
 
 import (
+	"testing"
+
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"
-	"testing"
 )
 
 func TestSpecIsValid(t *testing.T) {
@@ -78,6 +79,46 @@ func TestSpecIsValid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SpecIsValid(tt.tspec, tt.promInstalled)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMetricsEndpointIsPresent(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverVersion string
+		want          bool
+	}{
+		{
+			"Old 3.11, no metrics endpoint",
+			"3.11.10",
+			false,
+		},
+		{
+			"Recent 3.11, metrics endpoint available",
+			"3.11.13",
+			true,
+		},
+		{
+			"Old 4.0, no metrics endpoint",
+			"4.0.2",
+			false,
+		},
+		{
+			"Recent 4.0, metrics endpoint available",
+			"4.0.4",
+			true,
+		},
+		{
+			"Recent 4.0, metrics endpoint available",
+			"4.0.5",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNewMetricsEndpointAvailable(tt.serverVersion)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Detects if MCAC is disabled but the version of Cassandra in use doesn't support the new metrics endpoint, and fails the reconcile with a proper error.
Also updates the docs to mention which versions of Cassandra support the new metrics endpoint.

**Which issue(s) this PR fixes**:
Fixes #933

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
