### PR TITLE
Use a single image for the container and the init-container of Reaper

### DIFF
--- a/CHANGELOG/CHANGELOG-1.15.md
+++ b/CHANGELOG/CHANGELOG-1.15.md
@@ -18,3 +18,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#1217](https://github.com/k8ssandra/k8ssandra-operator/issues/1217) Medusa storage secrets now use a ReplicatedSecret for synchronization, fixing an issue where changes to the secrets were not propagating. Additionally, fix a number of issues with local testing on ARM Macs.
 * [BUGFIX] [#1253](https://github.com/k8ssandra/k8ssandra-operator/issues/1253) Medusa storage secrets are now labelled with a unique label.
 * [FEATURE] [#1260](https://github.com/k8ssandra/k8ssandra-operator/issues/1260) Update controller-gen to version 0.14.0.
+* [BUGFIX] [1287](https://github.com/k8ssandra/k8ssandra-operator/pull/1287) Use the same image for Reaper init and main containers

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -194,10 +194,9 @@ func testCreateReaper(t *testing.T, ctx context.Context, k8sClient client.Client
 	assert.Len(t, deployment.OwnerReferences, 1, "deployment owner reference not set")
 	assert.Equal(t, rpr.UID, deployment.OwnerReferences[0].UID, "deployment owner reference has wrong uid")
 
-	// init container should be a default image and thus should not contain the latest tag; pull policy should be the
-	// default one (IfNotPresent)
-	assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:"+reaper.DefaultVersion, deployment.Spec.Template.Spec.InitContainers[0].Image)
-	assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
+	// init container should use the same image and tag as the main container.
+	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Image, deployment.Spec.Template.Spec.InitContainers[0].Image)
+	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy, deployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
 
 	// main container is a custom image where the tag isn't specified, so it should default to latest, and pull policy
 	// to Always.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Uses the same image for the init container than the container.
The initContainer cannot be overridden which creates issues when we want to override the coordinates of the reaper image.
These two should always be the same anyway, otherwise there could be a drift between the schema that is created and the main container image.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
