### PR TITLE
Clean up MedusaBackupJobs and propagate MedusaTask labels

### DIFF
--- a/CHANGELOG/CHANGELOG-1.14.md
+++ b/CHANGELOG/CHANGELOG-1.14.md
@@ -13,6 +13,11 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+
+* [BUGFIX] [#1334](https://github.com/k8ssandra/k8ssandra-operator/issues/1334) Delete `MedusaBackupJobs` during purge
+* [BUGFIX] [#1336](https://github.com/k8ssandra/k8ssandra-operator/issues/1336) Propagate labels to the sync `MedusaTask` created after purge
+
 ## v1.14.0 - 2024-04-02
 
 * [FEATURE] [#1242](https://github.com/k8ssandra/k8ssandra-operator/issues/1242) Allow for creation of replicated secrets with a prefix, so that we can distinguish between multiple secrets with the same origin but targeting different clusters.

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -36,6 +36,7 @@ const (
 	fakeBackupFileCount = int64(13)
 	fakeBackupByteSize  = int64(42)
 	fakeBackupHumanSize = "42.00 B"
+	fakeMaxBackupCount  = 1
 )
 
 func testMedusaBackupDatacenter(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
@@ -395,8 +396,13 @@ func (c *fakeMedusaClient) BackupStatus(ctx context.Context, name string) (*medu
 }
 
 func (c *fakeMedusaClient) PurgeBackups(ctx context.Context) (*medusa.PurgeBackupsResponse, error) {
+	size := len(c.RequestedBackups)
+	if size > fakeMaxBackupCount {
+		c.RequestedBackups = c.RequestedBackups[size-fakeMaxBackupCount:]
+	}
+
 	response := &medusa.PurgeBackupsResponse{
-		NbBackupsPurged:           2,
+		NbBackupsPurged:           int32(size - len(c.RequestedBackups)),
 		NbObjectsPurged:           10,
 		TotalObjectsWithinGcGrace: 0,
 		TotalPurgedSize:           1000,

--- a/controllers/medusa/medusatask_controller.go
+++ b/controllers/medusa/medusatask_controller.go
@@ -301,6 +301,20 @@ func (r *MedusaTaskReconciler) syncOperation(ctx context.Context, task *medusav1
 						return ctrl.Result{}, err
 					} else {
 						logger.Info("Deleted Cassandra Backup", "Backup", backup.ObjectMeta.Name)
+
+						backupJob := medusav1alpha1.MedusaBackupJob{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      backup.GetName(),
+								Namespace: backup.GetNamespace(),
+							},
+						}
+						logger.Info("Deleting MedusaBackupJob", "MedusaBackupJob", backupJob.GetName())
+
+						if err := r.Delete(ctx, &backupJob); err != nil && !errors.IsNotFound(err) {
+							logger.Error(err, "failed to delete MedusaBackupJob", "MedusaBackupJob", backupJob.GetName())
+						} else {
+							logger.Info("Deleted MedusaBackupJob", "MedusaBackupJob", backupJob.GetName())
+						}
 					}
 				}
 			}
@@ -377,6 +391,7 @@ func (r *MedusaTaskReconciler) scheduleSyncForPurge(task *medusav1alpha1.MedusaT
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      task.GetObjectMeta().GetName() + "-sync",
 					Namespace: task.Namespace,
+					Labels:    task.GetLabels(),
 				},
 				Spec: medusav1alpha1.MedusaTaskSpec{
 					Operation:           medusav1alpha1.OperationTypeSync,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Delete `MedusaBackupJobs` during purging
- Propagate labels to the sync `MedusaTask` created after purge

**Which issue(s) this PR fixes**:
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1334
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1336

**Checklist**
- [ ] Changes manually tested
- [X] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
