### PR TITLE
inject init-container secrets webhook

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -18,3 +18,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#914](https://github.com/k8ssandra/k8ssandra-operator/issues/914) Don't parse logs by default when Vector telemetry is enabled.
 * [BUGFIX] [#916](https://github.com/k8ssandra/k8ssandra-operator/issues/916) Deprecate jmxInitContainerImage field.
 * [DOCS] [#919](https://github.com/k8ssandra/k8ssandra-operator/issues/919) Improve the release process documentation.
+* [ENHANCEMENT] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/605) Change webhook to inject init-container for secrets mounting.
+

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -19,4 +19,3 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#916](https://github.com/k8ssandra/k8ssandra-operator/issues/916) Deprecate jmxInitContainerImage field.
 * [DOCS] [#919](https://github.com/k8ssandra/k8ssandra-operator/issues/919) Improve the release process documentation.
 * [ENHANCEMENT] [#605](https://github.com/k8ssandra/k8ssandra-operator/issues/605) Change webhook to inject init-container for secrets mounting.
-

--- a/controllers/secrets-webhook/secretswebhook_test.go
+++ b/controllers/secrets-webhook/secretswebhook_test.go
@@ -112,7 +112,7 @@ func TestMutatePodsSingleSecret(t *testing.T) {
 				VolumeMounts: vm,
 			}},
 			InitContainers: []corev1.Container{{
-				Name:         "secrets-inject",
+				Name:         defaultInjectContainerName,
 				Image:        defaultInitContainerImage,
 				Args:         []string{"mount", secretsStr},
 				VolumeMounts: vm,
@@ -172,7 +172,7 @@ func TestMutatePodsSingleSecretCustomImage(t *testing.T) {
 				VolumeMounts: vm,
 			}},
 			InitContainers: []corev1.Container{{
-				Name:         "secrets-inject",
+				Name:         defaultInjectContainerName,
 				Image:        image,
 				Args:         []string{"mount", secretsStr},
 				VolumeMounts: vm,
@@ -245,7 +245,7 @@ func TestMutatePodsMultiSecret(t *testing.T) {
 				VolumeMounts: vm,
 			}},
 			InitContainers: []corev1.Container{{
-				Name:         "secrets-inject",
+				Name:         defaultInjectContainerName,
 				Image:        defaultInitContainerImage,
 				Args:         []string{"mount", injectionAnnotation},
 				VolumeMounts: vm,

--- a/controllers/secrets-webhook/secretswebhook_test.go
+++ b/controllers/secrets-webhook/secretswebhook_test.go
@@ -40,7 +40,7 @@ func TestHandleInjectSecretSuccess(t *testing.T) {
 	resp := p.Handle(context.Background(), req)
 	fmt.Println(fmt.Sprintf("%v", resp))
 	assert.Equal(t, true, resp.AdmissionResponse.Allowed)
-	// 2 patches for addition of volume and volumeMount
+	// 3 patches for addition of init-container, volume, and volumeMount
 	assert.Equal(t, len(resp.Patches), 3)
 	sort.Slice(resp.Patches, func(i, j int) bool {
 		return resp.Patches[i].Path < resp.Patches[j].Path


### PR DESCRIPTION
**What this PR does**:
Changes the default secrets-webhook to inject an init-container into each pod that is eligible for mutation through the secrets injection annotation. The webhook will insert the init-container into the first position of each pod since some init-containers might depend on the credentials being available on the local filesystem (e.g. medusa restores). By default, the webhook will inject the `k8ssandra/k8ssandra-client` image, which will have a [mount command](https://github.com/k8ssandra/k8ssandra-client/pull/6) to process the annotation string, retrieving and mounting the secrets to the specified path. If a user wants to use their own custom image, they can set the annotation `k8ssandra.io/inject-secret-image` with the image name. The custom image must be compatible with the args `["mount", {secretInjection}"]`

**Which issue(s) this PR fixes**:
Fixes #605 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
