### PR TITLE
K8OP-303 Use namespaced service name when registering k8ssandra cluster to Reaper

### DIFF
--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -24,3 +24,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [BUGFIX] [#1460](https://github.com/k8ssandra/k8ssandra-operator/issues/1460) Fix podName calculations in medusa's hostmap.go to account for unbalanced racks also
 * [BUGFIX] [#1466](https://github.com/k8ssandra/k8ssandra-operator/issues/1466) Do not overwrite existing status fields or forget to write the changes. Also, add new ContextName for the Datacenter to know where it used to be. 
 * [ENHANCEMENT] [#1455](https://github.com/k8ssandra/k8ssandra-operator/issues/1455) Expose configuration of Medusa's gRPC server port
+* [BUGFIX] [#1471](https://github.com/k8ssandra/k8ssandra-operator/issues/1471) Use namespaced service name when registering k8ssandra cluster to Reaper

--- a/pkg/reaper/manager.go
+++ b/pkg/reaper/manager.go
@@ -68,7 +68,8 @@ func (r *restReaperManager) connect(ctx context.Context, reaperSvc, username, pa
 }
 
 func (r *restReaperManager) AddClusterToReaper(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) error {
-	return r.reaperClient.AddCluster(ctx, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName), cassdc.GetSeedServiceName())
+	namespacedServiceName := cassdc.GetSeedServiceName() + "." + cassdc.Namespace
+	return r.reaperClient.AddCluster(ctx, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName), namespacedServiceName)
 }
 
 func (r *restReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) (bool, error) {

--- a/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/k8ssandra.yaml
@@ -37,6 +37,7 @@ spec:
         concurrent_writes: 2
         concurrent_counter_writes: 2
       jvmOptions:
+        cassandra_ring_delay_ms: 0
         heapSize: 512Mi
         heapNewGenSize: 256Mi
         gc: CMS
@@ -69,3 +70,9 @@ spec:
             nodeAffinityLabels:
               "topology.kubernetes.io/zone": region2-zone2
     mgmtAPIHeap: 64Mi
+  reaper:
+    reaperRef:
+      name: reaper1
+      namespace: test-0
+    uiUserSecretRef:
+      name: reaper-ui-secret

--- a/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - medusa-config.yaml
+  - reaper.yaml
   - k8ssandra.yaml

--- a/test/testdata/fixtures/multi-dc-cluster-scope/reaper.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/reaper.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reaper-ui-secret
+data:
+  # username: reaper-jmx (actually)
+  username: cmVhcGVyLWpteA==
+  # password: R3ap3r
+  password: UjNhcDNy
+---
+apiVersion: reaper.k8ssandra.io/v1alpha1
+kind: Reaper
+metadata:
+  name: reaper1
+spec:
+  storageType: local
+  storageConfig:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 256Mi
+  httpManagement:
+    enabled: true
+  heapSize: 256Mi
+  autoScheduling:
+    enabled: false
+  uiUserSecretRef:
+    name: reaper-ui-secret


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
* Adds namespace to the k8ssandra clusters seed service name when registering the cluster to reaper.
* Expands the cluster-scope test to deploy a contorl plane reaper in k8ssandra-operator namespace, then checks if the k8ssandra cluster in another namespace properly registers to it.

**Which issue(s) this PR fixes**:
Fixes #1471 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
