### PR TITLE
K8OP-294 Do not try to work out backup status if there are no pods

### DIFF
--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#1383](https://github.com/k8ssandra/k8ssandra-operator/issues/1383) Do not create MedusaBackup if MedusaBakupJob did not fully succeed
 * [ENHANCEMENT] [#1667](https://github.com/k8ssahttps://github.com/k8ssandra/k8ssandra/issues/1667) Add `skipSchemaMigration` option to `K8ssandraCluster.spec.reaper`
 * [FEATURE] [#1034](https://github.com/k8ssandra/k8ssandra-operator/issues/1034) Add support for priorityClassName
+* [BUGFIX] [#1454](https://github.com/k8ssandra/k8ssandra-operator/issues/1454) Do not try to work out backup status if there are no pods

--- a/controllers/medusa/medusabackupjob_controller.go
+++ b/controllers/medusa/medusabackupjob_controller.go
@@ -18,7 +18,6 @@ package medusa
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -34,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
@@ -253,7 +253,7 @@ func (r *MedusaBackupJobReconciler) getBackupSummary(ctx context.Context, backup
 			}
 		}
 	}
-	return nil, errors.New("backup summary couldn't be found")
+	return nil, reconcile.TerminalError(fmt.Errorf("backup summary couldn't be found"))
 }
 
 func (r *MedusaBackupJobReconciler) createMedusaBackup(ctx context.Context, backup *medusav1alpha1.MedusaBackupJob, backupSummary *medusa.BackupSummary, logger logr.Logger) error {

--- a/controllers/medusa/medusabackupjob_controller.go
+++ b/controllers/medusa/medusabackupjob_controller.go
@@ -245,6 +245,11 @@ func (r *MedusaBackupJobReconciler) getBackupSummary(ctx context.Context, backup
 			return nil, err
 		} else {
 			for _, remoteBackup := range remoteBackups {
+				if remoteBackup == nil {
+					err := fmt.Errorf("backup %s summary is nil", backup.Name)
+					logger.Error(err, "remote backup is nil")
+					return nil, err
+				}
 				logger.Info("found backup", "CassandraPod", pod.Name, "Backup", remoteBackup.BackupName)
 				if backup.ObjectMeta.Name == remoteBackup.BackupName {
 					return remoteBackup, nil

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -433,35 +433,40 @@ func (c *fakeMedusaClient) GetBackups(ctx context.Context) ([]*medusa.BackupSumm
 			status = *medusa.StatusType_IN_PROGRESS.Enum()
 		}
 
-		backup := &medusa.BackupSummary{
-			BackupName:    name,
-			StartTime:     0,
-			FinishTime:    10,
-			TotalNodes:    3,
-			FinishedNodes: 3,
-			TotalObjects:  fakeBackupFileCount,
-			TotalSize:     fakeBackupByteSize,
-			Status:        status,
-			Nodes: []*medusa.BackupNode{
-				{
-					Host:       "host1",
-					Tokens:     []int64{1, 2, 3},
-					Datacenter: "dc1",
-					Rack:       "rack1",
+		var backup *medusa.BackupSummary
+		if strings.HasPrefix(name, backupWithNoPods) {
+			backup = nil
+		} else {
+			backup = &medusa.BackupSummary{
+				BackupName:    name,
+				StartTime:     0,
+				FinishTime:    10,
+				TotalNodes:    3,
+				FinishedNodes: 3,
+				TotalObjects:  fakeBackupFileCount,
+				TotalSize:     fakeBackupByteSize,
+				Status:        status,
+				Nodes: []*medusa.BackupNode{
+					{
+						Host:       "host1",
+						Tokens:     []int64{1, 2, 3},
+						Datacenter: "dc1",
+						Rack:       "rack1",
+					},
+					{
+						Host:       "host2",
+						Tokens:     []int64{1, 2, 3},
+						Datacenter: "dc1",
+						Rack:       "rack1",
+					},
+					{
+						Host:       "host3",
+						Tokens:     []int64{1, 2, 3},
+						Datacenter: "dc1",
+						Rack:       "rack1",
+					},
 				},
-				{
-					Host:       "host2",
-					Tokens:     []int64{1, 2, 3},
-					Datacenter: "dc1",
-					Rack:       "rack1",
-				},
-				{
-					Host:       "host3",
-					Tokens:     []int64{1, 2, 3},
-					Datacenter: "dc1",
-					Rack:       "rack1",
-				},
-			},
+			}
 		}
 		backups = append(backups, backup)
 	}

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -526,7 +526,7 @@ func findDatacenterCondition(status *cassdcapi.CassandraDatacenterStatus, condTy
 }
 
 func deleteDatacenterPods(t *testing.T, f *framework.Framework, ctx context.Context, dcKey framework.ClusterKey, dc *cassdcapi.CassandraDatacenter) {
-	for i := int32(0); i < dc.Spec.Size; i++ {
+	for i := 0; i < int(dc.Spec.Size); i++ {
 		pod := &corev1.Pod{}
 		podName := fmt.Sprintf("%s-%s-%d", dc.Spec.ClusterName, dc.DatacenterName(), i)
 		podKey := framework.NewClusterKey(dcKey.K8sContext, dcKey.Namespace, podName)

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -535,18 +535,10 @@ func deleteDatacenterPods(t *testing.T, f *framework.Framework, ctx context.Cont
 		pod := &corev1.Pod{}
 		podName := fmt.Sprintf("%s-%s-%d", dc.Spec.ClusterName, dc.DatacenterName(), i)
 		podKey := framework.NewClusterKey(dcKey.K8sContext, dcKey.Namespace, podName)
-		err := f.Get(ctx, podKey, pod)
+		err := f.Delete(ctx, podKey, pod)
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				t.Logf("failed to get pod %s: %v", podKey, err)
-			}
-		} else {
-			err = f.Delete(ctx, podKey, pod)
-			if err != nil {
-				t.Logf("failed to delete pod %s: %v", podKey, err)
-			}
+			t.Logf("failed to delete pod %s: %v", podKey, err)
 		}
-
 	}
 }
 

--- a/controllers/medusa/medusabackupjob_controller_test.go
+++ b/controllers/medusa/medusabackupjob_controller_test.go
@@ -33,6 +33,7 @@ const (
 	failingBackupName    = "bad-backup"
 	missingBackupName    = "missing-backup"
 	backupWithNoPods     = "backup-with-no-pods"
+	backupWithNilSummary = "backup-with-nil-summary"
 	dc1PodPrefix         = "192.168.1."
 	dc2PodPrefix         = "192.168.2."
 	fakeBackupFileCount  = int64(13)
@@ -171,6 +172,9 @@ func testMedusaBackupDatacenter(t *testing.T, ctx context.Context, f *framework.
 
 	// in K8OP-294 we found out we can try to make backups on StatefulSets with no pods
 	backupCreated = createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backupWithNoPods)
+	require.False(backupCreated, "the backup object shouldn't have been created")
+	// in that same effort, we also found out we can have nil instead of backup sumamry
+	backupCreated = createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backupWithNilSummary)
 	require.False(backupCreated, "the backup object shouldn't have been created")
 
 	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
@@ -434,7 +438,7 @@ func (c *fakeMedusaClient) GetBackups(ctx context.Context) ([]*medusa.BackupSumm
 		}
 
 		var backup *medusa.BackupSummary
-		if strings.HasPrefix(name, backupWithNoPods) {
+		if strings.HasPrefix(name, backupWithNilSummary) {
 			backup = nil
 		} else {
 			backup = &medusa.BackupSummary{

--- a/pkg/medusa/utils.go
+++ b/pkg/medusa/utils.go
@@ -2,6 +2,7 @@ package medusa
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -21,8 +22,8 @@ func GetCassandraDatacenterPods(ctx context.Context, cassdc *cassdcapi.Cassandra
 		return nil, err
 	}
 
-	pods := make([]corev1.Pod, 0)
-	pods = append(pods, podList.Items...)
-
-	return pods, nil
+	if podList.Items != nil {
+		return podList.Items, nil
+	}
+	return nil, errors.New("podList came with nil Items field")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: In the MedusaBackupJob controller, we add a check for pods being present. Pods might be absent for temporary reasons, such as nodepool replacement in the linked issue. If we find no pods, we cannot find the related backups (statuses) and crash. Since the pods are likely to come back, we do not stop requeing the reconciliation.
However, if we get the pods, but for some other reason we don't get the backup statuses, something worse happened and we can't recover. So we stop requeing.

**Which issue(s) this PR fixes**:
Fixes #1454 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
