### PR TITLE
Fix MedusaTask to delete only its own backups

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#981](https://github.com/k8ssandra/k8ssandra-operator/issues/981) Fix race condition in K8ssandraTask status update
 * [BUGFIX] [#1023](https://github.com/k8ssandra/k8ssandra-operator/issues/1023) Ensure merged serverVersion passed to IsNewMetricsEndpointAvailable()
 * [DOCS] [#1019](https://github.com/k8ssandra/k8ssandra-operator/issues/1019) Add PR review guidelines documentation
+* [BUGFIX] [#1017](https://github.com/k8ssandra/k8ssandra-operator/issues/1017) Fix MedusaTask to delete only its own backups

--- a/controllers/medusa/medusatask_controller.go
+++ b/controllers/medusa/medusatask_controller.go
@@ -294,7 +294,7 @@ func (r *MedusaTaskReconciler) syncOperation(ctx context.Context, task *medusav1
 				return ctrl.Result{}, err
 			}
 			for _, backup := range localBackups.Items {
-				if !backupExistsRemotely(remoteBackups, backup.ObjectMeta.Name) {
+				if !backupExistsRemotely(remoteBackups, backup.ObjectMeta.Name) && backup.Spec.CassandraDatacenter == task.Spec.CassandraDatacenter {
 					logger.Info("Deleting Cassandra Backup", "Backup", backup.ObjectMeta.Name)
 					if err := r.Delete(ctx, &backup); err != nil {
 						logger.Error(err, "failed to delete backup", "MedusaBackup", backup.ObjectMeta.Name)


### PR DESCRIPTION

**What this PR does**: This commit addresses the issue where MedusaTask was erroneously deleting medusabackups belonging to other cassandraDatacenters in the same namespace. The bug occurred due to the lack of a condition to check if the `backup.Spec.CassandraDatacenter` matched the `task.Spec.CassandraDatacenter`. This fix adds the necessary condition to ensure that MedusaTask only deletes its own Cassandra backups, resolving the issue reported in the PR.


**Which issue(s) this PR fixes**:
Fixes #1017 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
