### PR TITLE
Namespace metrics label

### DIFF
--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [ENHANCEMENT] [#1073](https://github.com/k8ssandra/k8ssandra-operator/issues/1073) Add a namespace label to the Cassandra metrics 
 * [BUGFIX] [#1060](https://github.com/k8ssandra/k8ssandra-operator/issues/1060) Fix restore mapping shuffling nodes when restoring in place
 * [BUGFIX] [#1061](https://github.com/k8ssandra/k8ssandra-operator/issues/1061) Point to cass-config-builder 1.0.7 for arm64 compatibility
 * [ENHANCEMENT] [#956](https://github.com/k8ssandra/k8ssandra-operator/issues/956) Enable linting in the project

--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.17.2
+- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=master
 
 components:
   - ../../components/cass-operator-image-config
+
+images:
+- name: k8ssandra/cass-operator
+  newTag: v1.18.0-dev.34e2ae6-20231002

--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 components:
   - ../../components/cass-operator-image-config
 
+# TODO: remove these image changes before release so that they don't pull a dev release of cass-operator.
+# This is required when a new feature of cass-operator is needed that is not yet released.
 images:
 - name: k8ssandra/cass-operator
   newTag: v1.18.0-dev.34e2ae6-20231002

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.17.2
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=master
 
 components:
   - ../../components/cass-operator-image-config
+
+images:
+- name: k8ssandra/cass-operator
+  newTag: v1.18.0-dev.34e2ae6-20231002

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 components:
   - ../../components/cass-operator-image-config
 
+# TODO: remove these image changes before release so that they don't pull a dev release of cass-operator.
+# This is required when a new feature of cass-operator is needed that is not yet released.
 images:
 - name: k8ssandra/cass-operator
   newTag: v1.18.0-dev.34e2ae6-20231002

--- a/config/deployments/default/kustomization.yaml
+++ b/config/deployments/default/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - ../../default
 images:
   - name: k8ssandra/k8ssandra-operator
-    newTag: 1.9-latest
+    newTag: latest

--- a/docs/content/en/tasks/monitor/vector/_index.md
+++ b/docs/content/en/tasks/monitor/vector/_index.md
@@ -42,57 +42,51 @@ The following content will be added automatically to the vector.toml file:
 type = "file"
 include = [ "/var/log/cassandra/system.log" ]
 read_from = "beginning"
-fingerprint.strategy = "device_and_inode
+fingerprint.strategy = "device_and_inode"
 [sources.systemlog.multiline]
 start_pattern = "^(INFO|WARN|ERROR|DEBUG|TRACE|FATAL)"
 condition_pattern = "^(INFO|WARN|ERROR|DEBUG|TRACE|FATAL)"
 mode = "halt_before"
 timeout_ms = 10000
 
-[sources.cassandra_metrics]
+
+[sources.cassandra_metrics_raw]
 type = "prometheus_scrape"
-endpoints = [ "http://localhost:{{ .ScrapePort }}" ]
-scrape_interval_secs = {{ .ScrapeInterval }}
+endpoints = [ "http://localhost:9103" ]
+scrape_interval_secs = 30
 
-[transforms.parse_cassandra_log]
+[transforms.cassandra_metrics]
 type = "remap"
-inputs = [ "systemlog" ]
+inputs = ["cassandra_metrics_raw"]
 source = '''
-del(.source_type)
-. |= parse_groks!(.message, patterns: [
-  "%{LOGLEVEL:loglevel}\\s+\\[(?<thread>((.+)))\\]\\s+%{TIMESTAMP_ISO8601:timestamp}\\s+%{JAVACLASS:class}:%{NUMBER:line}\\s+-\\s+(?<message>(.+\\n?)+)",
-  ]
-)
-pod_name, err = get_env_var("POD_NAME")
+namespace, err = get_env_var("NAMESPACE")
 if err == null {
-  .pod_name = pod_name
-
-node_name, err = get_env_var("NODE_NAME")
-if err == null {
-  .node_name = node_name
-
-cluster, err = get_env_var("CLUSTER_NAME")
-if err == null {
-  .cluster = cluster
-
-datacenter, err = get_env_var("DATACENTER_NAME")
-if err == null {
-  .datacenter = datacenter
-
-rack, err = get_env_var("RACK_NAME")
-if err == null {
-  .rack = rack
+  .namespace = namespace
 }
 '''
 
-[sinks.console]
+
+[sinks.console_output]
+type = "console"
+inputs = ["cassandra_metrics"]
+target = "stdout"
+[sinks.console_output.encoding]
+codec = "json"    
+
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["cassandra_metrics"]
+
+[sinks.console_log]
 type = "console"
 inputs = ["systemlog"]
 target = "stdout"
 encoding.codec = "text"
 ```
 
-The default options are always added to the configuration, but one may override them and if not used, they're automatically cleaned up (see next section).
+The default options are always added to the configuration, but one may override them and if not used, they're automatically cleaned up (see next section).  
+The `cassandra_metrics` transform adds the namespace of the datacenter to the exposed metrics and should be used as the input for any transform or sink that would modify or route the metrics to a remote system.
 
 ## Automated cleanup of unused sources
 

--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -117,7 +117,7 @@ timeout_ms = 10000
 	}
 
 	metricsInput := telemetry.VectorSourceSpec{
-		Name:   "cassandra_metrics",
+		Name:   "cassandra_metrics_raw",
 		Type:   "prometheus_scrape",
 		Config: fmt.Sprintf("endpoints = [ \"http://localhost:%v%s\" ]\nscrape_interval_secs = %v", config.ScrapePort, config.ScrapeEndpoint, config.ScrapeInterval),
 	}
@@ -157,11 +157,31 @@ rack, err = get_env_var("RACK_NAME")
 if err == null {
   .rack = rack
 }
+namespace, err = get_env_var("NAMESPACE")
+if err == null {
+  .namespace = namespace
+}
 '''
 `,
 	}
 
 	transformers = append(transformers, systemLogParser)
+
+	// Add the namespace label to the Cassandra metrics
+	metricsParser := telemetry.VectorTransformSpec{
+		Name:   "cassandra_metrics",
+		Type:   "remap",
+		Inputs: []string{"cassandra_metrics_raw"},
+		Config: `source = '''
+namespace, err = get_env_var("NAMESPACE")
+if err == null {
+  .namespace = namespace
+}
+'''
+`,
+	}
+
+	transformers = append(transformers, metricsParser)
 
 	systemLogSink := telemetry.VectorSinkSpec{
 		Name:   "console_log",

--- a/pkg/telemetry/vector_test.go
+++ b/pkg/telemetry/vector_test.go
@@ -220,10 +220,21 @@ mode = "halt_before"
 timeout_ms = 10000
 
 
-[sources.cassandra_metrics]
+[sources.cassandra_metrics_raw]
 type = "prometheus_scrape"
 endpoints = [ "http://localhost:9000/metrics" ]
 scrape_interval_secs = 30
+
+[transforms.cassandra_metrics]
+type = "remap"
+inputs = ["cassandra_metrics_raw"]
+source = '''
+namespace, err = get_env_var("NAMESPACE")
+if err == null {
+  .namespace = namespace
+}
+'''
+
 
 [sinks.console]
 type = "console"
@@ -246,7 +257,7 @@ func TestDefaultRemoveUnusedSources(t *testing.T) {
 	assert := assert.New(t)
 	sources, transformers, sinks := BuildDefaultVectorComponents(vector.VectorConfig{})
 	assert.Equal(2, len(sources))
-	assert.Equal(1, len(transformers))
+	assert.Equal(2, len(transformers))
 	assert.Equal(1, len(sinks))
 
 	sources, transformers, sinks = FilterUnusedPipelines(sources, transformers, sinks)
@@ -260,7 +271,7 @@ func TestRemoveUnusedSourcesModified(t *testing.T) {
 	assert := assert.New(t)
 	sources, transformers, sinks := BuildDefaultVectorComponents(vector.VectorConfig{})
 	assert.Equal(2, len(sources))
-	assert.Equal(1, len(transformers))
+	assert.Equal(2, len(transformers))
 	assert.Equal(1, len(sinks))
 
 	sinks = append(sinks, telemetry.VectorSinkSpec{Name: "a", Inputs: []string{"cassandra_metrics"}})
@@ -268,7 +279,7 @@ func TestRemoveUnusedSourcesModified(t *testing.T) {
 	sources, transformers, sinks = FilterUnusedPipelines(sources, transformers, sinks)
 
 	assert.Equal(2, len(sources))
-	assert.Equal(0, len(transformers))
+	assert.Equal(1, len(transformers))
 	assert.Equal(2, len(sinks))
 }
 
@@ -335,7 +346,7 @@ func TestOverrideSourcePossible(t *testing.T) {
 	assert := assert.New(t)
 	sources, transformers, sinks := BuildDefaultVectorComponents(vector.VectorConfig{})
 	assert.Equal(2, len(sources))
-	assert.Equal(1, len(transformers))
+	assert.Equal(2, len(transformers))
 	assert.Equal(1, len(sinks))
 
 	newSources := []telemetry.VectorSourceSpec{

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "v1.17.2"
+	cassOperatorVersion       = "master"
 	prometheusOperatorVersion = "v0.9.0"
 )
 

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -45,7 +45,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "master"
+	cassOperatorVersion       = "v1.17.2"
 	prometheusOperatorVersion = "v0.9.0"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Renames the `cassandra_metrics` Vector source to `cassandra_metrics_raw` and adds a new remap transform named `cassandra_metrics` which adds the namespace label to all metrics.

**Which issue(s) this PR fixes**:
Fixes #1073 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
