### PR TITLE
Add certificates settings for medusa encryption

### DIFF
--- a/CHANGELOG/CHANGELOG-1.19.md
+++ b/CHANGELOG/CHANGELOG-1.19.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [FEATURE] Add customizable TLS certificate settings for Medusa

--- a/apis/medusa/v1alpha1/medusa_types.go
+++ b/apis/medusa/v1alpha1/medusa_types.go
@@ -117,6 +117,25 @@ type Storage struct {
 	PodStorage *PodStorageSettings `json:"podStorage,omitempty"`
 }
 
+type Certificates struct {
+	// Settings for TLS certificates used when client-side encryption is enabled with Medusa.
+
+	// Custom name for the CA certificate key in the Secret.
+	// Defaults to 'rootca.crt.
+	// +optional
+	Certfile string `json:"certfile,omitempty"`
+
+	// Custom name for the client certificate key in the Secret.
+	// Defaults to 'client.crt_signed'.
+	// +optional
+	Usercert string `json:"usercert,omitempty"`
+
+	// Custom name for the client private key in the Secret.
+	// Defaults to 'client.key'.
+	// +optional
+	Userkey string `json:"userkey,omitempty"`
+}
+
 type PodStorageSettings struct {
 	// Settings for the pod's storage when backups use the local storage provider.
 
@@ -161,10 +180,15 @@ type MedusaClusterTemplate struct {
 	StorageProperties Storage `json:"storageProperties,omitempty"`
 
 	// Certificates for Medusa if client encryption is enabled in Cassandra.
-	// The secret must be in the same namespace as Cassandra and must contain three keys: "rootca.crt", "client.crt_signed" and "client.key".
+	// The Secret should be in the same namespace as the Cassandra instance and must include the keys for the CA certificate, client certificate, and client private key.
+    // By default, the keys in the Secret are expected to be named "rootca.crt", "client.crt_signed", and "client.key". However, these names can be customized using the 'certfile', 'usercert', and 'userkey' options.
 	// See https://docs.datastax.com/en/developer/python-driver/latest/security/ for more information on the required files.
 	// +optional
 	CertificatesSecretRef corev1.LocalObjectReference `json:"certificatesSecretRef,omitempty"`
+
+    // Certificates settings for Medusa if client encryption is enabled in Cassandra.
+	// +optional
+	CertificatesSettings Certificates `json:"certificatesSettings,omitempty"`
 
 	// medusa-restore init container resources.
 	// +optional

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -25696,6 +25696,30 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  certificatesSettings:
+                    description: "Settings for TLS certificates used when client-side encryption
+                      is enabled with Medusa. The Secret must reside in the same namespace
+                      as the Cassandra instance. It must contain keys for the CA certificate,
+                      client certificate, and client private key. Custom names for these keys can
+                      be specified. See https://docs.datastax.com/en/developer/python-driver/latest/security/
+                      for more information on the required files."
+                    properties:
+                      certfile:
+                        default: rootca.crt
+                        description: "Custom name for the CA certificate key within the Secret's `data` field.
+                          Defaults to 'rootca.crt' if not specified"
+                        type: string
+                      usercert:
+                        default: client.crt_signed
+                        description: "Custom name for the client certificate key within the Secret's `data` field.
+                          Defaults to 'client.crt_signed' if not specified."
+                        type: string
+                      userkey:
+                        default: client.key
+                        description: "Custom name for the client private key within the Secret's `data` field.
+                          Defaults to 'client.key' if not specified."
+                        type: string
+                    type: object
                   containerImage:
                     description: |-
                       MedusaContainerImage is the image characteristics to use for Medusa containers. Leave nil

--- a/docs/content/en/tasks/secure/encryption/_index.md
+++ b/docs/content/en/tasks/secure/encryption/_index.md
@@ -241,6 +241,10 @@ spec:
   medusa:
     certificatesSecretRef:
       name: client-certificates
+    certificatesSettings:
+      certfile: rootca.crt
+      usercert: client.crt_signed
+      userkey: client.key
 ```
 
 This will provide Medusa with the client certificate and key, as well as the root CA certificate, which will be used to connect to the Cassandra cluster through the Python Driver.

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -58,9 +58,9 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster, dcConfig *cassandra.DatacenterCo
     [cassandra]
     use_sudo = false
     {{- if .Spec.Medusa.CertificatesSecretRef.Name }}
-    certfile = /etc/certificates/rootca.crt
-    usercert = /etc/certificates/client.crt_signed
-    userkey = /etc/certificates/client.key
+    certfile = /etc/certificates/{{ .Spec.Medusa.CertificatesSettings.Certfile }}
+    usercert = /etc/certificates/{{ .Spec.Medusa.CertificatesSettings.Usercert }}
+    userkey = /etc/certificates/{{ .Spec.Medusa.CertificatesSettings.Userkey }}
     {{- end}}
 
     [storage]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR enhances the K8ssandra Operator by adding customizable TLS certificate settings for Medusa client-side encryption. Specifically, it introduces a new `certificatesSettings` configuration option, which allows users to specify custom names for the CA certificate, client certificate, and client private key within the Secret's `data` field. 

This enhancement ensures compatibility with CertManager by allowing users to map the standard CertManager keys (`ca.crt`, `tls.crt`, `tls.key`) to the Medusa configuration:

```hcl
"medusa" = {
  "certificatesSettings" = {
    "certfile" = "ca.crt"
    "usercert" = "tls.crt"
    "userkey"  = "tls.key"
  }
}
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
