### PR TITLE
Add the ability to override default registry and set imagePullSecrets

### DIFF
--- a/CHANGELOG/CHANGELOG-1.14.md
+++ b/CHANGELOG/CHANGELOG-1.14.md
@@ -14,11 +14,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
-* [BUGFIX] [#1253](https://github.com/k8ssandra/k8ssandra-operator/issues/1253) Medusa storage secrets are now labelled with a unique label.
 * [FEATURE] [#1260](https://github.com/k8ssandra/k8ssandra-operator/issues/1260) Update controller-gen to version 0.14.0.
+* [FEATURE] [#1280](https://github.com/k8ssandra/k8ssandra-operator/issues/1280) Env variables DEFAULT_REGISTRY and IMAGE_PULL_SECRETS allow overriding the default imagePullSecrets as well as the default registry to use when deploying medusa/reaper/stargate.
+* [BUGFIX] [#1253](https://github.com/k8ssandra/k8ssandra-operator/issues/1253) Medusa storage secrets are now labelled with a unique label.
 * [BUGFIX] [#1240](https://github.com/k8ssandra/k8ssandra-operator/issues/1240) The PullSecretRef for medusa is ignored in the standalone deployment of medusa
-
-
 
 ## v1.14.0 - 2024-04-02
 

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -9007,7 +9007,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             registry:
-                              default: docker.io
                               description: The Docker registry to use. Defaults to
                                 "docker.io", the official Docker Hub.
                               type: string
@@ -11158,7 +11157,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 registry:
-                                  default: docker.io
                                   description: The Docker registry to use. Defaults
                                     to "docker.io", the official Docker Hub.
                                   type: string
@@ -12293,7 +12291,6 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       registry:
-                                        default: docker.io
                                         description: The Docker registry to use. Defaults
                                           to "docker.io", the official Docker Hub.
                                         type: string
@@ -20845,7 +20842,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -24606,7 +24602,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -26274,7 +26269,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -26362,7 +26356,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -28562,7 +28555,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -31878,7 +31870,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string
@@ -31990,7 +31981,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string
@@ -34576,7 +34566,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string
@@ -35683,7 +35672,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         registry:
-                          default: docker.io
                           description: The Docker registry to use. Defaults to "docker.io",
                             the official Docker Hub.
                           type: string

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -51,6 +51,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.image.registryOverride }}
+        - name: DEFAULT_REGISTRY
+          value: {{ .Values.image.registryOverride | quote }}
+        {{- end }}
+        {{- if .Values.imagePullSecrets}}
+        - name: IMAGE_PULL_SECRETS
+          value: {{ join "," .Values.imagePullSecrets | quote }}
+        {{- end }}
         image: {{ include "k8ssandra-common.flattenedImage" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -26,9 +26,8 @@ image:
   pullPolicy: IfNotPresent
   # -- Tag of the k8ssandra-operator image to pull from image.repository
   tag: latest
-  # -- Docker registry containing all cass-operator related images. Setting this
-  # allows for usage of an internal registry without specifying serverImage,
-  # configBuilderImage, and busyboxImage on all CassandraDatacenter objects.
+  # -- Docker registry containing all k8ssandra-operator related images, such as reaper/medusa/stargate. 
+  # Setting this allows for usage of an internal registry without specifying image on all K8ssandraCluster objects.
   registryOverride:
 # -- References to secrets to use when pulling images. See:
 # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -8945,7 +8945,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             registry:
-                              default: docker.io
                               description: The Docker registry to use. Defaults to
                                 "docker.io", the official Docker Hub.
                               type: string
@@ -11096,7 +11095,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 registry:
-                                  default: docker.io
                                   description: The Docker registry to use. Defaults
                                     to "docker.io", the official Docker Hub.
                                   type: string
@@ -12231,7 +12229,6 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       registry:
-                                        default: docker.io
                                         description: The Docker registry to use. Defaults
                                           to "docker.io", the official Docker Hub.
                                         type: string
@@ -20783,7 +20780,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -24544,7 +24540,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -26212,7 +26207,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -26300,7 +26294,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string
@@ -28500,7 +28493,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       registry:
-                        default: docker.io
                         description: The Docker registry to use. Defaults to "docker.io",
                           the official Docker Hub.
                         type: string

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1019,7 +1019,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string
@@ -1131,7 +1130,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -1082,7 +1082,6 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   registry:
-                    default: docker.io
                     description: The Docker registry to use. Defaults to "docker.io",
                       the official Docker Hub.
                     type: string
@@ -2189,7 +2188,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         registry:
-                          default: docker.io
                           description: The Docker registry to use. Defaults to "docker.io",
                             the official Docker Hub.
                           type: string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRegistryParsing(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("docker.io", images.DefaultRegistry)
+	assert.Equal(0, len(images.DefaultPullSecretOverride))
+	assert.NotNil(images.DefaultPullSecretOverride)
+
+	t.Setenv(DefaultRegistryEnvVar, "localhost:5001")
+	InitConfig()
+	assert.Equal("localhost:5001", images.DefaultRegistry)
+	assert.NotNil(images.DefaultPullSecretOverride)
+
+	images.DefaultRegistry = "docker.io"
+	t.Setenv(DefaultPullSecretEnvVar, "my-super-secret")
+	InitConfig()
+	assert.Equal("localhost:5001", images.DefaultRegistry)
+	assert.Equal(1, len(images.DefaultPullSecretOverride))
+	assert.Equal("my-super-secret", images.DefaultPullSecretOverride[0].Name)
+
+	images.DefaultPullSecretOverride = make([]corev1.LocalObjectReference, 0)
+	t.Setenv(DefaultPullSecretEnvVar, "my-super-secret,secondary-secret")
+	InitConfig()
+	assert.Equal("localhost:5001", images.DefaultRegistry)
+	assert.Equal(2, len(images.DefaultPullSecretOverride))
+	assert.Equal("my-super-secret", images.DefaultPullSecretOverride[0].Name)
+	assert.Equal("secondary-secret", images.DefaultPullSecretOverride[1].Name)
+}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -2,15 +2,20 @@ package images
 
 import (
 	"fmt"
+
 	"github.com/adutra/goalesce"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	DefaultRegistry          = "docker.io"
-	DockerOfficialRepository = "library"
+var (
+	DefaultRegistry           = "docker.io"
+	DefaultPullSecretOverride []corev1.LocalObjectReference
 )
+
+func init() {
+	DefaultPullSecretOverride = make([]corev1.LocalObjectReference, 0)
+}
 
 // Image uniquely describes a container image and also specifies how to pull it from its remote repository.
 // More info: https://kubernetes.io/docs/concepts/containers/images.
@@ -50,6 +55,9 @@ type Image struct {
 
 // String returns this image's Docker name. It does not validate that the returned name is a valid Docker name.
 func (in Image) String() string {
+	if in.Registry == "" {
+		return fmt.Sprintf("%v/%v:%v", in.Repository, in.Name, in.Tag)
+	}
 	return fmt.Sprintf("%v/%v/%v:%v", in.Registry, in.Repository, in.Name, in.Tag)
 }
 
@@ -85,6 +93,8 @@ func (in *Image) ApplyDefaults(defaults Image) *Image {
 // empty if none of the images requires a secret to be successfully pulled.
 func CollectPullSecrets(images ...*Image) []corev1.LocalObjectReference {
 	var secrets []corev1.LocalObjectReference
+	secrets = append(secrets, DefaultPullSecretOverride...)
+
 	var secretNames []string
 	for _, image := range images {
 		if image != nil && image.PullSecretRef != nil && !utils.SliceContains(secretNames, image.PullSecretRef.Name) {

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -23,7 +23,6 @@ func init() {
 type Image struct {
 
 	// The Docker registry to use. Defaults to "docker.io", the official Docker Hub.
-	// +kubebuilder:default="docker.io"
 	// +optional
 	Registry string `json:"registry,omitempty"`
 

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -49,7 +49,6 @@ const (
 
 var (
 	defaultMedusaImage = images.Image{
-		Registry:   images.DefaultRegistry,
 		Repository: DefaultMedusaImageRepository,
 		Name:       DefaultMedusaImageName,
 		Tag:        DefaultMedusaVersion,

--- a/pkg/reaper/deployment.go
+++ b/pkg/reaper/deployment.go
@@ -37,7 +37,6 @@ const (
 )
 
 var defaultImage = images.Image{
-	Registry:   images.DefaultRegistry,
 	Repository: DefaultImageRepository,
 	Name:       DefaultImageName,
 	Tag:        DefaultVersion,

--- a/pkg/stargate/deployments.go
+++ b/pkg/stargate/deployments.go
@@ -50,19 +50,16 @@ const (
 
 var (
 	defaultImage3 = images.Image{
-		Registry:   images.DefaultRegistry,
 		Repository: DefaultImageRepository,
 		Name:       DefaultImageName3,
 		Tag:        "v" + DefaultVersion,
 	}
 	defaultImage4 = images.Image{
-		Registry:   images.DefaultRegistry,
 		Repository: DefaultImageRepository,
 		Name:       DefaultImageName4,
 		Tag:        "v" + DefaultVersion,
 	}
 	defaultImage68 = images.Image{
-		Registry:   images.DefaultRegistry,
 		Repository: DefaultImageRepository,
 		Name:       DefaultImageNameDse68,
 		Tag:        "v" + DefaultVersion,

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -744,7 +744,7 @@ func testImages(t *testing.T) {
 		deployments := NewDeployments(stargate, dc, logger)
 		require.Len(t, deployments, 1)
 		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
-		assert.Equal(t, defaultImage3.String(), deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/stargateio/stargate-3_11:v1.0.77", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 	})
@@ -757,7 +757,7 @@ func testImages(t *testing.T) {
 		deployments := NewDeployments(stargate, dc, logger)
 		require.Len(t, deployments, 1)
 		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
-		assert.Equal(t, defaultImage4.String(), deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/stargateio/stargate-4_0:v1.0.77", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 	})
@@ -771,7 +771,7 @@ func testImages(t *testing.T) {
 		deployments := NewDeployments(stargate, dc, logger)
 		require.Len(t, deployments, 1)
 		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
-		assert.Equal(t, defaultImage3.String(), deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/stargateio/stargate-3_11:v1.0.77", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 	})
@@ -787,7 +787,7 @@ func testImages(t *testing.T) {
 		deployments := NewDeployments(stargate, dc, logger)
 		require.Len(t, deployments, 1)
 		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
-		assert.Equal(t, defaultImage4.String(), deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/stargateio/stargate-4_0:v1.0.77", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 	})
@@ -840,7 +840,7 @@ func testImages(t *testing.T) {
 		deployments := NewDeployments(stargate, dc, logger)
 		require.Len(t, deployments, 1)
 		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
-		assert.Equal(t, defaultImage68.String(), deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/stargateio/stargate-dse-68:v1.0.77", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 		assert.Equal(t, "1", utils.FindEnvVarInContainer(&deployment.Spec.Template.Spec.Containers[0], "DSE").Value)


### PR DESCRIPTION
… for medusa/reaper/stargate

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds two new env variables, DEFAULT_REGISTRY which overrides the default registry used to deploy external images and a IMAGE_PULL_SECRETS that allows to set certain imagePullSecrets always.

The Helm chart already had values for these, ``.image.registryOverride`` and ``.imagePullSecrets[]``

Running the following command:

``helm template charts/k8ssandra-operator --api-versions=cert-manager.io/v1 --set 'imagePullSecrets={a,b,c}' --set image.registryOverride=localhost:5001``

Gives us the following deployment:

```yaml
        - name: DEFAULT_REGISTRY
          value: "localhost:5001"
        - name: IMAGE_PULL_SECRETS
          value: "a,b,c"
```

**Which issue(s) this PR fixes**:
Fixes #1280

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
