### PR TITLE
Update cass-operator chart to 0.46.1

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -17,3 +17,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 - [ENHANCEMENT] [#1115](https://github.com/k8ssandra/k8ssandra-operator/issues/1115) Add a validation check for the projected pod names length
 * [CHANGE] [#1050](https://github.com/k8ssandra/k8ssandra-operator/issues/1050) Remove unnecessary requeues in the Medusa controllers
+* [ENHANCEMENT] [#1161](https://github.com/k8ssandra/k8ssandra-operator/issues/1161) Update cass-operator Helm chart to 0.46.1. Adds containerPort for cass-operator metrics and changes cass-config-builder base from UBI7 to UBI8

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.29.0
     repository: https://helm.k8ssandra.io
   - name: cass-operator
-    version: 0.45.1
+    version: 0.46.1
     repository: https://helm.k8ssandra.io
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Update cass-operator chart to 0.46.1 for UBI8 base image for cass-config-builder (ARM64 support) as well as expose containerPort for cass-operator metrics.

**Which issue(s) this PR fixes**:
Fixes #1161 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
