### PR TITLE
Link prominently to docs site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # K8ssandra Operator
+
+**[Documentation site](https://docs.k8ssandra.io/)**
+
 This is the Kubernetes operator for K8ssandra.
 
 K8ssandra is a Kubernetes-based distribution of Apache Cassandra that includes several tools and components that automate and simplify configuring, managing, and operating a Cassandra cluster.


### PR DESCRIPTION
I get very sad when docs don't link prominently to repos, or repos don't link prominently to docs.

Currently, a Google search for k8ssandra-operator returns this repo as the first result, but the README is not a good source for documentation. Sadly, the docs link is at the very bottom of the page. This PR fixes that.