### PR TITLE
Add nodeSelector support to crd-upgrader-job-k8ssandra

### DIFF
--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -17,3 +17,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [BUGFIX] [#1060](https://github.com/k8ssandra/k8ssandra-operator/issues/1060) Fix restore mapping shuffling nodes when restoring in place
 * [BUGFIX] [#1061](https://github.com/k8ssandra/k8ssandra-operator/issues/1061) Point to cass-config-builder 1.0.7 for arm64 compatibility
+* [ENHANCEMENT] [#1078](https://github.com/k8ssandra/k8ssandra-operator/issues/1078) Add nodeSelector support to crd-upgrader-job-k8ssandra

--- a/charts/k8ssandra-operator/templates/crd/batch_job.yaml
+++ b/charts/k8ssandra-operator/templates/crd/batch_job.yaml
@@ -34,3 +34,7 @@ spec:
             - {{ .Chart.Version }}
             - --chartName
             - {{ .Chart.Name }}
+      {{- with .Values.client.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -91,3 +91,5 @@ client:
     tag: latest
     # -- Pull policy for the client container
     pullPolicy: IfNotPresent
+  # -- Node labels for pod assignment
+  nodeSelector: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR adds support for the nodeSelector variable in the crd-upgrader-job-k8ssandra job. This feature allows users to specify which nodes this job can run on, providing a workaround for the ARM64 compatibility issue with the k8ssandra/k8ssandra-tools container.

**Which issue(s) this PR fixes**:
Fixes #1078

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
