### PR TITLE
Distinguish originals and copies for replicated secrets

### DIFF
--- a/apis/replication/v1alpha1/replicatedsecret_types.go
+++ b/apis/replication/v1alpha1/replicatedsecret_types.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	ReplicatedSecretSourceLabelKey   = "k8ssandra.io/secret-source"
-	ReplicatedSecretSourceLabelValue = "replicated-secret"
+	ReplicatedSecretSourceAnnotationKey   = "k8ssandra.io/secret-source"
+	ReplicatedSecretSourceAnnotationValue = "replicated-secret"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/apis/replication/v1alpha1/replicatedsecret_types.go
+++ b/apis/replication/v1alpha1/replicatedsecret_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ReplicatedSecretSourceLabelKey   = "k8ssandra.io/secret-source"
+	ReplicatedSecretSourceLabelValue = "replicated-secret"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/controllers/replication/secret_controller.go
+++ b/controllers/replication/secret_controller.go
@@ -236,7 +236,7 @@ func (s *SecretSyncController) Reconcile(ctx context.Context, req ctrl.Request) 
 					if copiedSecret.Annotations == nil {
 						copiedSecret.Annotations = make(map[string]string)
 					}
-					copiedSecret.Annotations[api.ReplicatedSecretSourceLabelKey] = api.ReplicatedSecretSourceLabelValue
+					copiedSecret.Labels[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
 					copiedSecret.OwnerReferences = []metav1.OwnerReference{}
 					if err = remoteClient.Create(ctx, copiedSecret); err != nil {
 						logger.Error(err, "Failed to sync secret to target cluster", "Secret", copiedSecret.Name, "TargetContext", target)
@@ -326,7 +326,6 @@ func syncSecrets(src, dest *corev1.Secret) {
 	if dest.GetAnnotations() == nil {
 		dest.Annotations = make(map[string]string)
 	}
-	dest.Annotations[api.ReplicatedSecretSourceLabelKey] = api.ReplicatedSecretSourceLabelValue
 
 	for k, v := range src.Annotations {
 		if !filterValue(k) {
@@ -344,6 +343,7 @@ func syncSecrets(src, dest *corev1.Secret) {
 			dest.Labels[k] = v
 		}
 	}
+	dest.Labels[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
 }
 
 // filterValue verifies the annotation is not something datacenter specific

--- a/controllers/replication/secret_controller.go
+++ b/controllers/replication/secret_controller.go
@@ -236,7 +236,7 @@ func (s *SecretSyncController) Reconcile(ctx context.Context, req ctrl.Request) 
 					if copiedSecret.Annotations == nil {
 						copiedSecret.Annotations = make(map[string]string)
 					}
-					copiedSecret.Labels[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
+					copiedSecret.Annotations[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
 					copiedSecret.OwnerReferences = []metav1.OwnerReference{}
 					if err = remoteClient.Create(ctx, copiedSecret); err != nil {
 						logger.Error(err, "Failed to sync secret to target cluster", "Secret", copiedSecret.Name, "TargetContext", target)
@@ -343,7 +343,7 @@ func syncSecrets(src, dest *corev1.Secret) {
 			dest.Labels[k] = v
 		}
 	}
-	dest.Labels[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
+	dest.Annotations[api.ReplicatedSecretSourceAnnotationKey] = api.ReplicatedSecretSourceAnnotationValue
 }
 
 // filterValue verifies the annotation is not something datacenter specific

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -414,7 +414,7 @@ func TestSyncSecrets(t *testing.T) {
 
 	syncSecrets(orig, dest)
 
-	assert.Equal(orig.GetAnnotations(), dest.GetAnnotations())
+	assert.Equal(orig.GetAnnotations()["k8ssandra.io/resource-hash"], dest.GetAnnotations()["k8ssandra.io/resource-hash"])
 	assert.Equal(orig.GetLabels(), dest.GetLabels())
 
 	assert.Equal(orig.Data, dest.Data)

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -101,7 +101,7 @@ func copySecretsFromClusterToCluster(t *testing.T, ctx context.Context, f *frame
 	require.Eventually(func() bool {
 		secret := &corev1.Secret{}
 		require.NoError(f.Client.Get(ctx, types.NamespacedName{Name: generatedSecrets[0].Name, Namespace: namespace}, secret))
-		return secret.Annotations[api.ReplicatedSecretSourceLabelKey] == api.ReplicatedSecretSourceLabelValue
+		return secret.Annotations[api.ReplicatedSecretSourceAnnotationKey] == api.ReplicatedSecretSourceAnnotationValue
 	}, timeout, interval)
 
 	t.Log("check that secret not match by replicated secret was not copied")


### PR DESCRIPTION
Replicated secrets controller adds an annotation noting that the secret was create through replication.


**Which issue(s) this PR fixes**:
Fixes #1191 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
