### PR TITLE
Restrict the mutating webhook to cass-operator managed pods

### DIFF
--- a/CHANGELOG/CHANGELOG-1.11.md
+++ b/CHANGELOG/CHANGELOG-1.11.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [BUGFIX] [#1172](https://github.com/k8ssandra/k8ssandra-operator/issues/1172) Restrict the mutating webhook to cass-operator managed pods
+
 ## v1.11.0 - 2023-12-20
 
 * [CHANGE] Upgrade to Medusa v0.17.0

--- a/charts/k8ssandra-operator/templates/admissionwebhookconfiguration.yaml
+++ b/charts/k8ssandra-operator/templates/admissionwebhookconfiguration.yaml
@@ -15,11 +15,8 @@ webhooks:
   failurePolicy: Fail
   name: mpod.kb.io
   objectSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: NotIn
-      values:
-      - k8ssandra-operator
+    matchLabels:
+      app.kubernetes.io/created-by: cass-operator
   rules:
   - apiGroups:
     - ""

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -37,7 +37,5 @@ patchesJson6902:
     - op: add
       path: /webhooks/0/objectSelector
       value:
-        matchExpressions:
-          - key: control-plane
-            operator: NotIn
-            values: ["k8ssandra-operator"]
+        matchLabels:
+          app.kubernetes.io/created-by: cass-operator

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -21,9 +21,9 @@ patchesJson6902:
       path: /webhooks/0/clientConfig/service/name
       value: k8ssandra-operator-webhook-service
 
-# adding the objectSelector prevents the bootstrapping problem
-# where the mutation request for the operator pod would be 
-# sent before the operator pod is created
+# The objectSelector will be added to the MutatingWebhookConfiguration
+# to restrict the webhook to pods created by cass-operator.
+# They're the only pods that should be mutated to inject secrets.
 patchesJson6902:
 - target:
     group: admissionregistration.k8s.io

--- a/test/kuttl/test-cassandra-versions/01-assert.yaml
+++ b/test/kuttl/test-cassandra-versions/01-assert.yaml
@@ -9,3 +9,32 @@ status:
     type: Available
   - status: "True"
     type: Progressing
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: k8ssandra-operator-mutating-webhook-configuration
+webhooks:
+  - name: mpod.kb.io
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - ''
+        apiVersions:
+          - v1
+        resources:
+          - pods
+        scope: '*'
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/created-by: cass-operator
+    sideEffects: None
+    timeoutSeconds: 10
+    admissionReviewVersions:
+      - v1
+    reinvocationPolicy: Never


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Our mutating webhook currently breaks kubernetes clusters as soon as the k8ssandra-operator pod gets unresponsive or deleted.
This is because the webhook will stay registered and is currently mutating ALL pods in the cluster.
Instead we need to restrict it to pods created by cass-operator as they're the only ones we need to act upon.
This PR modifies the objectSelector to target pods with the `app.kubernetes.io/created-by: cass-operator` label only.


**Which issue(s) this PR fixes**:
Fixes #1172 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
