### PR TITLE
Completion of a restore triggers secrets refresh

### DIFF
--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -57,22 +57,22 @@ jobs:
     strategy:
       matrix:
         e2e_test:
-          # - CreateMultiDatacenterCluster
-          # - CreateMixedMultiDataCenterCluster
-          # - AddDcToClusterDiffDataplane
-          # - RemoveDcFromCluster
-          # - CheckStargateApisWithMultiDcCluster
-          # - CreateMultiStargateAndDatacenter
-          # - CreateMultiReaper
-          # - ClusterScoped/MultiDcMultiCluster
+          - CreateMultiDatacenterCluster
+          - CreateMixedMultiDataCenterCluster
+          - AddDcToClusterDiffDataplane
+          - RemoveDcFromCluster
+          - CheckStargateApisWithMultiDcCluster
+          - CreateMultiStargateAndDatacenter
+          - CreateMultiReaper
+          - ClusterScoped/MultiDcMultiCluster
           - CreateMultiMedusaJob
-          # - MultiDcAuthOnOff
+          - MultiDcAuthOnOff
           # TODO: these e2e tests started breaking after new client certificates were added. Needs fixing.
           #- MultiDcEncryptionWithStargate
-          # - MultiDcEncryptionWithReaper
-          # - StopAndRestartDc
-          # - CreateMultiDatacenterDseCluster
-          # - PerNodeConfig/InitialTokens
+          - MultiDcEncryptionWithReaper
+          - StopAndRestartDc
+          - CreateMultiDatacenterDseCluster
+          - PerNodeConfig/InitialTokens
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/.github/workflows/kind_multicluster_e2e_tests.yaml
+++ b/.github/workflows/kind_multicluster_e2e_tests.yaml
@@ -57,22 +57,22 @@ jobs:
     strategy:
       matrix:
         e2e_test:
-          - CreateMultiDatacenterCluster
-          - CreateMixedMultiDataCenterCluster
-          - AddDcToClusterDiffDataplane
-          - RemoveDcFromCluster
-          - CheckStargateApisWithMultiDcCluster
-          - CreateMultiStargateAndDatacenter
-          - CreateMultiReaper
-          - ClusterScoped/MultiDcMultiCluster
+          # - CreateMultiDatacenterCluster
+          # - CreateMixedMultiDataCenterCluster
+          # - AddDcToClusterDiffDataplane
+          # - RemoveDcFromCluster
+          # - CheckStargateApisWithMultiDcCluster
+          # - CreateMultiStargateAndDatacenter
+          # - CreateMultiReaper
+          # - ClusterScoped/MultiDcMultiCluster
           - CreateMultiMedusaJob
-          - MultiDcAuthOnOff
+          # - MultiDcAuthOnOff
           # TODO: these e2e tests started breaking after new client certificates were added. Needs fixing.
           #- MultiDcEncryptionWithStargate
-          - MultiDcEncryptionWithReaper
-          - StopAndRestartDc
-          - CreateMultiDatacenterDseCluster
-          - PerNodeConfig/InitialTokens
+          # - MultiDcEncryptionWithReaper
+          # - StopAndRestartDc
+          # - CreateMultiDatacenterDseCluster
+          # - PerNodeConfig/InitialTokens
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:

