### PR TITLE
Replicated Secrets no longer pick up secrets from outside their own namespace

### DIFF
--- a/CHANGELOG/RELEASE-NOTES.md
+++ b/CHANGELOG/RELEASE-NOTES.md
@@ -10,6 +10,13 @@ To update an existing cluster, or create a new one, ensure that the `namespace` 
 
 If this functionality is critical to your use case, please raise an issue on Github and describe why it is important to you.
 
+## v1.15.0
+
+### Correction to ReplicatedSecrets namespacing behaviour
+
+Replicated secrets no longer look in all namespaces to Replicate secrets whose labels match the MatchLabels selector in the ReplicatedSecret.
+
+Instead, secrets will only be picked up by the matcher if they both have matching labels AND are also in the same namespace as the ReplicatedSecret.
 
 ## v1.12.0
 

--- a/controllers/replication/secret_controller.go
+++ b/controllers/replication/secret_controller.go
@@ -81,8 +81,8 @@ func (s *SecretSyncController) Reconcile(ctx context.Context, req ctrl.Request) 
 					logger.Error(err, "Failed to delete the replicated secret, defined labels are invalid", "ReplicatedSecret", req.NamespacedName)
 					return reconcile.Result{}, err
 				}
-				// These are the secrets which are currently being replicated by THIS ReplicatedSecret in the local namespace.
-				secrets, err := s.fetchAllMatchingSecrets(ctx, selector)
+
+				secrets, err := s.fetchAllMatchingSecrets(ctx, selector, rsec.Namespace)
 				if err != nil {
 					logger.Error(err, "Failed to fetch the replicated secrets to cleanup", "ReplicatedSecret", req.NamespacedName)
 					return reconcile.Result{}, err
@@ -183,7 +183,7 @@ func (s *SecretSyncController) Reconcile(ctx context.Context, req ctrl.Request) 
 	s.selectorMutex.Unlock()
 
 	// Fetch all the secrets that match the ReplicatedSecret's rules
-	secrets, err := s.fetchAllMatchingSecrets(ctx, selector)
+	secrets, err := s.fetchAllMatchingSecrets(ctx, selector, req.Namespace)
 	if err != nil {
 		logger.Error(err, "Failed to fetch linked secrets", "ReplicatedSecret", req.NamespacedName)
 		return reconcile.Result{Requeue: true}, err
@@ -373,10 +373,11 @@ func (s *SecretSyncController) verifyHashAnnotation(ctx context.Context, sec *co
 	return nil
 }
 
-func (s *SecretSyncController) fetchAllMatchingSecrets(ctx context.Context, selector labels.Selector) ([]corev1.Secret, error) {
+func (s *SecretSyncController) fetchAllMatchingSecrets(ctx context.Context, selector labels.Selector, namespace string) ([]corev1.Secret, error) {
 	secrets := &corev1.SecretList{}
 	listOption := client.ListOptions{
 		LabelSelector: selector,
+		Namespace:     namespace,
 	}
 	err := s.ClientCache.GetLocalClient().List(ctx, secrets, &listOption)
 	if err != nil {


### PR DESCRIPTION
ReplicatedSecrets should not pick up secrets from outside their own namespace.


**Which issue(s) this PR fixes**:
Fixes #1282

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
