### PR TITLE
Upgrade cass-operator helm chart to 0.54.0 (v1.22.4)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.20.md
+++ b/CHANGELOG/CHANGELOG-1.20.md
@@ -13,6 +13,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+
+* [CHANGE] Upgrade cass-operator's chart to 0.54.0 (v1.22.4) to allow overriding default image coordinates
+
 ## v1.20.2 - 2024-10-07
 
 * [DOCS] [#1469](https://github.com/riptano/mission-control/issues/1469) Add docs for Reaper's Control Plane deployment mode

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.29.0
     repository: https://helm.k8ssandra.io
   - name: cass-operator
-    version: 0.53.6
+    version: 0.54.0
     repository: https://helm.k8ssandra.io
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:


### PR DESCRIPTION
**What this PR does**:
This PR upgrades the cass-operator helm chart to expose overrides of default images coordinates through helm values.

Dependency updates:

* [`charts/k8ssandra-operator/Chart.yaml`](diffhunk://#diff-1ad1e57ec5f65e79d8d2be95719740c89be6217f8733bc146507e340c9d6be4fL12-R12): Upgraded cass-operator's chart version from 0.53.6 to 0.54.0.

Changelog updates:

* [`CHANGELOG/CHANGELOG-1.20.md`](diffhunk://#diff-3a4c5b444c73d6919c70efdaf7f70a4aa663f17a09f1b63d4ba1f7a6143f15a9R16-R19): Added an entry under the `unreleased` section to document the upgrade of cass-operator's chart to version 0.54.0.

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