--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [FEATURE] [#1080](https://github.com/k8ssandra/k8ssandra-operator/issues/1080) When a restore is completed, an annotation is added to the user secrets that will cause cass-operator to refresh them on the Cassandra side.
+
 ## v1.10.3 - 2023-11-15
 
 * [BUGFIX] [#1110](https://github.com/k8ssandra/k8ssandra-operator/issues/1110) Fix cluster name being set to "Test Cluster" when running Cassandra 4.1+

--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,13 @@ endif
 
 ##@ Build
 
+DATE  ?= $(shell date)
+VERSION ?= $(VERSION)
+COMMIT ?= $(shell git rev-parse --short HEAD)
+
+
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build --ldflags "-X \"main.version=$(VERSION)\" -X \"main.date=$(DATE)\" -X \"main.commit=$(COMMIT)\"" -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/Makefile
+++ b/Makefile
@@ -168,12 +168,10 @@ endif
 ##@ Build
 
 DATE  ?= $(shell date)
-VERSION ?= $(VERSION)
 COMMIT ?= $(shell git rev-parse --short HEAD)
 
-
 build: generate fmt vet ## Build manager binary.
-	go build --ldflags "-X \"main.version=$(VERSION)\" -X \"main.date=$(DATE)\" -X \"main.commit=$(COMMIT)\"" -o bin/manager main.go
+	go build --ldflags "-X \"main.version=${VERSION}\" -X \"main.date=${DATE}\" -X \"main.commit=${COMMIT}\"" -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/apis/k8ssandra/v1alpha1/constants.go
+++ b/apis/k8ssandra/v1alpha1/constants.go
@@ -59,6 +59,8 @@ const (
 	K8ssandraClusterNamespaceLabel = "k8ssandra.io/cluster-namespace"
 
 	DatacenterLabel = "k8ssandra.io/datacenter"
+	// Forces refresh of secrets which relate to roles and authn in Cassandra.
+	RefreshAnnotation = "k8ssandra.io/refresh"
 )
 
 var (

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -177,6 +177,8 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	request.Log.Info("The restore operation is complete")
+	medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -176,7 +176,7 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: r.DefaultDelay}, err
 	}
 
-	request.Log.Info("The restore operation is complete")
+	request.Log.Info("The restore operation is complete for DC", "CassandraDatacenter", request.Datacenter.Name)
 
 	err = medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
 	if err != nil {

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -177,7 +177,13 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	request.Log.Info("The restore operation is complete")
-	medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
+
+	err = medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
+	if err != nil {
+		request.Log.Error(err, "Failed to refresh Cassandra users in the DB")
+		// Not going to bother applying updates here since we hit an error.
+		return ctrl.Result{RequeueAfter: r.DefaultDelay}, err
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -178,7 +178,7 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	request.Log.Info("The restore operation is complete for DC", "CassandraDatacenter", request.Datacenter.Name)
 
-	recRes := medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
+	recRes := medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay, request.RestoreJob.Status.FinishTime)
 	switch {
 	case recRes.IsError():
 		return ctrl.Result{RequeueAfter: r.DefaultDelay}, recRes.GetError()

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -178,7 +178,7 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	request.Log.Info("The restore operation is complete for DC", "CassandraDatacenter", request.Datacenter.Name)
 
-	recRes := medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay, request.RestoreJob.Status.FinishTime)
+	recRes := medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay, request.RestoreJob.Status.StartTime)
 	switch {
 	case recRes.IsError():
 		return ctrl.Result{RequeueAfter: r.DefaultDelay}, recRes.GetError()

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -178,11 +178,12 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	request.Log.Info("The restore operation is complete for DC", "CassandraDatacenter", request.Datacenter.Name)
 
-	err = medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
-	if err != nil {
-		request.Log.Error(err, "Failed to refresh Cassandra users in the DB")
-		// Not going to bother applying updates here since we hit an error.
-		return ctrl.Result{RequeueAfter: r.DefaultDelay}, err
+	recRes := medusa.RefreshSecrets(request.Datacenter, ctx, r.Client, request.Log, r.DefaultDelay)
+	switch {
+	case recRes.IsError():
+		return ctrl.Result{RequeueAfter: r.DefaultDelay}, recRes.GetError()
+	case recRes.IsRequeue():
+		return ctrl.Result{RequeueAfter: r.DefaultDelay}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/medusa/medusarestorejob_controller_test.go
+++ b/controllers/medusa/medusarestorejob_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
@@ -292,8 +293,12 @@ func testMedusaRestoreDatacenter(t *testing.T, ctx context.Context, f *framework
 		return !restore.Status.FinishTime.IsZero()
 	}, timeout, interval)
 
-	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: dc.Namespace, Name: kc.Name}, timeout, interval)
 	require.NoError(err, "failed to delete K8ssandraCluster")
+	superuserSecret := corev1.Secret{}
+	require.NoError(f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cass-superuser"}, &superuserSecret))
+	assert.Contains(t, superuserSecret.ObjectMeta.Annotations, k8ssandraapi.RefreshAnnotation)
+
 }
 
 func testValidationErrorStopsRestore(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {

--- a/controllers/medusa/medusarestorejob_controller_test.go
+++ b/controllers/medusa/medusarestorejob_controller_test.go
@@ -293,11 +293,12 @@ func testMedusaRestoreDatacenter(t *testing.T, ctx context.Context, f *framework
 		return !restore.Status.FinishTime.IsZero()
 	}, timeout, interval)
 
-	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: dc.Namespace, Name: kc.Name}, timeout, interval)
-	require.NoError(err, "failed to delete K8ssandraCluster")
 	superuserSecret := corev1.Secret{}
 	require.NoError(f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cass-superuser"}, &superuserSecret))
 	assert.Contains(t, superuserSecret.ObjectMeta.Annotations, k8ssandraapi.RefreshAnnotation)
+
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: dc.Namespace, Name: kc.Name}, timeout, interval)
+	require.NoError(err, "failed to delete K8ssandraCluster")
 
 }
 

