### PR TITLE
Add validation check for projected pod names length

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -15,3 +15,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+- [ENHANCEMENT] [#1115](https://github.com/k8ssandra/k8ssandra-operator/issues/1115) Add a validation check for the projected pod names length


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Checks if the projected pod names (for each dc and rack) could overflow the 63 characters limit. Fails the validation if it's the case.

**Which issue(s) this PR fixes**:
Fixes #1115 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
