### PR TITLE
Sseidman/secret annotations

### DIFF
--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -2226,16 +2226,6 @@ func getCassDcAnnotations(t *testing.T, f *framework.Framework, ctx context.Cont
 	return dc.Spec.PodTemplateSpec.Annotations
 }
 
-// func getReaperAnnotations(t *testing.T, f *framework.Framework, ctx context.Context, key framework.ClusterKey) map[string]string {
-// 	reaper := &reaperapi.Reaper{}
-// 	err = f.Get(ctx, key, reaper)
-// 	if err != nil {
-// 		t.Logf("Failed to get Reaper: %v", err)
-// 	}
-
-// 	return reaper.Spec.ResourceMeta.Pods.Annotations
-// }
-
 func secretAnnotationAdded(t *testing.T, f *framework.Framework, ctx context.Context, key framework.ClusterKey,
 	annFn func(t *testing.T, f *framework.Framework, ctx context.Context, key framework.ClusterKey) map[string]string, secretName string) func() bool {
 	return func() bool {

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -79,6 +79,9 @@ func (r *K8ssandraClusterReconciler) reconcileMedusaSecrets(
 			return result.Error(err)
 		}
 	}
+
+	// TODO(ss): if we were to add annotation, inject it here
+
 	logger.Info("Medusa user secrets successfully reconciled")
 	return result.Continue()
 }

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -80,8 +80,6 @@ func (r *K8ssandraClusterReconciler) reconcileMedusaSecrets(
 		}
 	}
 
-	// TODO(ss): if we were to add annotation, inject it here
-
 	logger.Info("Medusa user secrets successfully reconciled")
 	return result.Continue()
 }

--- a/controllers/k8ssandra/reaper.go
+++ b/controllers/k8ssandra/reaper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	kerrors "github.com/k8ssandra/k8ssandra-operator/pkg/errors"
 	k8ssandralabels "github.com/k8ssandra/k8ssandra-operator/pkg/labels"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
+	reaper "github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -104,7 +104,11 @@ func (r *K8ssandraClusterReconciler) reconcileReaper(
 
 		logger.Info("Reaper present for DC " + actualDc.Name)
 