--- a/controllers/medusa/medusarestorejob_controller_test.go
+++ b/controllers/medusa/medusarestorejob_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
@@ -292,10 +291,6 @@ func testMedusaRestoreDatacenter(t *testing.T, ctx context.Context, f *framework
 
 		return !restore.Status.FinishTime.IsZero()
 	}, timeout, interval)
-
-	superuserSecret := corev1.Secret{}
-	require.NoError(f.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "cass-superuser"}, &superuserSecret))
-	assert.Contains(t, superuserSecret.ObjectMeta.Annotations, k8ssandraapi.RefreshAnnotation)
 
 	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: dc.Namespace, Name: kc.Name}, timeout, interval)
 	require.NoError(err, "failed to delete K8ssandraCluster")

--- a/main.go
+++ b/main.go
@@ -68,6 +68,15 @@ import (
 )
 
 var (
+	version        = "dev"
+	commit         = "n/a"
+	date           = "n/a"
+	versionMessage = "#######################" +
+		fmt.Sprintf("#### version %s commit %s date %s ####", version, commit, date) +
+		"#######################"
+)
+
+var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
@@ -113,6 +122,8 @@ func main() {
 	} else {
 		setupLog.Info("watch namespace configured", "namespace", watchNamespace)
 	}
+
+	setupLog.Info(versionMessage)
 
 	options := ctrl.Options{
 		Scheme:                 scheme,

--- a/pkg/medusa/refresh_secrets.go
+++ b/pkg/medusa/refresh_secrets.go
@@ -14,10 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	defaultSUSecretName = "cass-superuser"
-)
-
 func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, client client.Client, logger logr.Logger, requeueDelay time.Duration) error {
 	logger.Info(fmt.Sprintf("Restore complete for DC %#v, Refreshing secrets", dc.ObjectMeta))
 	userSecrets := []string{}
@@ -26,7 +22,7 @@ func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, clie
 		userSecrets = append(userSecrets, user.SecretName)
 	}
 	if dc.Spec.SuperuserSecretName == "" {
-		userSecrets = append(userSecrets, defaultSUSecretName) //default SU secret
+		userSecrets = append(userSecrets, cassdcapi.CleanupForKubernetes(dc.Spec.ClusterName)+"-superuser") //default SU secret
 	} else {
 		userSecrets = append(userSecrets, dc.Spec.SuperuserSecretName)
 	}

