### PR TITLE
Consider DC-level config when validating numToken updates in webhook (fixes #1222)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.18.md
+++ b/CHANGELOG/CHANGELOG-1.18.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [FEATURE] [#1310](https://github.com/k8ssandra/k8ssandra-operator/issues/1310) Enhance the MedusaBackupSchedule API to allow scheduling purge tasks
+* [BUGFIX] [#1222](https://github.com/k8ssandra/k8ssandra-operator/issues/1222) Consider DC-level config when validating numToken updates in webhook

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/Masterminds/semver/v3"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	medusaapi "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
@@ -540,13 +539,6 @@ func (sd *ServerDistribution) IsCassandra() bool {
 
 func (sd *ServerDistribution) IsDse() bool {
 	return *sd == ServerDistributionDse
-}
-
-func (kc *K8ssandraCluster) DefaultNumTokens(serverVersion *semver.Version) float64 {
-	if kc.Spec.Cassandra.ServerType.IsCassandra() && serverVersion.Major() == 3 {
-		return float64(256)
-	}
-	return float64(16)
 }
 
 // GetClusterIdHash should be used to derive short form unique identifiers for the cluster,

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_webhook_test.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_webhook_test.go
@@ -216,6 +216,7 @@ func testStorageConfigValidation(t *testing.T) {
 	required := require.New(t)
 	createNamespace(required, "storage-namespace")
 	cluster := createMinimalClusterObj("storage-test", "storage-namespace")
+	cluster.Spec.Cassandra.DatacenterOptions.ServerVersion = "3.11.10"
 
 	cluster.Spec.Cassandra.DatacenterOptions.StorageConfig = nil
 	err := k8sClient.Create(ctx, cluster)


### PR DESCRIPTION
**What this PR does**:
Instead of only comparing the top-level config (which can fail if fields are missing), compute and compare the numToken of each individual DC, using the inheritance and defaulting rules.
This also covers cases that were not handled before, like config being nil on one side but not the other.

**Which issue(s) this PR fixes**:
Fixes #1222

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
