### PR TITLE
Replicate medusa bucket secrets to each Cass DC

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -15,6 +15,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## v1.12.0 - 2024-02-02
 
+* [ENHANCEMENT] [#1159](https://github.com/k8ssandra/k8ssandra-operator/issues/1159) Replicate bucket key secrets to namespaces hosting clusters
 * [CHANGE] Upgrade to Medusa v0.17.2
 * [CHANGE] [#1158](https://github.com/k8ssandra/k8ssandra-operator/issues/1158) Use the MedusaConfiguration API when creating Medusa configuration
 * [CHANGE] [#1050](https://github.com/k8ssandra/k8ssandra-operator/issues/1050) Remove unnecessary requeues in the Medusa controllers

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -103,6 +103,7 @@ func TestK8ssandraCluster(t *testing.T) {
 	t.Run("CreateMultiDcClusterWithMedusa", testEnv.ControllerTest(ctx, createMultiDcClusterWithMedusa))
 	t.Run("CreateSingleDcClusterWithMedusaConfigRef", testEnv.ControllerTest(ctx, createSingleDcClusterWithMedusaConfigRef))
 	t.Run("CreatingSingleDcClusterWithoutPrefixInClusterSpecFail", testEnv.ControllerTest(ctx, creatingSingleDcClusterWithoutPrefixInClusterSpecFails))
+	t.Run("CreateMultiDcClusterWithReplicatedSecrets", testEnv.ControllerTest(ctx, createMultiDcClusterWithReplicatedSecrets))
 	t.Run("CreateSingleDcClusterNoAuth", testEnv.ControllerTest(ctx, createSingleDcClusterNoAuth))
 	t.Run("CreateSingleDcClusterAuth", testEnv.ControllerTest(ctx, createSingleDcClusterAuth))
 	t.Run("CreateSingleDcClusterAuthExternalSecrets", testEnv.ControllerTest(ctx, createSingleDcClusterAuthExternalSecrets))

--- a/docs/content/en/tasks/backup-restore/_index.md
+++ b/docs/content/en/tasks/backup-restore/_index.md
@@ -106,7 +106,7 @@ stringData:
 
 The file should always specify `credentials` as shown in the example above; in that section, provide the expected format and credential values that are expected by Medusa for the chosen storage backend. For more, refer to the [Medusa documentation](https://github.com/thelastpickle/cassandra-medusa/blob/master/docs/Installation.md) to know which file format should used for each supported storage backend.
 
-If using a shared Medusa configuration (see below), this secret can be created in the same namespace as the `MedusaConfiguration` object. The K8ssandra operator will then make sure the secret is replicated to the namespaces hosting the Cassandra clusters.
+If using a shared Medusa configuration (see below), this secret has to be created in the same namespace as the `MedusaConfiguration` object. k8ssandra-operator will then make sure the secret is replicated to the namespaces hosting the Cassandra clusters.
 
 A successful deployment should inject a new init container named `medusa-restore` and a new container named `medusa` in the Cassandra StatefulSet pods.
 

--- a/docs/content/en/tasks/backup-restore/_index.md
+++ b/docs/content/en/tasks/backup-restore/_index.md
@@ -88,7 +88,7 @@ spec:
       #   size: 100Mi
 ```
 
-The definition above requires a secret named `medusa-bucket-key` to be created in the target namespace before the `K8ssandraCluster` object gets created. Use the following format for this secret: 
+The definition above requires a secret named `medusa-bucket-key` to be present in the target namespace before the `K8ssandraCluster` object gets created. Use the following format for this secret: 
 
 ```yaml
 apiVersion: v1
@@ -106,9 +106,11 @@ stringData:
 
 The file should always specify `credentials` as shown in the example above; in that section, provide the expected format and credential values that are expected by Medusa for the chosen storage backend. For more, refer to the [Medusa documentation](https://github.com/thelastpickle/cassandra-medusa/blob/master/docs/Installation.md) to know which file format should used for each supported storage backend.
 
-A successful deployment should inject a new init container named `medusa-restore` and a new container named `medusa` in the Cassandra StatefulSet pods.  
+If using a shared Medusa configuration (see below), this secret can be created in the same namespace as the `MedusaConfiguration` object. The K8ssandra operator will then make sure the secret is replicated to the namespaces hosting the Cassandra clusters.
 
-## Using shared medusa configuration properties
+A successful deployment should inject a new init container named `medusa-restore` and a new container named `medusa` in the Cassandra StatefulSet pods.
+
+## Using shared Medusa configuration properties
 
 Medusa configuration properties can be shared across multiple K8ssandraClusters by creating a `MedusaConfiguration` custom resource in the Control Plane K8ssandra cluster.
 Example:

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -23,6 +23,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: dc1Namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dc1Key, f)
+	checkBucketKeyPresent(t, f, ctx, dc1Namespace, dc1Key.K8sContext, k8ssandra)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
@@ -41,6 +42,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: dc2Namespace, Name: "dc2"}}
 	checkDatacenterReady(t, ctx, dc2Key, f)
+	checkBucketKeyPresent(t, f, ctx, dc2Namespace, dc2Key.K8sContext, k8ssandra)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
@@ -64,6 +66,10 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 		}
 		return cassandraDatacenterReady(cassandraStatus)
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
+
+	t.Log("check replicated secret mounted")
+	checkReplicatedSecretMounted(t, ctx, f, dc1Key, dc1Namespace, k8ssandra)
+	checkReplicatedSecretMounted(t, ctx, f, dc2Key, dc2Namespace, k8ssandra)
 
 	t.Log("retrieve database credentials")
 	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], dc1Namespace, k8ssandra.SanitizedName())

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -277,6 +277,7 @@ func TestOperator(t *testing.T) {
 			clusterScoped:        true,
 			sutNamespace:         "test-0",
 			additionalNamespaces: []string{"test-1", "test-2"},
+			installMinio:         true,
 		}))
 	})
 	t.Run("CreateSingleMedusaJob", e2eTest(ctx, &e2eTestOpts{

--- a/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
@@ -4,6 +4,12 @@ metadata:
   name: test
   namespace: test-0
 spec:
+  medusa:
+    medusaConfigurationRef:
+      name: global-medusa-config
+      namespace: test-0
+    storageProperties:
+      prefix: test
   cassandra:
     serverVersion: "3.11.14"
     storageConfig:

--- a/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - medusa-config.yaml
   - k8ssandra.yaml

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: global-bucket-key
+  namespace: test-0
+type: Opaque
+stringData:
+  # Note that this currently has to be set to credentials!
+  credentials: |-
+    [default]
+    aws_access_key_id = k8ssandra
+    aws_secret_access_key = k8ssandra
+---
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaConfiguration
+metadata:
+  name: global-medusa-config
+  namespace: test-0
+spec:
+  storageProperties:
+    storageProvider: s3_compatible
+    bucketName: k8ssandra-medusa
+    storageSecretRef:
+      name: global-bucket-key
+    host: minio-service.minio.svc.cluster.local
+    port: 9000
+    secure: false

--- a/test/testdata/fixtures/multi-dc-encryption-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-encryption-medusa/k8ssandra.yaml
@@ -21,15 +21,10 @@ metadata:
   name: test
 spec:
   medusa:
+    medusaConfigurationRef:
+      name: global-medusa-config
     storageProperties:
-      storageProvider: s3_compatible
-      bucketName: k8ssandra-medusa
       prefix: test
-      storageSecretRef:
-        name: medusa-bucket-key
-      host: minio-service.minio.svc.cluster.local
-      port: 9000
-      secure: false 
     certificatesSecretRef:
       name: client-certificates
   cassandra:

--- a/test/testdata/fixtures/multi-dc-encryption-medusa/kustomization.yaml
+++ b/test/testdata/fixtures/multi-dc-encryption-medusa/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - medusa-config.yaml
   - k8ssandra.yaml

--- a/test/testdata/fixtures/multi-dc-encryption-medusa/medusa-config.yaml
+++ b/test/testdata/fixtures/multi-dc-encryption-medusa/medusa-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: global-bucket-key
+type: Opaque
+stringData:
+  # Note that this currently has to be set to credentials!
+  credentials: |-
+    [default]
+    aws_access_key_id = k8ssandra
+    aws_secret_access_key = k8ssandra
+---
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaConfiguration
+metadata:
+  name: global-medusa-config
+spec:
+  storageProperties:
+    storageProvider: s3_compatible
+    bucketName: k8ssandra-medusa
+    storageSecretRef:
+      name: global-bucket-key
+    host: minio-service.minio.svc.cluster.local
+    port: 9000
+    secure: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR adds a bucket secret reconciliation process. If Medusa is configured globally (meaning the cluster's medusa config features a `medusaConfigurationRef`, then this process will make sure the bucket key secrets are properly replicated into the namespaces (and clusters) of each of the DCs. It will also alter the k8ssandra cluster to use the copied secret, instead of the original one.

This PR does not implement the actual replication, it only makes a copy of the secret and places labels on it. We make a copy so that we can clean up after ourselves (the original secret is user-created and we should not touch it). The labels are then picked up by the secret reconciliation process which actually copies them over.

**Which issue(s) this PR fixes**:
Fixes #1159.

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