--- a/pkg/medusa/refresh_secrets.go
+++ b/pkg/medusa/refresh_secrets.go
@@ -15,7 +15,7 @@ import (
 )
 
 func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, client client.Client, logger logr.Logger, requeueDelay time.Duration) error {
-	logger.Info(fmt.Sprintf("Restore complete for DC %#v, Refreshing secrets", dc.ObjectMeta))
+	println(fmt.Sprintf("Restore complete for DC %#v, Refreshing secrets", dc.ObjectMeta))
 	userSecrets := []string{}
 	for _, user := range dc.Spec.Users {
 		userSecrets = append(userSecrets, user.SecretName)
@@ -25,7 +25,7 @@ func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, clie
 	} else {
 		userSecrets = append(userSecrets, dc.Spec.SuperuserSecretName)
 	}
-	logger.Info(fmt.Sprintf("refreshing user secrets for %v", userSecrets))
+	println(fmt.Sprintf("refreshing user secrets for %v", userSecrets))
 	//  Both Reaper and medusa secrets go into the userSecrets, so they don't need special handling.
 	for _, i := range userSecrets {
 		secret := &corev1.Secret{}

--- a/pkg/medusa/refresh_secrets.go
+++ b/pkg/medusa/refresh_secrets.go
@@ -17,7 +17,6 @@ import (
 func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, client client.Client, logger logr.Logger, requeueDelay time.Duration) error {
 	logger.Info(fmt.Sprintf("Restore complete for DC %#v, Refreshing secrets", dc.ObjectMeta))
 	userSecrets := []string{}
-
 	for _, user := range dc.Spec.Users {
 		userSecrets = append(userSecrets, user.SecretName)
 	}
@@ -26,6 +25,7 @@ func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, clie
 	} else {
 		userSecrets = append(userSecrets, dc.Spec.SuperuserSecretName)
 	}
+	logger.Info(fmt.Sprintf("refreshing user secrets for %v", userSecrets))
 	//  Both Reaper and medusa secrets go into the userSecrets, so they don't need special handling.
 	for _, i := range userSecrets {
 		secret := &corev1.Secret{}

--- a/pkg/medusa/refresh_secrets.go
+++ b/pkg/medusa/refresh_secrets.go
@@ -1,0 +1,49 @@
+package medusa
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/reconciliation"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultSUSecretName = "cass-superuser"
+)
+
+func RefreshSecrets(dc *cassdcapi.CassandraDatacenter, ctx context.Context, client client.Client, logger logr.Logger, requeueDelay time.Duration) error {
+	logger.Info(fmt.Sprintf("Restore complete for DC %#v, Refreshing secrets", dc.ObjectMeta))
+	userSecrets := []string{}
+
+	for _, user := range dc.Spec.Users {
+		userSecrets = append(userSecrets, user.SecretName)
+	}
+	if dc.Spec.SuperuserSecretName == "" {
+		userSecrets = append(userSecrets, defaultSUSecretName) //default SU secret
+	} else {
+		userSecrets = append(userSecrets, dc.Spec.SuperuserSecretName)
+	}
+	//  Both Reaper and medusa secrets go into the userSecrets, so they don't need special handling.
+	for _, i := range userSecrets {
+		secret := &corev1.Secret{}
+		err := client.Get(ctx, types.NamespacedName{Name: i, Namespace: dc.Namespace}, secret)
+		if err != nil {
+			logger.Error(err, fmt.Sprintf("Failed to get secret %s", i))
+			return err
+		}
+		if secret.ObjectMeta.Annotations == nil {
+			secret.ObjectMeta.Annotations = make(map[string]string)
+		}
+		secret.ObjectMeta.Annotations[k8ssandraapi.RefreshAnnotation] = time.Now().String()
+		reconciliation.ReconcileObject(ctx, client, requeueDelay, *secret)
+	}
+	return nil
+
+}

--- a/pkg/medusa/refresh_secrets_test.go
+++ b/pkg/medusa/refresh_secrets_test.go
@@ -28,7 +28,8 @@ func TestRefreshSecrets_defaultSUSecret(t *testing.T) {
 	for _, i := range secrets {
 		assert.NoError(t, fakeClient.Create(context.Background(), &i))
 	}
-	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0)
+
+	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0, metav1.Now())
 	assert.True(t, recRes.IsDone())
 	suSecret := &corev1.Secret{}
 	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster-superuser", Namespace: "test"}, suSecret))
@@ -57,7 +58,7 @@ func TestRefreshSecrets_customSecrets(t *testing.T) {
 		assert.NoError(t, fakeClient.Create(context.Background(), &i))
 	}
 
-	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0)
+	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0, metav1.Now())
 	assert.True(t, recRes.IsDone())
 	suSecret := &corev1.Secret{}
 	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cass-custom-superuser", Namespace: "test"}, suSecret))

--- a/pkg/medusa/refresh_secrets_test.go
+++ b/pkg/medusa/refresh_secrets_test.go
@@ -28,7 +28,8 @@ func TestRefreshSecrets_defaultSUSecret(t *testing.T) {
 	for _, i := range secrets {
 		assert.NoError(t, fakeClient.Create(context.Background(), &i))
 	}
-	assert.NoError(t, RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0))
+	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0)
+	assert.True(t, recRes.IsDone())
 	suSecret := &corev1.Secret{}
 	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster-superuser", Namespace: "test"}, suSecret))
 	_, exists := suSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
@@ -55,7 +56,9 @@ func TestRefreshSecrets_customSecrets(t *testing.T) {
 	for _, i := range secrets {
 		assert.NoError(t, fakeClient.Create(context.Background(), &i))
 	}
-	assert.NoError(t, RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0))
+
+	recRes := RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0)
+	assert.True(t, recRes.IsDone())
 	suSecret := &corev1.Secret{}
 	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cass-custom-superuser", Namespace: "test"}, suSecret))
 	_, exists := suSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]

