### PR TITLE
bugfix: ensure merged serverVersion passed to IsNewMetricsEndpointAva…

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -17,3 +17,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [BUGFIX] [#981](https://github.com/k8ssandra/k8ssandra-operator/issues/981) Fix race condition in K8ssandraTask status update
 * [DOCS] [#1019](https://github.com/k8ssandra/k8ssandra-operator/issues/1019) Add PR review guidelines documentation
+* [BUGFIX] [#1023](https://github.com/k8ssandra/k8ssandra-operator/issues/1023) Ensure merged serverVersion passed to IsNewMetricsEndpointAvailable()

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -84,7 +84,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 		// The new metrics endpoint is available since 3.11.13 and 4.0.4.
 		// If MCAC is disabled and the new metrics endpoint is not available then we should return an error.
 		mergedTelemetrySpec := MergeTelemetrySpecs(kc, dcTemplate)
-		if !mergedTelemetrySpec.IsMcacEnabled() && !telemetry.IsNewMetricsEndpointAvailable(kc.Spec.Cassandra.ServerVersion) && kc.Spec.Cassandra.ServerType == k8ssandraapi.ServerDistributionCassandra {
+		if !mergedTelemetrySpec.IsMcacEnabled() && !telemetry.IsNewMetricsEndpointAvailable(dcConfig.ServerVersion.String()) && kc.Spec.Cassandra.ServerType == k8ssandraapi.ServerDistributionCassandra {
 			return dcConfigs, errors.New("new metrics endpoint is only available since Cassandra 3.11.13/4.0.4, so MCAC cannot be disabled")
 		} else {
 			logger.Info("new metrics endpoint is available, so MCAC can be disabled", "serverVersion", kc.Spec.Cassandra.ServerVersion)

--- a/test/testdata/fixtures/single-dc/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc/k8ssandra.yaml
@@ -4,7 +4,6 @@ metadata:
   name: test
 spec:
   cassandra:
-    serverVersion: 4.0.6
     clusterName: "Weird Cluster Name"
     telemetry:
       mcac:
@@ -30,6 +29,7 @@ spec:
           name: dc1
         k8sContext: kind-k8ssandra-0
         size: 3
+        serverVersion: 4.0.6
         storageConfig:
           cassandraDataVolumeClaimSpec:
             storageClassName: standard


### PR DESCRIPTION
**What this PR does**:
The `dcConfig` represents a template that has merged both cluster-level and data center (DC)-level configurations. To ensure the correct server version is being passed to `telemetry.IsNewMetricsEndpointAvailable`, we should use `dcConfig.ServerVersion.String()`.

**Which issue(s) this PR fixes**:
Fixes #1023 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
