### PR TITLE
Update cassandra-medusa version to 0.21.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.16.md
+++ b/CHANGELOG/CHANGELOG-1.16.md
@@ -15,5 +15,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [CHANGE] Update cassandra-medusa to 0.21.0
 * [BUGFIX] [#1272](https://github.com/k8ssandra/k8ssandra-operator/issues/1272) Prevent cass-operator from creating users when an external DC is referenced to allow migration through expansion
 * [ENHANCEMENT] [#1066](https://github.com/k8ssandra/k8ssandra-operator/issues/1066) Remove the medusa standalone pod as it is not needed anymore

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -25,7 +25,7 @@ import (
 const (
 	DefaultMedusaImageRepository = "k8ssandra"
 	DefaultMedusaImageName       = "medusa"
-	DefaultMedusaVersion         = "0.20.1"
+	DefaultMedusaVersion         = "0.21.0"
 	DefaultMedusaPort            = 50051
 	DefaultProbeInitialDelay     = 10
 	DefaultProbeTimeout          = 1


### PR DESCRIPTION
**What this PR does**:
Updates the default cassandra-medusa image the k8ssandra-operator uses to 0.21.0.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