-		desiredReaper := reaper.NewReaper(reaperKey, kc, actualDc, reaperTemplate)
+		desiredReaper, err := reaper.NewReaper(reaperKey, kc, actualDc, reaperTemplate)
+		if err != nil {
+			logger.Error(err, "failed to create Reaper API object")
+			return result.Error(err)
+		}
 
 		if err := remoteClient.Get(ctx, reaperKey, actualReaper); err != nil {
 			if errors.IsNotFound(err) {

--- a/controllers/k8ssandra/reaper.go
+++ b/controllers/k8ssandra/reaper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	kerrors "github.com/k8ssandra/k8ssandra-operator/pkg/errors"
 	k8ssandralabels "github.com/k8ssandra/k8ssandra-operator/pkg/labels"
-	reaper "github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -48,7 +48,6 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 		return result.Error(err)
 	}
 
-	// inject annotation here (cluster or dc spec?) -- if using external secrets, do you still need to specify the secretname in the config?
 	err := secret.AddInjectionAnnotation(&kc.Spec.Cassandra.Meta.Pods, kc.Spec.Cassandra.SuperuserSecretRef.Name)
 	if err != nil {
 		logger.Error(err, "Failed to add superuser injection annotation")
@@ -59,9 +58,6 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 }
 
 func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
-	// TODO(ss): add annotation here? since they're being reconciled?
-	// what to do if external, should be allowed to customize secret name, but should it be specified here
-
 	if kc.Spec.Reaper != nil {
 		// Reaper secrets are only required when authentication is enabled on the cluster
 		if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
@@ -88,22 +84,6 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 				return result.Error(err)
 			}
 			logger.Info("Reaper user secrets successfully reconciled")
-
-			// if kc.Spec.Reaper.ResourceMeta == nil {
-			// 	kc.Spec.Reaper.ResourceMeta = &meta.ResourceMeta{}
-			// }
-
-			// err := secret.AddInjectionAnnotation(&kc.Spec.Reaper.ResourceMeta.Pods, cassandraUserSecretRef.Name)
-			// if err != nil {
-			// 	logger.Error(err, "Failed to add superuser injection annotation")
-			// 	return result.Error(err)
-			// }
-
-			// err = secret.AddInjectionAnnotation(&kc.Spec.Reaper.ResourceMeta.Pods, uiUserSecretRef.Name)
-			// if err != nil {
-			// 	logger.Error(err, "Failed to add superuser injection annotation")
-			// 	return result.Error(err)
-			// }
 
 		} else if kc.Spec.IsAuthEnabled() && kc.Spec.UseExternalSecrets() {
 			// Auth is enabled in the cluster, but the SecretsProvider is set to external, so no secret need to

--- a/controllers/k8ssandra/secrets.go
+++ b/controllers/k8ssandra/secrets.go
@@ -48,10 +48,20 @@ func (r *K8ssandraClusterReconciler) reconcileSuperuserSecret(ctx context.Contex
 		return result.Error(err)
 	}
 
+	// inject annotation here (cluster or dc spec?) -- if using external secrets, do you still need to specify the secretname in the config?
+	err := secret.AddInjectionAnnotation(&kc.Spec.Cassandra.Meta.Pods, kc.Spec.Cassandra.SuperuserSecretRef.Name)
+	if err != nil {
+		logger.Error(err, "Failed to add superuser injection annotation")
+		return result.Error(err)
+	}
+
 	return result.Continue()
 }
 
 func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context, kc *api.K8ssandraCluster, logger logr.Logger) result.ReconcileResult {
+	// TODO(ss): add annotation here? since they're being reconciled?
+	// what to do if external, should be allowed to customize secret name, but should it be specified here
+
 	if kc.Spec.Reaper != nil {
 		// Reaper secrets are only required when authentication is enabled on the cluster
 		if kc.Spec.IsAuthEnabled() && !kc.Spec.UseExternalSecrets() {
@@ -78,6 +88,23 @@ func (r *K8ssandraClusterReconciler) reconcileReaperSecrets(ctx context.Context,
 				return result.Error(err)
 			}
 			logger.Info("Reaper user secrets successfully reconciled")
+
+			// if kc.Spec.Reaper.ResourceMeta == nil {
+			// 	kc.Spec.Reaper.ResourceMeta = &meta.ResourceMeta{}
+			// }
+
+			// err := secret.AddInjectionAnnotation(&kc.Spec.Reaper.ResourceMeta.Pods, cassandraUserSecretRef.Name)
+			// if err != nil {
+			// 	logger.Error(err, "Failed to add superuser injection annotation")
+			// 	return result.Error(err)
+			// }
+
+			// err = secret.AddInjectionAnnotation(&kc.Spec.Reaper.ResourceMeta.Pods, uiUserSecretRef.Name)
+			// if err != nil {
+			// 	logger.Error(err, "Failed to add superuser injection annotation")
+			// 	return result.Error(err)
+			// }
+
 		} else if kc.Spec.IsAuthEnabled() && kc.Spec.UseExternalSecrets() {
 			// Auth is enabled in the cluster, but the SecretsProvider is set to external, so no secret need to
 			// be reconciled. Secrets will be injected into the Reaper pod by the mutating webhook configured by

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -58,20 +58,19 @@ func NewReaper(
 		},
 	}
 	if kc.Spec.IsAuthEnabled() {
-		if !kc.Spec.UseExternalSecrets() {
-			// if auth is enabled in this cluster, the k8ssandra controller will automatically create two secrets for
-			// Reaper: one for CQL and JMX connections, one for the UI. Here we assume that these secrets exist. If the
-			// secrets were specified by the user they should be already present in desiredReaper.Spec; otherwise, we assume
-			// that the k8ssandra controller created two secrets with default names, and we need to manually fill in this
-			// info in desiredReaper.Spec since it wasn't persisted in reaperTemplate.
-			if desiredReaper.Spec.CassandraUserSecretRef.Name == "" {
-				desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.SanitizedName())
-			}
-			// Note: deliberately skip JmxUserSecretRef, which is deprecated.
-			if desiredReaper.Spec.UiUserSecretRef.Name == "" {
-				desiredReaper.Spec.UiUserSecretRef.Name = DefaultUiSecretName(kc.SanitizedName())
-			}
+		// if auth is enabled in this cluster, the k8ssandra controller will automatically create two secrets for
+		// Reaper: one for CQL and JMX connections, one for the UI. Here we assume that these secrets exist. If the
+		// secrets were specified by the user they should be already present in desiredReaper.Spec; otherwise, we assume
+		// that the k8ssandra controller created two secrets with default names, and we need to manually fill in this
+		// info in desiredReaper.Spec since it wasn't persisted in reaperTemplate.
+		if desiredReaper.Spec.CassandraUserSecretRef.Name == "" {
+			desiredReaper.Spec.CassandraUserSecretRef.Name = DefaultUserSecretName(kc.SanitizedName())
 		}
+		// Note: deliberately skip JmxUserSecretRef, which is deprecated.
+		if desiredReaper.Spec.UiUserSecretRef.Name == "" {
+			desiredReaper.Spec.UiUserSecretRef.Name = DefaultUiSecretName(kc.SanitizedName())
+		}
+
 		if desiredReaper.Spec.ResourceMeta == nil {
 			desiredReaper.Spec.ResourceMeta = &meta.ResourceMeta{}
 		}

--- a/pkg/reaper/resource.go
+++ b/pkg/reaper/resource.go
@@ -19,9 +19,6 @@ const (
 
 	DatacenterAvailabilityEach = "EACH"
 	DatacenterAvailabilityAll  = "ALL"
-
-	defaultSecretMountPath = "/etc/secrets"
-	defaultSecretName      = "reaper"
 )
 
 // DefaultResourceName generates a name for a new Reaper resource that is derived from the Cassandra cluster and DC

--- a/pkg/secret/inject.go
+++ b/pkg/secret/inject.go
@@ -1,0 +1,71 @@
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/k8ssandra/k8ssandra-operator/pkg/meta"
+)
+
+// e.g. k8ssandra.io/inject-secret: '[{ "secretName": "test-secret", "path": "/etc/test/test-secret" }]'
+const (
+	SecretInjectionAnnotation = "k8ssandra.io/inject-secret"
+	credentialsMountPath      = "/etc/secrets"
+)
+
+type SecretInjection struct {
+	SecretName string `json:"secretName"`
+	Path       string `json:"path"`
+}
+
+func AddInjectionAnnotation(t *meta.Tags, secretName string) error {
+	if t.Annotations == nil {
+		t.Annotations = make(map[string]string)
+	}
+
+	var secrets []SecretInjection
+	if val, ok := t.Annotations[SecretInjectionAnnotation]; ok {
+		if err := json.Unmarshal([]byte(val), &secrets); err != nil {
+			return err
+		}
+	}
+
+	if isSecretIncluded(secrets, secretName) {
+		return nil
+	}
+
+	secretsStr, err := addSecretToAnnotationString(secrets, secretName, fmt.Sprintf("%s/%s", credentialsMountPath, secretName))
+	if err != nil {
+		return err
+	}
+
+	t.Annotations[SecretInjectionAnnotation] = string(secretsStr)
+	return nil
+}
+
+// checks if a secret with the same name and path has already been included in
+// the list of secrets to be injected
+func isSecretIncluded(secrets []SecretInjection, secretName string) bool {
+	for _, secret := range secrets {
+		if secret.SecretName == secretName {
+			return true
+		}
+	}
+	return false
+}
+
+func addSecretToAnnotationString(secrets []SecretInjection, secretName string, path string) (string, error) {
+	secret := SecretInjection{
+		SecretName: secretName,
+		Path:       path,
+	}
+
+	secrets = append(secrets, secret)
+
+	secretsStr, err := json.Marshal(secrets)
+	if err != nil {
+		return "", err
+	}
+
+	return string(secretsStr), nil
+}

--- a/pkg/secret/inject_test.go
+++ b/pkg/secret/inject_test.go
@@ -1,0 +1,103 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/k8ssandra/k8ssandra-operator/pkg/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddInjectionAnnotationEmptyTags(t *testing.T) {
+	tags := meta.Tags{}
+
+	err := AddInjectionAnnotation(&tags, "test-secret")
+	require.NoError(t, err)
+
+	val, ok := tags.Annotations[SecretInjectionAnnotation]
+	assert.True(t, ok)
+
+	expected := `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"}]`
+	assert.Equal(t, expected, val)
+}
+
+func TestAddInjectionAnnotationNonEmptyTags(t *testing.T) {
+	tags := meta.Tags{
+		Annotations: map[string]string{
+			"non-secret-key": "non-secret-value",
+		},
+	}
+
+	err := AddInjectionAnnotation(&tags, "test-secret")
+	require.NoError(t, err)
+
+	val, ok := tags.Annotations[SecretInjectionAnnotation]
+	assert.True(t, ok)
+
+	expected := `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"}]`
+	assert.Equal(t, expected, val)
+
+	val, ok = tags.Annotations["non-secret-key"]
+	assert.True(t, ok)
+	assert.Equal(t, val, "non-secret-value")
+}
+
+func TestAddInjectionAnnotationWithInjectionAnnotationPresent(t *testing.T) {
+	tags := meta.Tags{
+		Annotations: map[string]string{
+			SecretInjectionAnnotation: `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"}]`,
+		},
+	}
+
+	err := AddInjectionAnnotation(&tags, "other-secret")
+	require.NoError(t, err)
+
+	expected := `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"},{"secretName":"other-secret","path":"/etc/secrets/other-secret"}]`
+	val, ok := tags.Annotations[SecretInjectionAnnotation]
+	assert.True(t, ok)
+	assert.Equal(t, expected, val)
+}
+
+func TestAddInjectionAnnotationDuplicate(t *testing.T) {
+	tags := meta.Tags{
+		Annotations: map[string]string{
+			SecretInjectionAnnotation: `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"}]`,
+		},
+	}
+
+	err := AddInjectionAnnotation(&tags, "test-secret")
+	require.NoError(t, err)
+
+	expected := `[{"secretName":"test-secret","path":"/etc/secrets/test-secret"}]`
+	val, ok := tags.Annotations[SecretInjectionAnnotation]
+	assert.True(t, ok)
+	assert.Equal(t, expected, val)
+}
+
+func TestAddInjectionAnnotationNonJson(t *testing.T) {
+	tags := meta.Tags{
+		Annotations: map[string]string{
+			SecretInjectionAnnotation: `non-json-string-specified`,
+		},
+	}
+
+	err := AddInjectionAnnotation(&tags, "test-secret")
+	require.Error(t, err)
+}
+
+func TestIsSecretIncluded(t *testing.T) {
+	secrets := []SecretInjection{
+		SecretInjection{SecretName: "test", Path: "/etc/secrets"},
+		SecretInjection{SecretName: "other", Path: "/etc/secrets"},
+	}
+
+	assert.True(t, isSecretIncluded(secrets, "test"))
+	assert.True(t, isSecretIncluded(secrets, "other"))
+	assert.False(t, isSecretIncluded(secrets, "nothing"))
+
+}
+
+func TestIsSecretIncludedNilSlice(t *testing.T) {
+	var secrets []SecretInjection
+	assert.False(t, isSecretIncluded(secrets, "test"))
+}


### PR DESCRIPTION
**What this PR does**:
Configures the k8ssandra-operator to add pod annotations to the ResourceMeta for CassandraDatacenter and Reaper that specify the CQL credential secrets to inject into the cassandra & reaper pods. These annotations will trigger the webhook to (as currently setup) add the volumes and volumeMounts for the kubernetes secrets to each pod specified with the annotation.

The resulting API objects created should show:
```
apiVersion: v1
items:
- apiVersion: cassandra.datastax.com/v1beta1
  kind: CassandraDatacenter
...
    podTemplateSpec:
      metadata:
        annotations:
          k8ssandra.io/inject-secret: '[{"secretName":"demo-superuser","path":"/etc/secrets/demo-superuser"}]'
```

```
apiVersion: v1
items:
- apiVersion: reaper.k8ssandra.io/v1alpha1
  kind: Reaper
 ...
    metadata:
      pods:
        annotations:
          k8ssandra.io/inject-secret: '[{"secretName":"demo-reaper","path":"/etc/secrets/demo-reaper"},{"secretName":"demo-reaper-ui","path":"/etc/secrets/demo-reaper-ui"}]'
 ```

**Which issue(s) this PR fixes**:
Fixes #601 & #602 (paritally)

**Checklist**
- [x] Changes manually tested
- [ x Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
