### PR TITLE
Use container service account for Medusa purge cronjob

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -30,3 +30,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1154](https://github.com/k8ssandra/k8ssandra-operator/issues/1154) Schedule purges on clusters that have Medusa configured
 * [BUGFIX] [#1002](https://github.com/k8ssandra/k8ssandra-operator/issues/1002) Fix reaper secret name sanitization with cluster overrides
 * [BUGFIX] [#1188](https://github.com/k8ssandra/k8ssandra-operator/issues/1188) Fix wrong keyspace replication factor alteration by the operator when multiple dcs with the same name exist
+* [BUGFIX] [#1195](https://github.com/k8ssandra/k8ssandra-operator/issues/1195) Backup purge cronjobs use a hardcoded service account name

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
         {{- end }}
         - name: K8SSANDRA_CONTROL_PLANE
           value: {{ .Values.controlPlane | quote }}
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         image: {{ include "k8ssandra-common.flattenedImage" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,10 @@ spec:
                 fieldPath: metadata.namespace
           - name: K8SSANDRA_CONTROL_PLANE
             value: "true"
+          - name: SERVICE_ACCOUNT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -533,6 +533,7 @@ func TestPurgeCronJob(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s-%s-medusa-purge", "testcluster", "testdc"), actualCronJob.ObjectMeta.Name)
 	assert.Equal(t, 3, len(actualCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command))
 	assert.Contains(t, actualCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command[2], "\\nspec:\\n  cassandraDatacenter: testdc")
+	assert.Equal(t, "default", actualCronJob.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName)
 }
 
 func TestPurgeCronJobNameTooLong(t *testing.T) {

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -142,6 +142,7 @@ func checkPurgeCronJobExists(t *testing.T, ctx context.Context, namespace string
 	cronJob := &batchv1.CronJob{}
 	err = f.Get(ctx, framework.NewClusterKey(dcKey.K8sContext, namespace, medusapkg.MedusaPurgeCronJobName(kc.SanitizedName(), dc1.SanitizedName())), cronJob)
 	require.NoErrorf(err, "Error getting the Medusa purge CronJob. ClusterName: %s, DataceneterName: %s", kc.SanitizedName(), dc1.SanitizedName())
+	require.Equal("k8ssandra-operator", cronJob.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName, "Service account name is not correct")
 	// create a Job from the cronjob spec
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an env variable to hold the Service Account name so that it can be retrieved when building the CronJob spec for purging Medusa backups.

**Which issue(s) this PR fixes**:
Fixes #1195

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
