### PR TITLE
Upgrade reaper ro rootfs

### DIFF
--- a/CHANGELOG/CHANGELOG-1.17.md
+++ b/CHANGELOG/CHANGELOG-1.17.md
@@ -15,8 +15,9 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-* [CHANGE] [1313](https://github.com/k8ssandra/k8ssandra-operator/issues/1313) upgrade controller-runtime to 1.17 series, Go to 1.21.
-* [BUGFIX] [1317](https://github.com/k8ssandra/k8ssandra-operator/issues/1317) Fix issues with caches in cluster scoped deployments where they were continuing to use a multi-namespace scoped cache and not an informer cache.
-* [BUGFIX] [1316](https://github.com/k8ssandra/k8ssandra-operator/issues/1316) Fix interchanged intervals and timeouts in tests.
-* [BUGFIX] [1322](https://github.com/k8ssandra/k8ssandra-operator/issues/1322) Fix bug where server-system-logger customisations from the Containers field would be overwritten when vector was enabled. 
+* [CHANGE] [#1313](https://github.com/k8ssandra/k8ssandra-operator/issues/1313) upgrade controller-runtime to 1.17 series, Go to 1.21.
+* [BUGFIX] [#1317](https://github.com/k8ssandra/k8ssandra-operator/issues/1317) Fix issues with caches in cluster scoped deployments where they were continuing to use a multi-namespace scoped cache and not an informer cache.
+* [BUGFIX] [#1316](https://github.com/k8ssandra/k8ssandra-operator/issues/1316) Fix interchanged intervals and timeouts in tests.
+* [BUGFIX] [#1322](https://github.com/k8ssandra/k8ssandra-operator/issues/1322) Fix bug where server-system-logger customisations from the Containers field would be overwritten when vector was enabled. 
 * [FEATURE] Add support for HCD 1.0
+* [ENHANCEMENT] [#1329](https://github.com/k8ssandra/k8ssandra-operator/issues/1329) Add config emptyDir volume mount on Reaper deployment to allow read only root FS

--- a/apis/reaper/v1alpha1/reaper_types.go
+++ b/apis/reaper/v1alpha1/reaper_types.go
@@ -67,10 +67,10 @@ type ReaperTemplate struct {
 	SecretsProvider string `json:"secretsProvider,omitempty"`
 
 	// The image to use for the Reaper pod main container.
-	// The default is "thelastpickle/cassandra-reaper:3.6.0".
+	// The default is "thelastpickle/cassandra-reaper:f52e877".
 	// +optional
 	// TODO: update with real release version.
-	// +kubebuilder:default={repository:"thelastpickle",name:"cassandra-reaper",tag:"3.6.0"}
+	// +kubebuilder:default={repository:"thelastpickle",name:"cassandra-reaper",tag:"f52e877"}
 	ContainerImage *images.Image `json:"containerImage,omitempty"`
 
 	// Deprecated: The main container image will be used for the init container as well.

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -27545,10 +27545,10 @@ spec:
                     default:
                       name: cassandra-reaper
                       repository: thelastpickle
-                      tag: 3.6.0
+                      tag: f52e877
                     description: |-
                       The image to use for the Reaper pod main container.
-                      The default is "thelastpickle/cassandra-reaper:3.6.0".
+                      The default is "thelastpickle/cassandra-reaper:f52e877".
                       TODO: update with real release version.
                     properties:
                       name:
@@ -33383,10 +33383,10 @@ spec:
                 default:
                   name: cassandra-reaper
                   repository: thelastpickle
-                  tag: 3.6.0
+                  tag: f52e877
                 description: |-
                   The image to use for the Reaper pod main container.
-                  The default is "thelastpickle/cassandra-reaper:3.6.0".
+                  The default is "thelastpickle/cassandra-reaper:f52e877".
                   TODO: update with real release version.
                 properties:
                   name:

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -27483,10 +27483,10 @@ spec:
                     default:
                       name: cassandra-reaper
                       repository: thelastpickle
-                      tag: 3.6.0
+                      tag: f52e877
                     description: |-
                       The image to use for the Reaper pod main container.
-                      The default is "thelastpickle/cassandra-reaper:3.6.0".
+                      The default is "thelastpickle/cassandra-reaper:f52e877".
                       TODO: update with real release version.
                     properties:
                       name:

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1110,10 +1110,10 @@ spec:
                 default:
                   name: cassandra-reaper
                   repository: thelastpickle
-                  tag: 3.6.0
+                  tag: f52e877
                 description: |-
                   The image to use for the Reaper pod main container.
-                  The default is "thelastpickle/cassandra-reaper:3.6.0".
+                  The default is "thelastpickle/cassandra-reaper:f52e877".
                   TODO: update with real release version.
                 properties:
                   name:

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -197,6 +197,9 @@ func testCreateReaper(t *testing.T, ctx context.Context, k8sClient client.Client
 	// init container should use the same image and tag as the main container.
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Image, deployment.Spec.Template.Spec.InitContainers[0].Image)
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy, deployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
+	assert.Equal(t, deployment.Spec.Template.Spec.Volumes[0].Name, "conf", "deployment should have a volume for the config")
+	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name, "conf", "deployment should have a volume for the config")
+	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath, "/etc/cassandra-reaper/config", "deployment should have a volume for the config")
 
 	// main container is a custom image where the tag isn't specified, so it should default to latest, and pull policy
 	// to Always.

--- a/pkg/reaper/deployment.go
+++ b/pkg/reaper/deployment.go
@@ -24,7 +24,7 @@ import (
 const (
 	DefaultImageRepository = "thelastpickle"
 	DefaultImageName       = "cassandra-reaper"
-	DefaultVersion         = "3.6.0"
+	DefaultVersion         = "f52e877"
 	// When changing the default version above, please also change the kubebuilder markers in
 	// apis/reaper/v1alpha1/reaper_types.go accordingly.
 
@@ -169,8 +169,20 @@ func NewDeployment(reaper *api.Reaper, dc *cassdcapi.CassandraDatacenter, keysto
 		}
 	}
 
-	volumeMounts := []corev1.VolumeMount{}
-	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "conf",
+			MountPath: "/etc/cassandra-reaper/config",
+		},
+	}
+	volumes := []corev1.Volume{
+		{
+			Name: "conf",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 	// if client encryption is turned on, we need to mount the keystore and truststore volumes
 	if reaper.Spec.ClientEncryptionStores != nil && keystorePassword != nil && truststorePassword != nil {
 		keystoreVolume, truststoreVolume := cassandra.EncryptionVolumes(encryption.StoreTypeClient, *reaper.Spec.ClientEncryptionStores)

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -343,8 +343,8 @@ func TestImages(t *testing.T) {
 		reaper.Spec.ContainerImage = nil
 		logger := testlogr.NewTestLogger(t)
 		deployment := NewDeployment(reaper, newTestDatacenter(), nil, nil, logger)
-		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:3.6.0", deployment.Spec.Template.Spec.InitContainers[0].Image)
-		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:3.6.0", deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:f52e877", deployment.Spec.Template.Spec.InitContainers[0].Image)
+		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:f52e877", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)
@@ -354,8 +354,8 @@ func TestImages(t *testing.T) {
 		reaper.Spec.ContainerImage = nil
 		logger := testlogr.NewTestLogger(t)
 		deployment := NewDeployment(reaper, newTestDatacenter(), nil, nil, logger)
-		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:3.6.0", deployment.Spec.Template.Spec.InitContainers[0].Image)
-		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:3.6.0", deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:f52e877", deployment.Spec.Template.Spec.InitContainers[0].Image)
+		assert.Equal(t, "docker.io/thelastpickle/cassandra-reaper:f52e877", deployment.Spec.Template.Spec.Containers[0].Image)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy)
 		assert.Equal(t, corev1.PullIfNotPresent, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 		assert.Empty(t, deployment.Spec.Template.Spec.ImagePullSecrets)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds an emptyDir mount on the Reaper deployment to allow using stronger security with the read only FS and use it with any uid.


**Which issue(s) this PR fixes**:
Fixes #1329 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
