### PR TITLE
Remove the medusa standalone pod

### DIFF
--- a/CHANGELOG/CHANGELOG-1.16.md
+++ b/CHANGELOG/CHANGELOG-1.16.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [BUGFIX] [#1272](https://github.com/k8ssandra/k8ssandra-operator/issues/1272) Prevent cass-operator from creating users when an external DC is referenced to allow migration through expansion
+* [ENHANCEMENT] [#1066](https://github.com/k8ssandra/k8ssandra-operator/issues/1066) Remove the medusa standalone pod as it is not needed anymore

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/encryption"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/labels"
-	medusa "github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 
 	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -1582,8 +1581,6 @@ func applyClusterWithEncryptionOptions(t *testing.T, ctx context.Context, f *fra
 
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
-	medusaKey := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), "dc1")}, K8sContext: f.DataPlaneContexts[0]}
-	require.NoError(f.SetMedusaDeplAvailable(ctx, medusaKey))
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -1956,8 +1953,6 @@ func applyClusterWithEncryptionOptionsExternalSecrets(t *testing.T, ctx context.
 	require.NoError(err, "failed to create K8ssandraCluster")
 
 	verifyFinalizerAdded(ctx, t, f, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name})
-	medusaKey := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), "dc1")}, K8sContext: f.DataPlaneContexts[0]}
-	require.NoError(f.SetMedusaDeplAvailable(ctx, medusaKey))
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -2487,8 +2482,6 @@ func injectContainersAndVolumes(t *testing.T, ctx context.Context, f *framework.
 
 	verifySystemReplicationAnnotationSet(ctx, t, f, kc)
 
-	// Create a Medusa deployment object and simulate it being available to make the k8c reconcile progress.
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc1", f.DataPlaneContexts[0])
 	t.Log("check that dc1 was never created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)

--- a/controllers/k8ssandra/medusa_reconciler_test.go
+++ b/controllers/k8ssandra/medusa_reconciler_test.go
@@ -11,12 +11,10 @@ import (
 	medusaapi "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	cassandra "github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
-	medusa "github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -167,7 +165,6 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	require.NoError(err, "failed to create K8ssandraCluster")
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc1", f.DataPlaneContexts[0])
 	t.Log("check that dc1 was created")
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -175,28 +172,6 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	t.Log("verify the config map exists and has the contents from the MedusaConfiguration object")
 	defaultPrefix := kc.Spec.Medusa.StorageProperties.Prefix
 	verifyConfigMap(require, ctx, f, namespace, defaultPrefix, defaultConcurrentTransfers)
-
-	t.Log("check that the standalone Medusa deployment was created in dc1")
-	medusaDeploymentKey1 := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaStandaloneDeploymentName(k8ssandraClusterName, "dc1")}, K8sContext: f.DataPlaneContexts[0]}
-	medusaDeployment1 := &appsv1.Deployment{}
-	require.Eventually(func() bool {
-		if err := f.Get(ctx, medusaDeploymentKey1, medusaDeployment1); err != nil {
-			return false
-		}
-		return true
-	}, timeout, interval)
-
-	require.True(f.ContainerHasEnvVar(medusaDeployment1.Spec.Template.Spec.Containers[0], "MEDUSA_RESOLVE_IP_ADDRESSES", "False"))
-
-	t.Log("check that the standalone Medusa service was created")
-	medusaServiceKey1 := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaServiceName(k8ssandraClusterName, "dc1")}, K8sContext: f.DataPlaneContexts[0]}
-	medusaService1 := &corev1.Service{}
-	require.Eventually(func() bool {
-		if err := f.Get(ctx, medusaServiceKey1, medusaService1); err != nil {
-			return false
-		}
-		return true
-	}, timeout, interval)
 
 	t.Log("update datacenter status to scaling up")
 	err = f.PatchDatacenterStatus(ctx, dc1Key, func(dc *cassdcapi.CassandraDatacenter) {
@@ -259,29 +234,8 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 		return f.UpdateDatacenterGeneration(ctx, t, dc1Key)
 	}, timeout, interval, "failed to update dc1 generation")
 
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc2", f.DataPlaneContexts[1])
 	t.Log("check that dc2 was created")
 	require.Eventually(f.DatacenterExists(ctx, dc2Key), timeout, interval)
