### PR TITLE
Move Reaper multi-DC tests to http management proxy impl.

### DIFF
--- a/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-reaper/k8ssandra.yaml
@@ -24,6 +24,8 @@ metadata:
   name: test
 spec:
   reaper:
+    httpManagement:
+      enabled: true
     keyspace: reaper_ks # custom name
     cassandraUserSecretRef:
       name: reaper-cql-secret # pre-existing secret with non-default name


### PR DESCRIPTION
**What this PR does**:

Tests whether multi-DC reaper tests work with HTTP management proxy.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