--- a/pkg/medusa/refresh_secrets_test.go
+++ b/pkg/medusa/refresh_secrets_test.go
@@ -1,0 +1,68 @@
+package medusa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRefreshSecrets_defaultSUSecret(t *testing.T) {
+	fakeClient := test.NewFakeClientWRestMapper()
+	cassDC := test.NewCassandraDatacenter("dc1", "test")
+	cassDC.Spec.Users = []cassdcapi.CassandraUser{
+		{SecretName: "custom-user"},
+	}
+	assert.NoError(t, fakeClient.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}))
+	assert.NoError(t, fakeClient.Create(context.Background(), &cassDC))
+	secrets := []corev1.Secret{
+		{ObjectMeta: metav1.ObjectMeta{Name: "custom-user", Namespace: "test"}, Data: map[string][]byte{"username": []byte("test")}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cass-superuser", Namespace: "test"}, Data: map[string][]byte{"username": []byte("test")}},
+	}
+	for _, i := range secrets {
+		assert.NoError(t, fakeClient.Create(context.Background(), &i))
+	}
+	assert.NoError(t, RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0))
+	suSecret := &corev1.Secret{}
+	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cass-superuser", Namespace: "test"}, suSecret))
+	_, exists := suSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
+	assert.True(t, exists)
+	userSecret := &corev1.Secret{}
+	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "custom-user", Namespace: "test"}, userSecret))
+	_, exists = userSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
+	assert.True(t, exists)
+}
+
+func TestRefreshSecrets_customSecrets(t *testing.T) {
+	fakeClient := test.NewFakeClientWRestMapper()
+	cassDC := test.NewCassandraDatacenter("dc1", "test")
+	cassDC.Spec.Users = []cassdcapi.CassandraUser{
+		{SecretName: "custom-user"},
+	}
+	cassDC.Spec.SuperuserSecretName = "cass-custom-superuser"
+	assert.NoError(t, fakeClient.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}))
+	assert.NoError(t, fakeClient.Create(context.Background(), &cassDC))
+	secrets := []corev1.Secret{
+		{ObjectMeta: metav1.ObjectMeta{Name: "custom-user", Namespace: "test"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cass-custom-superuser", Namespace: "test"}},
+	}
+	for _, i := range secrets {
+		assert.NoError(t, fakeClient.Create(context.Background(), &i))
+	}
+	assert.NoError(t, RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0))
+	suSecret := &corev1.Secret{}
+	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cass-custom-superuser", Namespace: "test"}, suSecret))
+	_, exists := suSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
+	assert.True(t, exists)
+	userSecret := &corev1.Secret{}
+	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "custom-user", Namespace: "test"}, userSecret))
+	_, exists = userSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
+	assert.True(t, exists)
+
+}

--- a/pkg/medusa/refresh_secrets_test.go
+++ b/pkg/medusa/refresh_secrets_test.go
@@ -23,14 +23,14 @@ func TestRefreshSecrets_defaultSUSecret(t *testing.T) {
 	assert.NoError(t, fakeClient.Create(context.Background(), &cassDC))
 	secrets := []corev1.Secret{
 		{ObjectMeta: metav1.ObjectMeta{Name: "custom-user", Namespace: "test"}, Data: map[string][]byte{"username": []byte("test")}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "cass-superuser", Namespace: "test"}, Data: map[string][]byte{"username": []byte("test")}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-superuser", Namespace: "test"}, Data: map[string][]byte{"username": []byte("test")}},
 	}
 	for _, i := range secrets {
 		assert.NoError(t, fakeClient.Create(context.Background(), &i))
 	}
 	assert.NoError(t, RefreshSecrets(&cassDC, context.Background(), fakeClient, logr.Logger{}, 0))
 	suSecret := &corev1.Secret{}
-	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "cass-superuser", Namespace: "test"}, suSecret))
+	assert.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-cluster-superuser", Namespace: "test"}, suSecret))
 	_, exists := suSecret.ObjectMeta.Annotations["k8ssandra.io/refresh"]
 	assert.True(t, exists)
 	userSecret := &corev1.Secret{}

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -211,7 +211,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 		}
 
 		return !restore.Status.FinishTime.IsZero()
