### PR TITLE
Fix the namespace relabelling for metrics in Vector

### DIFF
--- a/pkg/telemetry/vector.go
+++ b/pkg/telemetry/vector.go
@@ -175,7 +175,7 @@ if err == null {
 		Config: `source = '''
 namespace, err = get_env_var("NAMESPACE")
 if err == null {
-  .namespace = namespace
+  .tags.namespace = namespace
 }
 '''
 `,

--- a/pkg/telemetry/vector_test.go
+++ b/pkg/telemetry/vector_test.go
@@ -231,7 +231,7 @@ inputs = ["cassandra_metrics_raw"]
 source = '''
 namespace, err = get_env_var("NAMESPACE")
 if err == null {
-  .namespace = namespace
+  .tags.namespace = namespace
 }
 '''
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
The remap was wrongfully setting `.namespace` instead of `.tags.namespace` in Vector's configuration. This led the metrics to be prefixed with the namespace instead of being labelled with it.
This PR fixes it:

![Capture d’écran 2023-10-24 à 11 38 30](https://github.com/k8ssandra/k8ssandra-operator/assets/5096002/da75e918-21d4-4af6-94f8-03f5f35d2b36)


**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
