### PR TITLE
Fix race condition in K8ssandraTask status update (fixes #981)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [BUGFIX] [#981](https://github.com/k8ssandra/k8ssandra-operator/issues/981) Fix race condition in K8ssandraTask status update

--- a/controllers/control/k8ssandratask_controller.go
+++ b/controllers/control/k8ssandratask_controller.go
@@ -181,9 +181,11 @@ func (r *K8ssandraTaskReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				break
 			}
 		}
-		patch := client.MergeFrom(kTask.DeepCopy())
 		kTask.RefreshGlobalStatus(len(dcs))
-		if err = r.Status().Patch(ctx, kTask, patch); err != nil {
+		if err = r.Status().Update(ctx, kTask); err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		// If the status update set a completion time, we want to reconcile again in order to handle the TTL. But

--- a/controllers/control/k8ssandratask_controller_test.go
+++ b/controllers/control/k8ssandratask_controller_test.go
@@ -68,7 +68,7 @@ func TestK8ssandraTask(t *testing.T) {
 	defer cancel()
 
 	t.Run("ExecuteParallelK8ssandraTask", testEnv.ControllerTest(ctx, executeParallelK8ssandraTask))
-	//t.Run("ExecuteSequentialK8ssandraTask", testEnv.ControllerTest(ctx, executeSequentialK8ssandraTask))
+	t.Run("ExecuteSequentialK8ssandraTask", testEnv.ControllerTest(ctx, executeSequentialK8ssandraTask))
 	t.Run("DeleteK8ssandraTask", testEnv.ControllerTest(ctx, deleteK8ssandraTask))
 	t.Run("ExpireK8ssandraTask", testEnv.ControllerTest(ctx, expireK8ssandraTask))
 }


### PR DESCRIPTION
**What this PR does**:
The error is happening in `TestK8ssandraTask/ExecuteSequentialK8ssandraTask`, about 10% of the time , only when the whole `TestK8ssandraTask` suite runs. Here's a script to reproduce it:
```shell
#!/bin/bash
export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.25.0-darwin-amd64"

RUNS=10
FAILURES=0

for i in $( seq 1 $RUNS )
do
  echo "Run $i/$RUNS ($FAILURES failures so far)"
  go test ./controllers/control/... -v -count=1
  if [ $? -ne 0 ]; then
    FAILURES=$((FAILURES+1))
  fi
done

echo "Done ($FAILURES failures)"
```
The test creates a `K8ssandraTask`, which spawns two `CassandraTask`s that both succeed. So the status should end up as `Active=0, Succeeded=2`, but what the test observes is `Active=1, Succeeded=2`.

Debug logs showed the correct counts in [RefreshGlobalStatus](https://github.com/k8ssandra/k8ssandra-operator/blob/main/apis/control/v1alpha1/k8ssandratask_types.go#L101), but not after we [patch the status](https://github.com/k8ssandra/k8ssandra-operator/blob/main/controllers/control/k8ssandratask_controller.go#L186) in the controller. I suspect there were occasionally conflicting patch operations, and `Active=0` being the zero value of the field was ignored (possibly compounded by the fact that the field is optional).

I switched to an Update operation to persist the status.

**Which issue(s) this PR fixes**:
Fixes #981

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
