### PR TITLE
Fix ReplicatedSecrets not being updated when adding a DC without specifying a context

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -98,6 +98,7 @@ jobs:
           - ChangeDseWorkload
           - PerNodeConfig/UserDefined
           - RemoveLocalDcFromCluster
+          - AddDcToClusterSameDataplane
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -20,5 +20,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#916](https://github.com/k8ssandra/k8ssandra-operator/issues/916) Deprecate jmxInitContainerImage field.
 * [BUGFIX] [#946](https://github.com/k8ssandra/k8ssandra-operator/issues/946) Fix medusaClient to fetch the pods from correct namespace
 * [BUGFIX] [#940](https://github.com/k8ssandra/k8ssandra-operator/issues/940) Vector resource requirements are correctly set to the server-system-logger and also allow override of server-system-logger resource properties from containers.
+* [BUGFIX] [#973](https://github.com/k8ssandra/k8ssandra-operator/issues/973) ReplicatedSecrets don't get updated when a DC is added in a different namespace but without context
 * [DOCS] [#935](https://github.com/k8ssandra/k8ssandra-operator/issues/935) Add and document updated dashboards for the new metrics endpoint
 * [DOCS] [#919](https://github.com/k8ssandra/k8ssandra-operator/issues/919) Improve the release process documentation.

--- a/pkg/secret/replicated.go
+++ b/pkg/secret/replicated.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"math/big"
+	"reflect"
+
 	"github.com/go-logr/logr"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
@@ -12,8 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"math/big"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -181,7 +182,6 @@ func generateReplicatedSecret(kcKey client.ObjectKey, replicationTargets []repli
 
 func requiresUpdate(current, desired *replicationapi.ReplicatedSecret) bool {
 	// Ensure our labels are there (allow additionals) and our selector is there (nothing else) and replicationTargets has at least our targets
-
 	// Selector must not change
 	if !reflect.DeepEqual(current.Spec.Selector, desired.Spec.Selector) {
 		return true
@@ -194,18 +194,6 @@ func requiresUpdate(current, desired *replicationapi.ReplicatedSecret) bool {
 		}
 	}
 
-	// TargetContexts must have our desired ones, additionals allowed also.
-	currentContexts := make(map[string]bool, len(current.Spec.ReplicationTargets))
-
-	for _, target := range current.Spec.ReplicationTargets {
-		currentContexts[target.K8sContextName] = true
-	}
-
-	for _, target := range desired.Spec.ReplicationTargets {
-		if _, found := currentContexts[target.K8sContextName]; !found {
-			return true
-		}
-	}
-
-	return false
+	// ReplicationTargets must be different to require an update
+	return !reflect.DeepEqual(current.Spec.ReplicationTargets, desired.Spec.ReplicationTargets)
 }

--- a/test/testdata/fixtures/add-dc-cass-only/k8ssandra.yaml
+++ b/test/testdata/fixtures/add-dc-cass-only/k8ssandra.yaml
@@ -1,0 +1,26 @@
+apiVersion: k8ssandra.io/v1alpha1
+kind: K8ssandraCluster
+metadata:
+  name: test
+spec:
+  cassandra:
+    serverVersion: "4.1.0"
+    storageConfig:
+      cassandraDataVolumeClaimSpec:
+        storageClassName: standard
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+    config:
+      jvmOptions:
+        heapSize: 384Mi
+    networking:
+      hostNetwork: true
+    datacenters:
+      - metadata:
+          name: dc1
+        k8sContext: kind-k8ssandra-0
+        size: 2
+    mgmtAPIHeap: 64Mi

--- a/test/testdata/fixtures/add-dc-cass-only/kustomization.yaml
+++ b/test/testdata/fixtures/add-dc-cass-only/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - k8ssandra.yaml


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Changes the checks to decide whether or not a ReplicatedSecret needs to be updated.
Currently it falls short if a dc is added in a different namespace but in the default context (without a specific context specified).

**Which issue(s) this PR fixes**:
Fixes #973

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] ~~Documentation added/updated~~
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] ~~CLA Signed:  [DataStax CLA](https://cla.datastax.com/)~~
