### PR TITLE
Fix wrong keyspace replication factor alteration when multiple dcs with the same name exist

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -26,3 +26,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1161](https://github.com/k8ssandra/k8ssandra-operator/issues/1161) Update cass-operator Helm chart to 0.46.1. Adds containerPort for cass-operator metrics and changes cass-config-builder base from UBI7 to UBI8
 * [ENHANCEMENT] [#1154](https://github.com/k8ssandra/k8ssandra-operator/issues/1154) Schedule purges on clusters that have Medusa configured
 * [BUGFIX] [#1002](https://github.com/k8ssandra/k8ssandra-operator/issues/1002) Fix reaper secret name sanitization with cluster overrides
+* [BUGFIX] [#1188](https://github.com/k8ssandra/k8ssandra-operator/issues/1188) Fix wrong keyspace replication factor alteration by the operator when multiple dcs with the same name exist

--- a/pkg/cassandra/management.go
+++ b/pkg/cassandra/management.go
@@ -134,7 +134,7 @@ func (r *defaultManagementApiFacade) CreateKeyspaceIfNotExists(
 
 func (r *defaultManagementApiFacade) fetchDatacenterPods() ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
-	labels := client.MatchingLabels{cassdcapi.DatacenterLabel: r.dc.DatacenterName()}
+	labels := client.MatchingLabels{cassdcapi.DatacenterLabel: r.dc.DatacenterName(), cassdcapi.ClusterLabel: r.dc.Spec.ClusterName}
 	if err := r.k8sClient.List(r.ctx, podList, labels); err != nil {
 		return nil, err
 	} else {
@@ -304,7 +304,7 @@ func (r *defaultManagementApiFacade) EnsureKeyspaceReplication(keyspaceName stri
 			r.logger.Info(fmt.Sprintf("Keyspace %s has desired replication", keyspaceName))
 			return nil
 		} else {
-			r.logger.Info(fmt.Sprintf("keyspace %s already exists in cluster %v but has wrong replication, altering it", keyspaceName, r.dc.Spec.ClusterName))
+			r.logger.Info(fmt.Sprintf("keyspace %s already exists in cluster %v but has wrong replication, altering it. Expected: %v / Got: %v", keyspaceName, r.dc.Spec.ClusterName, replication, actualReplication))
 			if err := r.AlterKeyspace(keyspaceName, replication); err != nil {
 				return err
 			} else {

--- a/pkg/cassandra/management.go
+++ b/pkg/cassandra/management.go
@@ -134,7 +134,7 @@ func (r *defaultManagementApiFacade) CreateKeyspaceIfNotExists(
 
 func (r *defaultManagementApiFacade) fetchDatacenterPods() ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
-	labels := client.MatchingLabels{cassdcapi.DatacenterLabel: r.dc.DatacenterName(), cassdcapi.ClusterLabel: r.dc.Spec.ClusterName}
+	labels := client.MatchingLabels{cassdcapi.DatacenterLabel: r.dc.DatacenterName(), cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(r.dc.Spec.ClusterName)}
 	if err := r.k8sClient.List(r.ctx, podList, labels); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Uses a proper cluster label filter when listing pods.

**Which issue(s) this PR fixes**:
Fixes #1188 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