-
-	t.Log("check that the standalone Medusa deployment was created in dc2")
-	medusaDeploymentKey2 := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaStandaloneDeploymentName(k8ssandraClusterName, "dc2")}, K8sContext: f.DataPlaneContexts[1]}
-	medusaDeployment2 := &appsv1.Deployment{}
-	require.Eventually(func() bool {
-		if err := f.Get(ctx, medusaDeploymentKey2, medusaDeployment2); err != nil {
-			return false
-		}
-		return true
-	}, timeout, interval)
-
-	t.Log("check that the standalone Medusa service was created in dc2")
-	medusaServiceKey2 := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: medusa.MedusaServiceName(k8ssandraClusterName, "dc2")}, K8sContext: f.DataPlaneContexts[1]}
-	medusaService2 := &corev1.Service{}
-	require.Eventually(func() bool {
-		if err := f.Get(ctx, medusaServiceKey2, medusaService2); err != nil {
-			return false
-		}
-		return true
-	}, timeout, interval)
 
 	t.Log("check that remote seeds are set on dc2")
 	dc2 = &cassdcapi.CassandraDatacenter{}
@@ -355,11 +309,6 @@ func createMultiDcClusterWithMedusa(t *testing.T, ctx context.Context, f *framew
 	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: namespace, Name: kc.Name}, timeout, interval)
 	require.NoError(err, "failed to delete K8ssandraCluster")
 	f.AssertObjectDoesNotExist(ctx, t, dc1Key, &cassdcapi.CassandraDatacenter{}, timeout, interval)
-	// Check that Medusa Standalone deployment and service were deleted
-	f.AssertObjectDoesNotExist(ctx, t, medusaDeploymentKey1, &appsv1.Deployment{}, timeout, interval)
-	f.AssertObjectDoesNotExist(ctx, t, medusaDeploymentKey2, &appsv1.Deployment{}, timeout, interval)
-	f.AssertObjectDoesNotExist(ctx, t, medusaServiceKey1, &corev1.Service{}, timeout, interval)
-	f.AssertObjectDoesNotExist(ctx, t, medusaServiceKey2, &corev1.Service{}, timeout, interval)
 }
 
 // Check that all the Medusa related objects have been created and are in the expected state.
@@ -395,47 +344,6 @@ func checkMedusaObjectsCompliance(t *testing.T, f *framework.Framework, dc *cass
 		}
 		assert.True(t, f.ContainerHasEnvVar(container, "MEDUSA_TMP_DIR", ""), "Missing MEDUSA_TMP_DIR env var for medusa-restore")
 	}
