### PR TITLE
Fix misspelling of the word 'overridden'

### DIFF
--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -132,7 +132,7 @@ type ReaperTemplate struct {
 	InitContainerResources *corev1.ResourceRequirements `json:"initContainerResources,omitempty"`
 
 	// Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster
-	// (unless overriden by DC specific settings)
+	// (unless overridden by DC specific settings)
 	// +optional
 	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 

--- a/apis/stargate/v1alpha1/stargate_types.go
+++ b/apis/stargate/v1alpha1/stargate_types.go
@@ -107,7 +107,7 @@ type StargateTemplate struct {
 	CassandraConfigMapRef *corev1.LocalObjectReference `json:"cassandraConfigMapRef,omitempty"`
 
 	// Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster
-	// (unless overriden by DC specific settings)
+	// (unless overridden by DC specific settings)
 	// +optional
 	Telemetry *telemetryapi.TelemetrySpec `json:"telemetry,omitempty"`
 

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -14243,8 +14243,8 @@ spec:
                             telemetry:
                               description: Telemetry defines the desired telemetry
                                 integrations to deploy targeting the Stargate pods
-                                for all DCs in this cluster (unless overridden by DC
-                                specific settings)
+                                for all DCs in this cluster (unless overridden by
+                                DC specific settings)
                               properties:
                                 cassandra:
                                   properties:

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -13724,7 +13724,7 @@ spec:
                                   telemetry:
                                     description: Telemetry defines the desired telemetry
                                       integrations to deploy targeting the Stargate
-                                      pods for all DCs in this cluster (unless overriden
+                                      pods for all DCs in this cluster (unless overridden
                                       by DC specific settings)
                                     properties:
                                       cassandra:
@@ -14243,7 +14243,7 @@ spec:
                             telemetry:
                               description: Telemetry defines the desired telemetry
                                 integrations to deploy targeting the Stargate pods
-                                for all DCs in this cluster (unless overriden by DC
+                                for all DCs in this cluster (unless overridden by DC
                                 specific settings)
                               properties:
                                 cassandra:
@@ -28176,7 +28176,7 @@ spec:
                   telemetry:
                     description: Telemetry defines the desired telemetry integrations
                       to deploy targeting the Reaper pods for all DCs in this cluster
-                      (unless overriden by DC specific settings)
+                      (unless overridden by DC specific settings)
                     properties:
                       cassandra:
                         properties:
@@ -29845,7 +29845,7 @@ spec:
                   telemetry:
                     description: Telemetry defines the desired telemetry integrations
                       to deploy targeting the Stargate pods for all DCs in this cluster
-                      (unless overriden by DC specific settings)
+                      (unless overridden by DC specific settings)
                     properties:
                       cassandra:
                         properties:

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -2076,7 +2076,7 @@ spec:
               telemetry:
                 description: Telemetry defines the desired telemetry integrations
                   to deploy targeting the Reaper pods for all DCs in this cluster
-                  (unless overriden by DC specific settings)
+                  (unless overridden by DC specific settings)
                 properties:
                   cassandra:
                     properties:

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -2764,7 +2764,7 @@ spec:
                     telemetry:
                       description: Telemetry defines the desired telemetry integrations
                         to deploy targeting the Stargate pods for all DCs in this
-                        cluster (unless overriden by DC specific settings)
+                        cluster (unless overridden by DC specific settings)
                       properties:
                         cassandra:
                           properties:
@@ -3231,7 +3231,7 @@ spec:
               telemetry:
                 description: Telemetry defines the desired telemetry integrations
                   to deploy targeting the Stargate pods for all DCs in this cluster
-                  (unless overriden by DC specific settings)
+                  (unless overridden by DC specific settings)
                 properties:
                   cassandra:
                     properties:

--- a/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md
+++ b/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md
@@ -18296,7 +18296,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -20321,7 +20321,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -22545,7 +22545,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -23447,7 +23447,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -43712,7 +43712,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -46948,7 +46948,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -47682,7 +47682,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -49906,7 +49906,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -71011,7 +71011,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -74465,7 +74465,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -75652,7 +75652,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -78106,7 +78106,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -80330,7 +80330,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -81232,7 +81232,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-0.4/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-0.4/_index.md
@@ -6122,7 +6122,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7910,7 +7910,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9877,7 +9877,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -10274,7 +10274,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -15930,7 +15930,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -17897,7 +17897,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -36548,7 +36548,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -38573,7 +38573,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -40540,7 +40540,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -40937,7 +40937,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-0.5/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-0.5/_index.md
@@ -6117,7 +6117,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7905,7 +7905,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9872,7 +9872,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -10269,7 +10269,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -15857,7 +15857,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -17824,7 +17824,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -36484,7 +36484,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -38509,7 +38509,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -40476,7 +40476,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -40873,7 +40873,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.0/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.0/_index.md
@@ -6023,7 +6023,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7811,7 +7811,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9778,7 +9778,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -10175,7 +10175,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -16026,7 +16026,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -17993,7 +17993,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -36653,7 +36653,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -38678,7 +38678,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -40645,7 +40645,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -41042,7 +41042,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.1/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.1/_index.md
@@ -6905,7 +6905,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8737,7 +8737,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10792,7 +10792,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -11233,7 +11233,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -17181,7 +17181,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -19236,7 +19236,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -39099,7 +39099,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -41168,7 +41168,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -43223,7 +43223,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -43664,7 +43664,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.2/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.2/_index.md
@@ -17298,7 +17298,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -19183,7 +19183,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -21284,7 +21284,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -21759,7 +21759,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -30150,7 +30150,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -33263,7 +33263,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -33553,7 +33553,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -35654,7 +35654,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -52116,7 +52116,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -55351,7 +55351,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -56094,7 +56094,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -58216,7 +58216,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -60317,7 +60317,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -60792,7 +60792,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.3/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.3/_index.md
@@ -12661,7 +12661,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14546,7 +14546,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16647,7 +16647,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -17122,7 +17122,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -25554,7 +25554,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -28667,7 +28667,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -28957,7 +28957,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -31058,7 +31058,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -47540,7 +47540,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -50775,7 +50775,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -51518,7 +51518,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -53640,7 +53640,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -55741,7 +55741,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -56216,7 +56216,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.4/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.4/_index.md
@@ -13219,7 +13219,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15114,7 +15114,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -17215,7 +17215,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -17690,7 +17690,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -26566,7 +26566,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -29679,7 +29679,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -29979,7 +29979,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -32080,7 +32080,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -48572,7 +48572,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -51903,7 +51903,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -52656,7 +52656,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -54980,7 +54980,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -57081,7 +57081,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -57556,7 +57556,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.5/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.5/_index.md
@@ -18286,7 +18286,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -20311,7 +20311,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -22535,7 +22535,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -23291,7 +23291,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -43118,7 +43118,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -46354,7 +46354,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -46942,7 +46942,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -49166,7 +49166,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -70125,7 +70125,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -73579,7 +73579,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -74620,7 +74620,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -77074,7 +77074,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -79298,7 +79298,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -80054,7 +80054,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>

--- a/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.6/_index.md
+++ b/docs/content/en/reference/crd/releases/k8ssandra-operator-releases/k8ssandra-operator-crds-1.6/_index.md
@@ -18300,7 +18300,7 @@ Stargate defines the desired deployment characteristics for Stargate in this dat
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -20325,7 +20325,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#k8ssandraclusterspeccassandradatacentersindexstargateracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -22549,7 +22549,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -23451,7 +23451,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -43716,7 +43716,7 @@ Reaper defines the desired deployment characteristics for Reaper in this K8ssand
         <td><b><a href="#k8ssandraclusterspecreapertelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -46952,7 +46952,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -47686,7 +47686,7 @@ Stargate defines the desired deployment characteristics for Stargate in this K8s
         <td><b><a href="#k8ssandraclusterspecstargatetelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -49910,7 +49910,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -71015,7 +71015,7 @@ ReaperSpec defines the desired state of Reaper
         <td><b><a href="#reaperspectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -74469,7 +74469,7 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Reaper pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -75656,7 +75656,7 @@ Specification of the desired behavior of this Stargate resource.
         <td><b><a href="#stargatespectelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -78110,7 +78110,7 @@ StargateRackTemplate defines custom rules for Stargate pods in a given rack. The
         <td><b><a href="#stargatespecracksindextelemetry">telemetry</a></b></td>
         <td>object</td>
         <td>
-          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)<br/>
+          Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -80334,7 +80334,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>
@@ -81236,7 +81236,7 @@ Resources is the Kubernetes resource requests and limits to apply, per Stargate 
 
 
 
-Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overriden by DC specific settings)
+Telemetry defines the desired telemetry integrations to deploy targeting the Stargate pods for all DCs in this cluster (unless overridden by DC specific settings)
 
 <table>
     <thead>


### PR DESCRIPTION
**What this PR does**: Fixes the misspelling of the word 'overridden' in the operator code and documentation

**Which issue(s) this PR fixes**:
Fixes -- no issue has been filled for this

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
