### PR TITLE
Sanitize Reaper secrets names to gracefully handle cluster name overrides

### DIFF
--- a/.github/workflows/kind_e2e_tests.yaml
+++ b/.github/workflows/kind_e2e_tests.yaml
@@ -79,7 +79,7 @@ jobs:
         e2e_test:
           - CreateSingleDatacenterCluster
           - CreateStargateAndDatacenter
-          - CreateSingleReaper
+          - CreateSingleReaperNoStargate
           - CreateSingleReaperWStargateAndHTTP
           - CreateReaperAndDatacenter
           - CreateSingleMedusaJob

--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -22,3 +22,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [FEATURE] [#1165](https://github.com/k8ssandra/k8ssandra-operator/issues/1165) Expose Medusa ssl_verify option to allow disabling cert verification for some on prem S3 compatible systems
 * [ENHANCEMENT] [#1115](https://github.com/k8ssandra/k8ssandra-operator/issues/1115) Add a validation check for the projected pod names length
 * [ENHANCEMENT] [#1161](https://github.com/k8ssandra/k8ssandra-operator/issues/1161) Update cass-operator Helm chart to 0.46.1. Adds containerPort for cass-operator metrics and changes cass-config-builder base from UBI7 to UBI8
+* [BUGFIX] [#1002](https://github.com/k8ssandra/k8ssandra-operator/issues/1002) Fix reaper secret name sanitization with cluster overrides

--- a/pkg/reaper/secrets.go
+++ b/pkg/reaper/secrets.go
@@ -2,6 +2,7 @@ package reaper
 
 import (
 	"fmt"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -36,11 +37,11 @@ var DisableAuthVar = &corev1.EnvVar{
 
 // DefaultUserSecretName generates a name for the Reaper CQL user, that is derived from the Cassandra cluster name.
 func DefaultUserSecretName(clusterName string) string {
-	return fmt.Sprintf("%v-reaper", clusterName)
+	return fmt.Sprintf("%v-reaper", cassdcapi.CleanupForKubernetes(clusterName))
 }
 
 func DefaultUiSecretName(clusterName string) string {
-	return fmt.Sprintf("%v-reaper-ui", clusterName)
+	return fmt.Sprintf("%v-reaper-ui", cassdcapi.CleanupForKubernetes(clusterName))
 }
 
 func GetAuthEnvironmentVars(secret *corev1.Secret, authType string) (*corev1.EnvVar, *corev1.EnvVar, error) {

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -79,7 +79,7 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 
 	t.Run("TestReaperApi[0]", func(t *testing.T) {
 		t.Log("test Reaper API in context", f.DataPlaneContexts[0])
-		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "test-reaper-ui"}}
+		reaperUiSecretKey := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: namespace, Name: "mycluster-reaper-ui"}}
 		username, password := retrieveCredentials(t, f, ctx, reaperUiSecretKey)
 		testReaperApi(t, ctx, f.DataPlaneContexts[0], DcClusterName(t, f, dcKey), "reaper_db", username, password)
 	})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -247,7 +247,7 @@ func TestOperator(t *testing.T) {
 		testFunc: checkStargateApisWithMultiDcCluster,
 		fixture:  framework.NewTestFixture("multi-dc-stargate", controlPlane),
 	}))
-	t.Run("CreateSingleReaper", e2eTest(ctx, &e2eTestOpts{
+	t.Run("CreateSingleReaperNoStargate", e2eTest(ctx, &e2eTestOpts{
 		testFunc:                     createSingleReaper,
 		fixture:                      framework.NewTestFixture("single-dc-reaper", controlPlane),
 		skipK8ssandraClusterCleanup:  false,

--- a/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-reaper/k8ssandra.yaml
@@ -21,6 +21,7 @@ spec:
             memory: 512Mi
   cassandra:
     serverVersion: "3.11.14"
+    clusterName: "My Cluster"
     jmxInitContainerImage:
       repository: library
       name: busybox

--- a/test/testdata/fixtures/stargate-reaper-http/k8ssandra.yaml
+++ b/test/testdata/fixtures/stargate-reaper-http/k8ssandra.yaml
@@ -36,6 +36,7 @@ spec:
       timeoutSeconds: 20
   cassandra:
     serverVersion: "3.11.14"
+    clusterName: "My Cluster"
     jmxInitContainerImage:
       repository: library
       name: busybox


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
What the title says, plus modify single dc reaper e2e tests to use an override.
Also renames the `CreateSingleReaper` subtest to `CreateSingleReaperNoStargate`, because running `CreateSingleReaper`  would also run `CreateSingleReaperWStargateAndHTTP` as it begins with the same string.

**Which issue(s) this PR fixes**:
Fixes #1002

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
