### PR TITLE
Add CHANGELOG entry for documentation image building changes

### DIFF
--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [CHANGE] [#985](https://github.com/k8ssandra/k8ssandra-operator/issues/985) CI/CD does not produce images for some commits


### PR DESCRIPTION
Changelog Entry for #985 to ensure a docs-only change that hits `main` will trigger an image build-and-push