-	}, polling.medusaRestoreDone.timeout, polling.medusaRestoreDone.interval, "restore didn't finish within timeout")
+	}, polling.medusaRestoreDone.timeout*100, polling.medusaRestoreDone.interval, "restore didn't finish within timeout")
 
 	require.Eventually(func() bool {
 		dc := &cassdcapi.CassandraDatacenter{}

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -231,9 +231,6 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 			return false
 		}
 		_, exists := secret.Annotations[k8ssandraapi.RefreshAnnotation]
-		if !exists {
-			t.Logf("%#v", *secret)
-		}
 		return exists
 	}, polling.medusaRestoreDone.timeout, polling.medusaRestoreDone.interval, "superuser secret wasn't updated with refresh annotation")
 

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -218,6 +218,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 		err := f.Get(ctx, dcKey, dc)
 		if err != nil {
 			t.Log(err)
+			return false
 		}
 		superUserSecret := dc.Spec.SuperuserSecretName
 		if dc.Spec.SuperuserSecretName == "" {
@@ -230,6 +231,9 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 			return false
 		}
 		_, exists := secret.Annotations[k8ssandraapi.RefreshAnnotation]
+		if !exists {
+			t.Logf("%#v", *secret)
+		}
 		return exists
 	}, polling.medusaRestoreDone.timeout, polling.medusaRestoreDone.interval, "superuser secret wasn't updated with refresh annotation")
 

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -211,7 +211,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 		}
 
 		return !restore.Status.FinishTime.IsZero()
-	}, polling.medusaRestoreDone.timeout*100, polling.medusaRestoreDone.interval, "restore didn't finish within timeout")
+	}, polling.medusaRestoreDone.timeout, polling.medusaRestoreDone.interval, "restore didn't finish within timeout")
 
 	require.Eventually(func() bool {
 		dc := &cassdcapi.CassandraDatacenter{}

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -217,6 +217,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 		secret := &corev1.Secret{}
 		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "cass-superuser"), secret)
 		if err != nil {
+			t.Log(err)
 			return false
 		}
 		_, exists := secret.Annotations[k8ssandraapi.RefreshAnnotation]

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -215,7 +215,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 
 	require.Eventually(func() bool {
 		secret := &corev1.Secret{}
-		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, cassdcapi.CleanupForKubernetes(dcKey.Name)+"-superuser"), secret)
+		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "test-superuser", secret)
 		if err != nil {
 			t.Log(err)
 			return false

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -218,6 +218,14 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "cass-superuser"), secret)
 		if err != nil {
 			t.Log(err)
+			secretList := &corev1.SecretList{}
+			err = f.List(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "cass-superuser"), secretList)
+			if err != nil {
+				t.Log(err)
+			}
+			for _, i := range secretList.Items {
+				t.Log(i.Name)
+			}
 			return false
 		}
 		_, exists := secret.Annotations[k8ssandraapi.RefreshAnnotation]

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -215,7 +215,7 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 
 	require.Eventually(func() bool {
 		secret := &corev1.Secret{}
-		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "test-superuser", secret)
+		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "test-superuser"), secret)
 		if err != nil {
 			t.Log(err)
 			return false

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -215,11 +215,11 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 
 	require.Eventually(func() bool {
 		secret := &corev1.Secret{}
-		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "cass-superuser"), secret)
+		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "firstcluster-superuser"), secret)
 		if err != nil {
 			t.Log(err)
 			secretList := &corev1.SecretList{}
-			err = f.List(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "cass-superuser"), secretList)
+			err = f.List(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "firstcluster-superuser"), secretList)
 			if err != nil {
 				t.Log(err)
 			}

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -215,17 +215,9 @@ func verifyRestoreJobFinished(t *testing.T, ctx context.Context, f *framework.E2
 
 	require.Eventually(func() bool {
 		secret := &corev1.Secret{}
-		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "firstcluster-superuser"), secret)
+		err := f.Get(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, cassdcapi.CleanupForKubernetes(dcKey.Name)+"-superuser"), secret)
 		if err != nil {
 			t.Log(err)
-			secretList := &corev1.SecretList{}
-			err = f.List(ctx, framework.NewClusterKey(restoreClusterKey.K8sContext, restoreClusterKey.Namespace, "firstcluster-superuser"), secretList)
-			if err != nil {
-				t.Log(err)
-			}
-			for _, i := range secretList.Items {
-				t.Log(i.Name)
-			}
 			return false
 		}
 		_, exists := secret.Annotations[k8ssandraapi.RefreshAnnotation]


### PR DESCRIPTION
**What this PR does**:

Adds an annotation to the user secrets when a DC is restored. Cass operator should then pick this up and cause a refresh of user credentials on the Cassandra side. 

**Which issue(s) this PR fixes**:
Fixes #1080 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
