### PR TITLE
Publish images even when only documentation changes are commited

### DIFF
--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
       - 'release/**'
-    paths-ignore:
-      - 'docs/**'
-      - 'CHANGELOG/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Removes the `paths-ignore` for commits that hit main or release branches so that documentation-only commits will still trigger an image build.
**Which issue(s) this PR fixes**:
Fixes #985 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
