### PR TITLE
Add medusa validation

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [ENHANCEMENT] [#1045](https://github.com/k8ssandra/k8ssandra-operator/issues/1045) Validate MedusaBackup before doing restore to prevent data loss scenarios
 * [ENHANCEMENT] [#1046](https://github.com/k8ssandra/k8ssandra-operator/issues/1046) Add detailed backup information in the MedusaBackup CRD status
 * [BUGFIX] [#1027](https://github.com/k8ssandra/k8ssandra-operator/issues/1027) Point system-logger image to use the v1.16.0 tag instead of latest
 * [BUGFIX] [#1026](https://github.com/k8ssandra/k8ssandra-operator/issues/1026) Fix DC name overrides not being properly handled

--- a/apis/medusa/v1alpha1/medusarestorejob_types.go
+++ b/apis/medusa/v1alpha1/medusarestorejob_types.go
@@ -54,6 +54,9 @@ type MedusaRestoreJobStatus struct {
 	Finished []string `json:"finished,omitempty"`
 
 	Failed []string `json:"failed,omitempty"`
+
+	// Message gives the reason why restore operation failed
+	Message string `json:"message,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -70,6 +73,7 @@ type MedusaRestoreJob struct {
 
 type MedusaRestoreMapping struct {
 	// Whether the restore is in-place or not
+	// +optional
 	InPlace *bool `json:"in_place"`
 
 	// Mapping between source and target nodes for a restore

--- a/apis/medusa/v1alpha1/medusarestorejob_types.go
+++ b/apis/medusa/v1alpha1/medusarestorejob_types.go
@@ -61,6 +61,9 @@ type MedusaRestoreJobStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Started",type=date,JSONPath=".status.startTime",description="Restore start time"
+//+kubebuilder:printcolumn:name="Finished",type=date,JSONPath=".status.finishTime",description="Restore finish time"
+//+kubebuilder:printcolumn:name="Error",type=string,JSONPath=".status.message",description="Error message"
 
 // MedusaRestoreJob is the Schema for the medusarestorejobs API
 type MedusaRestoreJob struct {

--- a/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
@@ -14,7 +14,20 @@ spec:
     singular: medusarestorejob
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Restore start time
+      jsonPath: .status.startTime
+      name: Started
+      type: date
+    - description: Restore finish time
+      jsonPath: .status.finishTime
+      name: Finished
+      type: date
+    - description: Error message
+      jsonPath: .status.message
+      name: Error
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MedusaRestoreJob is the Schema for the medusarestorejobs API

--- a/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusarestorejobs.yaml
@@ -66,6 +66,9 @@ spec:
                 items:
                   type: string
                 type: array
+              message:
+                description: Message gives the reason why restore operation failed
+                type: string
               restoreKey:
                 description: A unique key that identifies the restore operation.
                 type: string
@@ -90,8 +93,6 @@ spec:
                   in_place:
                     description: Whether the restore is in-place or not
                     type: boolean
-                required:
-                - in_place
                 type: object
               restorePrepared:
                 type: boolean

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -47,6 +47,8 @@ func TestCassandraBackupRestore(t *testing.T) {
 	defer testEnv3.Stop(t)
 	defer cancel()
 	t.Run("TestMedusaRestoreDatacenter", testEnv3.ControllerTest(ctx, testMedusaRestoreDatacenter))
+
+	t.Run("TestValidationErrorStopsRestore", testEnv3.ControllerTest(ctx, testValidationErrorStopsRestore))
 }
 
 func setupMedusaBackupTestEnv(t *testing.T, ctx context.Context) *testutils.MultiClusterTestEnv {

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -275,6 +275,11 @@ func (r *MedusaRestoreJobReconciler) prepareRestore(ctx context.Context, request
 }
 
 func validateBackupForRestore(backup *medusav1alpha1.MedusaBackup, cassdc *cassdcapi.CassandraDatacenter) error {
+	if backup.Status.TotalNodes == 0 && backup.Status.FinishedNodes == 0 {
+		// This is an old backup without enough data, need to skip for backwards compatibility
+		return nil
+	}
+
 	if backup.Status.FinishTime.IsZero() {
 		return fmt.Errorf("target backup has not finished")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds validation to MedusaRestoreJob controller that verifies the targetted MedusaBackup can be used to safely restore the target CassandraDatacenter

**Which issue(s) this PR fixes**:
Fixes #1045 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
