### PR TITLE
fix(main): SecretSyncController split namespaces

### DIFF
--- a/CHANGELOG/CHANGELOG-1.20.md
+++ b/CHANGELOG/CHANGELOG-1.20.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [BUGFIX] [#1399](https://github.com/k8ssandra/k8ssandra-operator/issues/1399) Fixed SecretSyncController to handle multiple namespaces

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func main() {
 		if err = (&replicationctrl.SecretSyncController{
 			ReconcilerConfig: reconcilerConfig,
 			ClientCache:      clientCache,
-			WatchNamespaces:  []string{watchNamespace},
+			WatchNamespaces:  strings.Split(watchNamespace, ","),
 		}).SetupWithManager(mgr, additionalClusters, setupLog); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SecretSync")
 			os.Exit(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Splits WatchNamespaces when multiple namespaces provided (WATCH_NAMESPACE)

**Which issue(s) this PR fixes**:
Fixes #1399

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
