### PR TITLE
Support Stargate with DSE and upgrade Stargate to 1.0.77

### DIFF
--- a/CHANGELOG/CHANGELOG-1.11.md
+++ b/CHANGELOG/CHANGELOG-1.11.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [ENHANCEMENT] [#1125](https://github.com/k8ssandra/k8ssandra-operator/issues/1125) Support Stargate with DSE and upgrade Stargate to 1.0.77
 * [ENHANCEMENT] [#1122](https://github.com/k8ssandra/k8ssandra-operator/issues/1122) Expose backup size in MedusaBackup CRD

--- a/apis/stargate/v1alpha1/stargate_types.go
+++ b/apis/stargate/v1alpha1/stargate_types.go
@@ -45,7 +45,7 @@ type StargateTemplate struct {
 	// ContainerImage is the image characteristics to use for Stargate containers. Leave nil
 	// to use a default image.
 	// +optional
-	// +kubebuilder:default={repository:"stargateio", tag:"v1.0.67"}
+	// +kubebuilder:default={repository:"stargateio", tag:"v1.0.77"}
 	ContainerImage *images.Image `json:"containerImage,omitempty"`
 
 	// ServiceAccount is the service account name to use for Stargate pods.

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -12013,7 +12013,7 @@ spec:
                             containerImage:
                               default:
                                 repository: stargateio
-                                tag: v1.0.67
+                                tag: v1.0.77
                               description: ContainerImage is the image characteristics
                                 to use for Stargate containers. Leave nil to use a
                                 default image.
@@ -13481,7 +13481,7 @@ spec:
                                   containerImage:
                                     default:
                                       repository: stargateio
-                                      tag: v1.0.67
+                                      tag: v1.0.77
                                     description: ContainerImage is the image characteristics
                                       to use for Stargate containers. Leave nil to
                                       use a default image.
@@ -30737,7 +30737,7 @@ spec:
                   containerImage:
                     default:
                       repository: stargateio
-                      tag: v1.0.67
+                      tag: v1.0.77
                     description: ContainerImage is the image characteristics to use
                       for Stargate containers. Leave nil to use a default image.
                     properties:

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -1103,7 +1103,7 @@ spec:
               containerImage:
                 default:
                   repository: stargateio
-                  tag: v1.0.67
+                  tag: v1.0.77
                 description: ContainerImage is the image characteristics to use for
                   Stargate containers. Leave nil to use a default image.
                 properties:
@@ -2306,7 +2306,7 @@ spec:
                     containerImage:
                       default:
                         repository: stargateio
-                        tag: v1.0.67
+                        tag: v1.0.77
                       description: ContainerImage is the image characteristics to
                         use for Stargate containers. Leave nil to use a default image.
                       properties:

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -107,6 +107,12 @@ func NewDeployments(stargate *api.Stargate, dc *cassdcapi.CassandraDatacenter, l
 
 		podMeta := createPodMeta(stargate, deploymentName)
 
+		isDse := "0"
+		if coreapi.ServerDistribution(dc.Spec.ServerType) == coreapi.ServerDistributionDse {
+			// Stargate requires a DSE env variable set to "1" to use the right backend.
+			isDse = "1"
+		}
+
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        deploymentName,
@@ -173,6 +179,7 @@ func NewDeployments(stargate *api.Stargate, dc *cassdcapi.CassandraDatacenter, l
 								{Name: "JAVA_OPTS", Value: jvmOptions},
 								{Name: "CLUSTER_NAME", Value: dc.Spec.ClusterName},
 								{Name: "CLUSTER_VERSION", Value: string(clusterVersion)},
+								{Name: "DSE", Value: isDse},
 								{Name: "SEED", Value: seedService},
 								{Name: "DATACENTER_NAME", Value: dc.DatacenterName()},
 								{Name: "RACK_NAME", Value: rack.Name},

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -826,6 +826,7 @@ func testImages(t *testing.T) {
 		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
 		assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
+		assert.Equal(t, "0", utils.FindEnvVarInContainer(&deployment.Spec.Template.Spec.Containers[0], "DSE").Value)
 	})
 	t.Run("default image DSE 6.8", func(t *testing.T) {
 		stargate := stargate.DeepCopy()
@@ -843,6 +844,7 @@ func testImages(t *testing.T) {
 		assert.Equal(t, defaultImage68.String(), deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
+		assert.Equal(t, "1", utils.FindEnvVarInContainer(&deployment.Spec.Template.Spec.Containers[0], "DSE").Value)
 	})
 	t.Run("custom image DSE 6.8", func(t *testing.T) {
 		stargate := stargate.DeepCopy()
@@ -863,6 +865,7 @@ func testImages(t *testing.T) {
 		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
 		assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
+		assert.Equal(t, "1", utils.FindEnvVarInContainer(&deployment.Spec.Template.Spec.Containers[0], "DSE").Value)
 	})
 }
 

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -826,7 +826,6 @@ func testImages(t *testing.T) {
 		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
 		assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
-		assert.Equal(t, "0", utils.FindEnvVarInContainer(&deployment.Spec.Template.Spec.Containers[0], "DSE").Value)
 	})
 	t.Run("default image DSE 6.8", func(t *testing.T) {
 		stargate := stargate.DeepCopy()

--- a/test/testdata/fixtures/single-dc-dse/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-dse/k8ssandra.yaml
@@ -4,6 +4,9 @@ metadata:
   name: test
 spec:
   auth: true
+  stargate:
+    size: 1
+    heapSize: 384Mi
   cassandra:
     serverVersion: 6.8.26
     serverType: dse


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Switches to the `dse-68` stargate image when it is deployed with a DSE cluster.
Upgrades Stargate to the latest 1.0.77.

**Which issue(s) this PR fixes**:
Fixes #1125 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
