### PR TITLE
Fix system logger image config

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#1027](https://github.com/k8ssandra/k8ssandra-operator/issues/1027) Point system-logger image to use the v1.16.0 tag instead of latest
 * [BUGFIX] [#981](https://github.com/k8ssandra/k8ssandra-operator/issues/981) Fix race condition in K8ssandraTask status update
-* [DOCS] [#1019](https://github.com/k8ssandra/k8ssandra-operator/issues/1019) Add PR review guidelines documentation
 * [BUGFIX] [#1023](https://github.com/k8ssandra/k8ssandra-operator/issues/1023) Ensure merged serverVersion passed to IsNewMetricsEndpointAvailable()
+* [DOCS] [#1019](https://github.com/k8ssandra/k8ssandra-operator/issues/1019) Add PR review guidelines documentation

--- a/config/components/cass-operator-image-config/image_config.yaml
+++ b/config/components/cass-operator-image-config/image_config.yaml
@@ -3,7 +3,7 @@ kind: ImageConfig
 metadata:
   name: image-config
 images:
-  system-logger: "k8ssandra/system-logger:latest"
+  system-logger: "k8ssandra/system-logger:v1.16.0"
   config-builder: "datastax/cass-config-builder:1.0.4-ubi7"
   # cassandra:
   #   "4.0.0": "k8ssandra/cassandra-ubi:latest"

--- a/test/kuttl/test-servicemonitors/03-assert.yaml
+++ b/test/kuttl/test-servicemonitors/03-assert.yaml
@@ -33,7 +33,7 @@ spec:
             - name: DSE_MGMT_EXPLICIT_START
               value: "true"
           name: cassandra
-        - image: k8ssandra/system-logger:latest
+        - image: k8ssandra/system-logger:v1.16.0
           name: server-system-logger
 status:
   readyReplicas: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Point the system-logger to v1.16.0 instead of latest in the ImageConfig override.

**Which issue(s) this PR fixes**:
Fixes #1027 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] ~Documentation added/updated~
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