-}
-
-func reconcileMedusaStandaloneDeployment(ctx context.Context, t *testing.T, f *framework.Framework, kc *api.K8ssandraCluster, dcName string, k8sContext string) {
-	t.Log("create Medusa Standalone deployment")
-
-	medusaDepl := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName),
-			Namespace: kc.Namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName)},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName)},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName),
-							Image: "quay.io/k8ssandra/medusa:0.11.0",
-						},
-					},
-				},
-			},
-		},
-	}
-	medusaKey := framework.ClusterKey{NamespacedName: utils.GetKey(medusaDepl), K8sContext: k8sContext}
-	require.NoError(t, f.Create(ctx, medusaKey, medusaDepl))
-
-	actualMedusaDepl := &appsv1.Deployment{}
-	assert.Eventually(t, func() bool {
-		err := f.Get(ctx, medusaKey, actualMedusaDepl)
-		return err == nil
-	}, timeout, interval, "failed to get Medusa Deployment")
-
-	err := f.SetMedusaDeplAvailable(ctx, medusaKey)
-
-	require.NoError(t, err, "Failed to update Medusa Deployment status")
 }
 
 func createSingleDcClusterWithMedusaConfigRef(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
@@ -636,8 +544,6 @@ func createMultiDcClusterWithReplicatedSecrets(t *testing.T, ctx context.Context
 	verifySuperuserSecretCreated(ctx, t, f, kc)
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
 
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc1", f.DataPlaneContexts[1])
-
 	// crate the first DC
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[1]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -648,7 +554,6 @@ func createMultiDcClusterWithReplicatedSecrets(t *testing.T, ctx context.Context
 	require.NoError(err, "failed to update dc1 status to ready")
 
 	// create the second DC
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc2", f.DataPlaneContexts[2])
 	dc2Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc2"}, K8sContext: f.DataPlaneContexts[2]}
 	require.Eventually(f.DatacenterExists(ctx, dc2Key), timeout, interval)
 
@@ -708,8 +613,6 @@ func createSingleDcClusterWithManagementApiSecured(t *testing.T, ctx context.Con
 
 	require.NoError(f.Client.Create(ctx, kc))
 	verifyReplicatedSecretReconciled(ctx, t, f, kc)
-
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc1", f.DataPlaneContexts[0])
 
 	dc1Key := framework.ClusterKey{NamespacedName: types.NamespacedName{Namespace: namespace, Name: "dc1"}, K8sContext: f.DataPlaneContexts[0]}
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -162,7 +162,15 @@ func setupMedusaRestoreJobTestEnv(t *testing.T, ctx context.Context) *testutils.
 		}
 
 		for _, env := range testEnv.GetDataPlaneEnvTests() {
-			dataPlaneMgr, err := ctrl.NewManager(env.Config, ctrl.Options{Scheme: scheme.Scheme})
+			dataPlaneMgr, err := ctrl.NewManager(
+				env.Config,
+				ctrl.Options{
+					Scheme:  scheme.Scheme,
+					Host:    env.WebhookInstallOptions.LocalServingHost,
+					Port:    env.WebhookInstallOptions.LocalServingPort,
+					CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+				},
+			)
 			if err != nil {
 				return err
 			}
@@ -173,6 +181,7 @@ func setupMedusaRestoreJobTestEnv(t *testing.T, ctx context.Context) *testutils.
 				Scheme:           scheme.Scheme,
 				ClientFactory:    medusaRestoreClientFactory,
 			}).SetupWithManager(dataPlaneMgr)
+			secretswebhook.SetupSecretsInjectorWebhook(dataPlaneMgr)
 			if err != nil {
 				return err
 			}

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -15,11 +15,9 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/shared"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +87,6 @@ func testMedusaBackupDatacenter(t *testing.T, ctx context.Context, f *framework.
 	require.NoError(err, "failed to create K8ssandraCluster")
 
 	reconcileReplicatedSecret(ctx, t, f, kc)
-	reconcileMedusaStandaloneDeployment(ctx, t, f, kc, "dc1", f.DataPlaneContexts[0])
 	t.Log("check that dc1 was created")
 	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc1")
 	require.Eventually(f.DatacenterExists(ctx, dc1Key), timeout, interval)
@@ -467,47 +464,6 @@ func verifyObjectDoesNotExist(ctx context.Context, t *testing.T, f *framework.Fr
 		err := f.Get(ctx, key, obj)
 		return err != nil && errors.IsNotFound(err)
 	}, timeout, interval, "failed to verify object does not exist", key)
-}
-
-func reconcileMedusaStandaloneDeployment(ctx context.Context, t *testing.T, f *framework.Framework, kc *k8ss.K8ssandraCluster, dcName string, k8sContext string) {
-	t.Logf("start reconcileMedusaStandaloneDeployment for dc %s", dcName)
-
-	medusaDepl := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName),
-			Namespace: kc.Namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName)},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName)},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  medusa.MedusaStandaloneDeploymentName(kc.SanitizedName(), dcName),
-							Image: "quay.io/k8ssandra/medusa:0.11.0",
-						},
-					},
-				},
-			},
-		},
-	}
-	medusaKey := framework.ClusterKey{NamespacedName: utils.GetKey(medusaDepl), K8sContext: k8sContext}
-	require.NoError(t, f.Create(ctx, medusaKey, medusaDepl))
-
-	actualMedusaDepl := &appsv1.Deployment{}
-	assert.Eventually(t, func() bool {
-		err := f.Get(ctx, medusaKey, actualMedusaDepl)
-		return err == nil
-	}, timeout, interval, "failed to get Medusa Deployment")
-
-	err := f.SetMedusaDeplAvailable(ctx, medusaKey)
-
-	require.NoError(t, err, "Failed to update Medusa Deployment status")
 }
 
 func TestHumanize(t *testing.T) {

--- a/controllers/medusa/medusatask_controller_test.go
+++ b/controllers/medusa/medusatask_controller_test.go
@@ -96,7 +96,6 @@ func testMedusaTasks(t *testing.T, ctx context.Context, f *framework.Framework, 
 	reconcileReplicatedSecret(ctx, t, f, kc)
 
 	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
-		reconcileMedusaStandaloneDeployment(ctx, t, f, kc, dcKey.Name, f.DataPlaneContexts[0])
 		t.Logf("check that %s was created", dcKey.Name)
 		require.Eventually(f.DatacenterExists(ctx, dcKey), timeout, interval)
 

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -9,7 +9,6 @@ import (
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	medusaapi "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
-	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -594,41 +593,6 @@ func TestInitContainerCustomResources(t *testing.T) {
 	assert.Equal(t, resource.MustParse("40Gi"), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Limits.Memory(), "expected main container memory limit to be set")
 	assert.Equal(t, resource.MustParse("40"), *dcConfig.PodTemplateSpec.Spec.Containers[0].Resources.Limits.Cpu(), "expected main container cpu limit to be set")
 
-}
-
-func TestStandaloneMedusaDeploymentImageSettings(t *testing.T) {
-	medusaSpec := &medusaapi.MedusaClusterTemplate{
-		StorageProperties: medusaapi.Storage{
-			StorageProvider: "s3",
-			StorageSecretRef: corev1.LocalObjectReference{
-				Name: "secret",
-			},
-			BucketName: "bucket",
-		},
-		ContainerImage: &images.Image{
-			Registry:      "reg1",
-			Name:          "img1",
-			Repository:    "repo1",
-			Tag:           "tag1",
-			PullPolicy:    "Always",
-			PullSecretRef: &corev1.LocalObjectReference{Name: "main-secret"},
-		},
-	}
-
-	dcConfig := cassandra.DatacenterConfig{}
-
-	logger := logr.New(logr.Discard().GetSink())
-
-	medusaContainer, err := CreateMedusaMainContainer(&dcConfig, medusaSpec, false, "test", logger)
-	assert.NoError(t, err)
-	UpdateMedusaInitContainer(&dcConfig, medusaSpec, false, "test", logger)
-	UpdateMedusaMainContainer(&dcConfig, medusaContainer)
-
-	desiredMedusaStandalone := StandaloneMedusaDeployment(*medusaContainer, "dc1", dcConfig.SanitizedName(), "test", logger, medusaSpec.ContainerImage)
-
-	assert.Equal(t, "main-secret", desiredMedusaStandalone.Spec.Template.Spec.ImagePullSecrets[0].Name, "expected standalone container image pull secret to be set")
-	assert.Equal(t, "reg1/repo1/img1:tag1", desiredMedusaStandalone.Spec.Template.Spec.Containers[0].Image, "expected standalone container image to be set to reg1/repo1/img1:tag1")
-	assert.Equal(t, corev1.PullAlways, desiredMedusaStandalone.Spec.Template.Spec.Containers[0].ImagePullPolicy, "expected standalone pull policy to be set to Always")
 }
 
 func TestExternalSecretsFlag(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Remove the medusa standalone pod which serves no real purpose today and can be traded for the medusa containers running in the Cassandra pods

**Which issue(s) this PR fixes**:
Fixes #1066

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
