### PR TITLE
Enhance the MedusaBackupSchedule API to trigger purge tasks

### DIFF
--- a/CHANGELOG/CHANGELOG-1.18.md
+++ b/CHANGELOG/CHANGELOG-1.18.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [FEATURE] [#1310](https://github.com/k8ssandra/k8ssandra-operator/issues/1310) Enhance the MedusaBackupSchedule API to allow scheduling purge tasks

--- a/apis/medusa/v1alpha1/medusaschedule_types.go
+++ b/apis/medusa/v1alpha1/medusaschedule_types.go
@@ -39,6 +39,12 @@ type MedusaBackupScheduleSpec struct {
 	// The "Allow" property is only valid if all the other active Tasks have "Allow" as well.
 	// +optional
 	ConcurrencyPolicy batchv1.ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
+
+	// Specifies the type of operation to be performed
+	// +kubebuilder:validation:Enum=backup;purge
+	// +kubebuilder:default=backup
+	// +optional
+	OperationType string `json:"operationType,omitempty"`
 }
 
 // MedusaBackupScheduleStatus defines the observed state of MedusaBackupSchedule

--- a/apis/medusa/v1alpha1/medusaschedule_types.go
+++ b/apis/medusa/v1alpha1/medusaschedule_types.go
@@ -62,7 +62,7 @@ type MedusaBackupScheduleStatus struct {
 // +kubebuilder:printcolumn:name="Datacenter",type=string,JSONPath=".spec.backupSpec.cassandraDatacenter",description="Datacenter which the task targets"
 // +kubebuilder:printcolumn:name="ScheduledExecution",type="date",JSONPath=".status.nextSchedule",description="Next scheduled execution time"
 // +kubebuilder:printcolumn:name="LastExecution",type="date",JSONPath=".status.lastExecution",description="Previous execution time"
-// +kubebuilder:printcolumn:name="BackupType",type="string",JSONPath=".spec.backupSpec.backupType",description="Type of backup"
+// +kubebuilder:printcolumn:name="OperationType",type="string",JSONPath=".spec.operationType",description="Type of scheduled operation"
 // MedusaBackupSchedule is the Schema for the medusabackupschedules API
 type MedusaBackupSchedule struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/medusa/v1alpha1/medusatask_types.go
+++ b/apis/medusa/v1alpha1/medusatask_types.go
@@ -90,6 +90,10 @@ const (
 //+kubebuilder:subresource:status
 
 // MedusaTask is the Schema for the MedusaTasks API
+// +kubebuilder:printcolumn:name="Datacenter",type=string,JSONPath=".spec.cassandraDatacenter",description="Datacenter which the task targets"
+// +kubebuilder:printcolumn:name="Operation",type="string",JSONPath=".spec.operation",description="Type of operation"
+// +kubebuilder:printcolumn:name="Start",type="date",JSONPath=".status.startTime",description="Start time"
+// +kubebuilder:printcolumn:name="Finish",type="date",JSONPath=".status.finishTime",description="Finish time"
 type MedusaTask struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -31708,9 +31708,9 @@ spec:
       jsonPath: .status.lastExecution
       name: LastExecution
       type: date
-    - description: Type of backup
-      jsonPath: .spec.backupSpec.backupType
-      name: BackupType
+    - description: Type of scheduled operation
+      jsonPath: .spec.operationType
+      name: OperationType
       type: string
     name: v1alpha1
     schema:
@@ -32191,7 +32191,24 @@ spec:
     singular: medusatask
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Datacenter which the task targets
+      jsonPath: .spec.cassandraDatacenter
+      name: Datacenter
+      type: string
+    - description: Type of operation
+      jsonPath: .spec.operation
+      name: Operation
+      type: string
+    - description: Start time
+      jsonPath: .status.startTime
+      name: Start
+      type: date
+    - description: Finish time
+      jsonPath: .status.finishTime
+      name: Finish
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MedusaTask is the Schema for the MedusaTasks API

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -31771,6 +31771,13 @@ spec:
               disabled:
                 description: Disabled if set ensures this job is not scheduling anything
                 type: boolean
+              operationType:
+                default: backup
+                description: Specifies the type of operation to be performed
+                enum:
+                - backup
+                - purge
+                type: string
             required:
             - backupSpec
             - cronSchedule

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
@@ -90,6 +90,13 @@ spec:
               disabled:
                 description: Disabled if set ensures this job is not scheduling anything
                 type: boolean
+              operationType:
+                default: backup
+                description: Specifies the type of operation to be performed
+                enum:
+                - backup
+                - purge
+                type: string
             required:
             - backupSpec
             - cronSchedule

--- a/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusabackupschedules.yaml
@@ -27,9 +27,9 @@ spec:
       jsonPath: .status.lastExecution
       name: LastExecution
       type: date
-    - description: Type of backup
-      jsonPath: .spec.backupSpec.backupType
-      name: BackupType
+    - description: Type of scheduled operation
+      jsonPath: .spec.operationType
+      name: OperationType
       type: string
     name: v1alpha1
     schema:

--- a/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusatasks.yaml
@@ -14,7 +14,24 @@ spec:
     singular: medusatask
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Datacenter which the task targets
+      jsonPath: .spec.cassandraDatacenter
+      name: Datacenter
+      type: string
+    - description: Type of operation
+      jsonPath: .spec.operation
+      name: Operation
+      type: string
+    - description: Start time
+      jsonPath: .status.startTime
+      name: Start
+      type: date
+    - description: Finish time
+      jsonPath: .status.finishTime
+      name: Finish
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MedusaTask is the Schema for the MedusaTasks API

--- a/controllers/medusa/medusabackupschedule_controller.go
+++ b/controllers/medusa/medusabackupschedule_controller.go
@@ -215,13 +215,13 @@ func (r *MedusaBackupScheduleReconciler) activeTasks(backupSchedule *medusav1alp
 
 		return len(activeJobs), nil
 	} else if operationType == string(medusav1alpha1.OperationTypePurge) {
-		purgeJobs := &medusav1alpha1.MedusaTaskList{}
-		if err := r.Client.List(context.Background(), purgeJobs, client.InNamespace(backupSchedule.Namespace), client.MatchingLabels(dc.GetDatacenterLabels())); err != nil {
+		medusaTasks := &medusav1alpha1.MedusaTaskList{}
+		if err := r.Client.List(context.Background(), medusaTasks, client.InNamespace(backupSchedule.Namespace), client.MatchingLabels(dc.GetDatacenterLabels())); err != nil {
 			return 0, err
 		}
 		activeJobs := make([]medusav1alpha1.MedusaTask, 0)
-		for _, job := range purgeJobs.Items {
-			if job.Status.FinishTime.IsZero() {
+		for _, job := range medusaTasks.Items {
+			if job.Spec.Operation == medusav1alpha1.OperationTypePurge && job.Status.FinishTime.IsZero() {
 				activeJobs = append(activeJobs, job)
 			}
 		}

--- a/controllers/medusa/medusabackupschedule_controller.go
+++ b/controllers/medusa/medusabackupschedule_controller.go
@@ -92,7 +92,6 @@ func (r *MedusaBackupScheduleReconciler) Reconcile(ctx context.Context, req ctrl
 			return ctrl.Result{}, err
 		} else {
 			logger.Info("updated task with owner reference", "CassandraDatacenter", dcKey)
-			return ctrl.Result{}, nil
 		}
 	}
 

--- a/controllers/medusa/medusabackupschedule_controller_test.go
+++ b/controllers/medusa/medusabackupschedule_controller_test.go
@@ -2,6 +2,7 @@ package medusa
 
 import (
 	"context"
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"testing"
 	"time"
 
@@ -24,160 +25,316 @@ func (f *FakeClock) Now() time.Time {
 
 var _ Clock = &FakeClock{}
 
-// func TestScheduler(t *testing.T) {
-// 	require := require.New(t)
-// 	require.NoError(medusav1alpha1.AddToScheme(scheme.Scheme))
-// 	require.NoError(cassdcapi.AddToScheme(scheme.Scheme))
+func TestScheduler(t *testing.T) {
+	require := require.New(t)
+	require.NoError(medusav1alpha1.AddToScheme(scheme.Scheme))
+	require.NoError(cassdcapi.AddToScheme(scheme.Scheme))
 
-// 	fClock := &FakeClock{}
+	fClock := &FakeClock{}
 
-// 	dc := cassdcapi.CassandraDatacenter{
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Name:      "dc1",
-// 			Namespace: "test-ns",
-// 		},
-// 		Spec: cassdcapi.CassandraDatacenterSpec{},
-// 	}
+	dc := cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "test-ns",
+		},
+		Spec: cassdcapi.CassandraDatacenterSpec{},
+	}
 
-// 	// To manipulate time and requeue, we use fakeclient here instead of envtest
-// 	backupSchedule := &medusav1alpha1.MedusaBackupSchedule{
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Name:      "test-schedule",
-// 			Namespace: "test-ns",
-// 		},
-// 		Spec: medusav1alpha1.MedusaBackupScheduleSpec{
-// 			CronSchedule: "* * * * *",
-// 			BackupSpec: medusav1alpha1.MedusaBackupJobSpec{
-// 				CassandraDatacenter: "dc1",
-// 				Type:                "differential",
-// 			},
-// 		},
-// 	}
+	// To manipulate time and requeue, we use fakeclient here instead of envtest
+	backupSchedule := &medusav1alpha1.MedusaBackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-schedule",
+			Namespace: "test-ns",
+		},
+		Spec: medusav1alpha1.MedusaBackupScheduleSpec{
+			CronSchedule: "* * * * *",
+			BackupSpec: medusav1alpha1.MedusaBackupJobSpec{
+				CassandraDatacenter: "dc1",
+				Type:                "differential",
+			},
+		},
+	}
 
-// 	fakeClient := fake.NewClientBuilder().
-// 		WithRuntimeObjects(backupSchedule, &dc).
-// 		WithScheme(scheme.Scheme).
-// 		Build()
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(backupSchedule, &dc).
+		WithStatusSubresource(backupSchedule).
+		WithScheme(scheme.Scheme).
+		Build()
 
-// 	nsName := types.NamespacedName{
-// 		Name:      backupSchedule.Name,
-// 		Namespace: backupSchedule.Namespace,
-// 	}
+	nsName := types.NamespacedName{
+		Name:      backupSchedule.Name,
+		Namespace: backupSchedule.Namespace,
+	}
 
-// 	r := &MedusaBackupScheduleReconciler{
-// 		Client: fakeClient,
-// 		Scheme: scheme.Scheme,
-// 		Clock:  fClock,
-// 	}
+	r := &MedusaBackupScheduleReconciler{
+		Client: fakeClient,
+		Scheme: scheme.Scheme,
+		Clock:  fClock,
+	}
 
-// 	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute).Add(1 * time.Second)
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute).Add(1 * time.Second)
 
-// 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	// We should have a backup now..
-// 	backupRequests := medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(1, len(backupRequests.Items))
+	// We should have a backup now..
+	backupRequests := medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(1, len(backupRequests.Items))
 
-// 	// Ensure the backup object is created correctly
-// 	backup := backupRequests.Items[0]
-// 	require.Equal(backupSchedule.Spec.BackupSpec.CassandraDatacenter, backup.Spec.CassandraDatacenter)
-// 	require.Equal(backupSchedule.Spec.BackupSpec.Type, backup.Spec.Type)
+	// Ensure the backup object is created correctly
+	backup := backupRequests.Items[0]
+	require.Equal(backupSchedule.Spec.BackupSpec.CassandraDatacenter, backup.Spec.CassandraDatacenter)
+	require.Equal(backupSchedule.Spec.BackupSpec.Type, backup.Spec.Type)
 
-// 	// Verify the Status of the BackupSchedule is modified and the object is requeued
-// 	backupScheduleLive := &medusav1alpha1.MedusaBackupSchedule{}
-// 	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
-// 	require.NoError(err)
+	// Verify the Status of the BackupSchedule is modified and the object is requeued
+	backupScheduleLive := &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
 
-// 	require.Equal(fClock.currentTime, backupScheduleLive.Status.LastExecution.Time.UTC())
-// 	require.Equal(time.Time{}.Add(2*time.Minute), backupScheduleLive.Status.NextSchedule.Time.UTC())
+	require.Equal(fClock.currentTime, backupScheduleLive.Status.LastExecution.Time.UTC())
+	require.Equal(time.Time{}.Add(2*time.Minute), backupScheduleLive.Status.NextSchedule.Time.UTC())
 
-// 	// Test that next invocation also works
-// 	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
+	// Test that next invocation also works
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
 
-// 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	// We should not have more than 1, since we never set the previous one as finished
-// 	backupRequests = medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(1, len(backupRequests.Items))
+	// We should not have more than 1, since we never set the previous one as finished
+	backupRequests = medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(1, len(backupRequests.Items))
 
-// 	// Mark the first one as finished and try again
-// 	backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
-// 	require.NoError(fakeClient.Update(context.TODO(), &backup))
+	// Mark the first one as finished and try again
+	backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
+	require.NoError(fakeClient.Update(context.TODO(), &backup))
 
-// 	backupRequests = medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(1, len(backupRequests.Items))
+	backupRequests = medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(1, len(backupRequests.Items))
 
-// 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	backupRequests = medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(2, len(backupRequests.Items))
+	backupRequests = medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(2, len(backupRequests.Items))
 
-// 	for _, backup := range backupRequests.Items {
-// 		backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
-// 		require.NoError(fakeClient.Update(context.TODO(), &backup))
-// 	}
+	for _, backup := range backupRequests.Items {
+		backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
+		require.NoError(fakeClient.Update(context.TODO(), &backup))
+	}
 
-// 	// Verify that invocating again without reaching the next time does not generate another backup
-// 	// or modify the Status
-// 	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
-// 	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
-// 	require.NoError(err)
+	// Verify that invocating again without reaching the next time does not generate another backup
+	// or modify the Status
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
 
-// 	previousExecutionTime := backupScheduleLive.Status.LastExecution
-// 	fClock.currentTime = fClock.currentTime.Add(30 * time.Second)
-// 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	previousExecutionTime := backupScheduleLive.Status.LastExecution
+	fClock.currentTime = fClock.currentTime.Add(30 * time.Second)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	backupRequests = medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(2, len(backupRequests.Items))
+	backupRequests = medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(2, len(backupRequests.Items))
 
-// 	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
-// 	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
-// 	require.NoError(err)
-// 	require.Equal(previousExecutionTime, backupScheduleLive.Status.LastExecution)
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+	require.Equal(previousExecutionTime, backupScheduleLive.Status.LastExecution)
 
-// 	// Set to disabled and verify that the backups aren't scheduled anymore - but the status is updated
-// 	backupScheduleLive.Spec.Disabled = true
-// 	err = fakeClient.Update(context.TODO(), backupScheduleLive)
-// 	require.NoError(err)
+	// Set to disabled and verify that the backups aren't scheduled anymore - but the status is updated
+	backupScheduleLive.Spec.Disabled = true
+	err = fakeClient.Update(context.TODO(), backupScheduleLive)
+	require.NoError(err)
 
-// 	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
 
-// 	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
-// 	require.NoError(err)
-// 	require.True(res.RequeueAfter > 0)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
 
-// 	backupRequests = medusav1alpha1.MedusaBackupJobList{}
-// 	err = fakeClient.List(context.TODO(), &backupRequests)
-// 	require.NoError(err)
-// 	require.Equal(2, len(backupRequests.Items)) // No new items were created
+	backupRequests = medusav1alpha1.MedusaBackupJobList{}
+	err = fakeClient.List(context.TODO(), &backupRequests)
+	require.NoError(err)
+	require.Equal(2, len(backupRequests.Items)) // No new items were created
 
-// 	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
-// 	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
-// 	require.NoError(err)
-// 	require.True(previousExecutionTime.Before(&backupScheduleLive.Status.LastExecution)) // Status time is still updated
-// }
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+	require.True(previousExecutionTime.Before(&backupScheduleLive.Status.LastExecution)) // Status time is still updated
+}
+
+func TestPurgeScheduler(t *testing.T) {
+	require := require.New(t)
+	require.NoError(medusav1alpha1.AddToScheme(scheme.Scheme))
+	require.NoError(cassdcapi.AddToScheme(scheme.Scheme))
+
+	fClock := &FakeClock{}
+
+	dc := cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "test-ns",
+		},
+		Spec: cassdcapi.CassandraDatacenterSpec{},
+	}
+
+	// To manipulate time and requeue, we use fakeclient here instead of envtest
+	purgeSchedule := &medusav1alpha1.MedusaBackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-purge-schedule",
+			Namespace: "test-ns",
+		},
+		Spec: medusav1alpha1.MedusaBackupScheduleSpec{
+			CronSchedule: "* * * * *",
+			BackupSpec: medusav1alpha1.MedusaBackupJobSpec{
+				CassandraDatacenter: "dc1",
+			},
+			OperationType: "purge",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(purgeSchedule, &dc).
+		WithStatusSubresource(purgeSchedule).
+		WithScheme(scheme.Scheme).
+		Build()
+
+	nsName := types.NamespacedName{
+		Name:      purgeSchedule.Name,
+		Namespace: purgeSchedule.Namespace,
+	}
+
+	r := &MedusaBackupScheduleReconciler{
+		Client: fakeClient,
+		Scheme: scheme.Scheme,
+		Clock:  fClock,
+	}
+
+	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute).Add(1 * time.Second)
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	// We should have a backup now..
+	purgeTasks := medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(1, len(purgeTasks.Items))
+
+	// Ensure the backup object is created correctly
+	backup := purgeTasks.Items[0]
+	require.Equal(purgeSchedule.Spec.BackupSpec.CassandraDatacenter, backup.Spec.CassandraDatacenter)
+
+	// Verify the Status of the BackupSchedule is modified and the object is requeued
+	backupScheduleLive := &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+
+	require.Equal(fClock.currentTime, backupScheduleLive.Status.LastExecution.Time.UTC())
+	require.Equal(time.Time{}.Add(2*time.Minute), backupScheduleLive.Status.NextSchedule.Time.UTC())
+
+	// Test that next invocation also works
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	// We should not have more than 1, since we never set the previous one as finished
+	purgeTasks = medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(1, len(purgeTasks.Items))
+
+	// Mark the first one as finished and try again
+	backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
+	require.NoError(fakeClient.Update(context.TODO(), &backup))
+
+	purgeTasks = medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(1, len(purgeTasks.Items))
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	purgeTasks = medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(2, len(purgeTasks.Items))
+
+	for _, backup := range purgeTasks.Items {
+		backup.Status.FinishTime = metav1.NewTime(fClock.currentTime)
+		require.NoError(fakeClient.Update(context.TODO(), &backup))
+	}
+
+	// Verify that invocating again without reaching the next time does not generate another backup
+	// or modify the Status
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+
+	previousExecutionTime := backupScheduleLive.Status.LastExecution
+	fClock.currentTime = fClock.currentTime.Add(30 * time.Second)
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	purgeTasks = medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(2, len(purgeTasks.Items))
+
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+	require.Equal(previousExecutionTime, backupScheduleLive.Status.LastExecution)
+
+	// Set to disabled and verify that the backups aren't scheduled anymore - but the status is updated
+	backupScheduleLive.Spec.Disabled = true
+	err = fakeClient.Update(context.TODO(), backupScheduleLive)
+	require.NoError(err)
+
+	fClock.currentTime = fClock.currentTime.Add(1 * time.Minute)
+
+	_, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: nsName})
+	require.NoError(err)
+	require.True(res.RequeueAfter > 0)
+
+	purgeTasks = medusav1alpha1.MedusaTaskList{}
+	err = fakeClient.List(context.TODO(), &purgeTasks)
+	require.NoError(err)
+	require.Equal(2, len(purgeTasks.Items)) // No new items were created
+
+	backupScheduleLive = &medusav1alpha1.MedusaBackupSchedule{}
+	err = fakeClient.Get(context.TODO(), nsName, backupScheduleLive)
+	require.NoError(err)
+	require.True(previousExecutionTime.Before(&backupScheduleLive.Status.LastExecution)) // Status time is still updated
+}
 
 func TestSchedulerParseError(t *testing.T) {
 	require := require.New(t)

--- a/test/testdata/fixtures/single-dc-encryption-medusa/kustomization.yaml
+++ b/test/testdata/fixtures/single-dc-encryption-medusa/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - k8ssandra.yaml
+  - medusa-purge.yaml

--- a/test/testdata/fixtures/single-dc-encryption-medusa/medusa-purge.yaml
+++ b/test/testdata/fixtures/single-dc-encryption-medusa/medusa-purge.yaml
@@ -1,0 +1,10 @@
+apiVersion: medusa.k8ssandra.io/v1alpha1
+kind: MedusaBackupSchedule
+metadata:
+  name: purge-schedule
+  namespace: k8ssandra-operator
+spec:
+  backupSpec:
+    cassandraDatacenter: dc1
+  cronSchedule: '* * * * *'
+  operationType: purge


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Extend the capabilities of the MedusaBackupSchedule API to allow it to schedule purge tasks as well.

**Which issue(s) this PR fixes**:
Fixes #1310

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
