### PR TITLE
Create Medusa CronJob in operator namespace

### DIFF
--- a/CHANGELOG/CHANGELOG-1.14.md
+++ b/CHANGELOG/CHANGELOG-1.14.md
@@ -14,3 +14,4 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+* [BUGFIX] [#1226](https://github.com/k8ssandra/k8ssandra-operator/issues/1226) Medusa purge cronjob should be created in the operator namespace

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: OPERARTOR_NAMESPACE
+        - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: OPERARTOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: {{ include "k8ssandra-common.flattenedImage" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
+          - name: OPERARTOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.serviceAccountName
-          - name: OPERARTOR_NAMESPACE
+          - name: OPERATOR_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -135,7 +135,7 @@ func (r *K8ssandraClusterReconciler) reconcileMedusa(
 			return result.RequeueSoon(r.DefaultDelay)
 		}
 		// Create a cron job to purge Medusa backups
-		operatorNamespace := r.getOperatorNamespace(logger)
+		operatorNamespace := r.getOperatorNamespace()
 		purgeCronJob, err := medusa.PurgeCronJob(dcConfig, kc.SanitizedName(), operatorNamespace, logger)
 		if err != nil {
 			logger.Info("Failed to create Medusa purge backups cronjob", "error", err)
@@ -327,10 +327,9 @@ func (r *K8ssandraClusterReconciler) reconcileBucketSecrets(
 	return nil
 }
 
-func (r *K8ssandraClusterReconciler) getOperatorNamespace(logger logr.Logger) string {
+func (r *K8ssandraClusterReconciler) getOperatorNamespace() string {
 	operatorNamespace, found := os.LookupEnv(operatorNamespaceEnvVar)
 	if !found {
-		logger.Info(fmt.Sprintf("Environment variable not found: %s", operatorNamespaceEnvVar))
 		return "default"
 	}
 	return operatorNamespace

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -135,11 +135,7 @@ func (r *K8ssandraClusterReconciler) reconcileMedusa(
 			return result.RequeueSoon(r.DefaultDelay)
 		}
 		// Create a cron job to purge Medusa backups
-		operatorNamespace, err := r.getOperatorNamespace()
-		if err != nil {
-			logger.Info("Failed to get Operator namespace", "error", err)
-			return result.Error(err)
-		}
+		operatorNamespace := r.getOperatorNamespace()
 		purgeCronJob, err := medusa.PurgeCronJob(dcConfig, kc.SanitizedName(), operatorNamespace, logger)
 		if err != nil {
 			logger.Info("Failed to create Medusa purge backups cronjob", "error", err)
@@ -331,10 +327,10 @@ func (r *K8ssandraClusterReconciler) reconcileBucketSecrets(
 	return nil
 }
 
-func (r *K8ssandraClusterReconciler) getOperatorNamespace() (string, error) {
+func (r *K8ssandraClusterReconciler) getOperatorNamespace() string {
 	operatorNamespace, found := os.LookupEnv(operatorNamespaceEnvVar)
 	if !found {
-		return "", fmt.Errorf("environment variable %s not set", operatorNamespaceEnvVar)
+		return "default"
 	}
-	return string(operatorNamespace), nil
+	return operatorNamespace
 }

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -330,7 +330,7 @@ func (r *K8ssandraClusterReconciler) reconcileBucketSecrets(
 func (r *K8ssandraClusterReconciler) getOperatorNamespace(logger logr.Logger) string {
 	operatorNamespace, found := os.LookupEnv(operatorNamespaceEnvVar)
 	if !found {
-		logger.Info("Environment variable not found", operatorNamespaceEnvVar)
+		logger.Info(fmt.Sprintf("Environment variable not found: %s", operatorNamespaceEnvVar))
 		return "default"
 	}
 	return operatorNamespace

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -135,7 +135,7 @@ func (r *K8ssandraClusterReconciler) reconcileMedusa(
 			return result.RequeueSoon(r.DefaultDelay)
 		}
 		// Create a cron job to purge Medusa backups
-		operatorNamespace := r.getOperatorNamespace()
+		operatorNamespace := r.getOperatorNamespace(logger)
 		purgeCronJob, err := medusa.PurgeCronJob(dcConfig, kc.SanitizedName(), operatorNamespace, logger)
 		if err != nil {
 			logger.Info("Failed to create Medusa purge backups cronjob", "error", err)
@@ -327,9 +327,10 @@ func (r *K8ssandraClusterReconciler) reconcileBucketSecrets(
 	return nil
 }
 
-func (r *K8ssandraClusterReconciler) getOperatorNamespace() string {
+func (r *K8ssandraClusterReconciler) getOperatorNamespace(logger logr.Logger) string {
 	operatorNamespace, found := os.LookupEnv(operatorNamespaceEnvVar)
 	if !found {
+		logger.Info("Environment variable not found", operatorNamespaceEnvVar)
 		return "default"
 	}
 	return operatorNamespace

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -3,8 +3,9 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
@@ -177,7 +178,7 @@ func checkPurgeCronJobExists(t *testing.T, ctx context.Context, namespace string
 	// check that the cronjob exists
 	cronJob := &batchv1.CronJob{}
 	err = f.Get(ctx, framework.NewClusterKey(dcKey.K8sContext, namespace, medusapkg.MedusaPurgeCronJobName(kc.SanitizedName(), dc1.SanitizedName())), cronJob)
-	require.NoErrorf(err, "Error getting the Medusa purge CronJob. ClusterName: %s, DataceneterName: %s", kc.SanitizedName(), dc1.SanitizedName())
+	require.NoErrorf(err, "Error getting the Medusa purge CronJob. ClusterName: %s, DatacenterName: %s", kc.SanitizedName(), dc1.SanitizedName())
 	require.Equal("k8ssandra-operator", cronJob.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName, "Service account name is not correct")
 	// create a Job from the cronjob spec
 	job := &batchv1.Job{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Creates the Medusa purge CronJob in the operator namespace (instead of the K8ssandra Cluster namespace)

**Which issue(s) this PR fixes**:
Fixes #1226

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
