### PR TITLE
K8OP-312 MC-1542 Fix reconciliation of Medusa configuration without credential files

### DIFF
--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -18,4 +18,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] [#1499](https://github.com/k8ssandra/k8ssandra-operator/issues/1499) Bump cassandra-operator to v1.23.2 / 0.55.2 Helm chart
 * [CHANGE] [#1505](https://github.com/k8ssandra/k8ssandra-operator/issues/1505) Replace yq Docker images with k8ssandra-client ones
 * [CHANGE] [#1508](https://github.com/k8ssandra/k8ssandra-operator/issues/1508) Bump Medusa to 0.24.0
-* [CHANGE] [#1903](https://github.com/riptano/mission-control/issues/1903) Add support for read-only file systems to Medusa containers
+* [CHANGE] [#1516](https://github.com/k8ssandra/k8ssandra-operator/pull/1516) Add support for read-only file systems to Medusa containers
+* [BUGFIX] [#1489](https://github.com/k8ssandra/k8ssandra-operator/issues/1489) Fix reconciliation of Medusa with config without credentials file.

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -102,6 +102,7 @@ func TestK8ssandraCluster(t *testing.T) {
 	t.Run("createMultiDcClusterWithControlPlaneReaper", testEnv.ControllerTest(ctx, createMultiDcClusterWithControlPlaneReaper))
 	t.Run("CreateMultiDcClusterWithMedusa", testEnv.ControllerTest(ctx, createMultiDcClusterWithMedusa))
 	t.Run("CreateSingleDcClusterWithMedusaConfigRef", testEnv.ControllerTest(ctx, createSingleDcClusterWithMedusaConfigRef))
+	t.Run("CreateSingleDcClusterWithoutStorageCredentials", testEnv.ControllerTest(ctx, createSingleDcClusterWithoutStorageCredentials))
 	t.Run("CreateSingleDcClusterWithManagementApiSecured", testEnv.ControllerTest(ctx, createSingleDcClusterWithManagementApiSecured))
 	t.Run("CreatingSingleDcClusterWithoutPrefixInClusterSpecFail", testEnv.ControllerTest(ctx, creatingSingleDcClusterWithoutPrefixInClusterSpecFails))
 	t.Run("CreateMultiDcClusterWithReplicatedSecrets", testEnv.ControllerTest(ctx, createMultiDcClusterWithReplicatedSecrets))

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -43,6 +43,8 @@ const (
 	MedusaBackupsVolumeName  = "medusa-backups"
 	MedusaBackupsMountPath   = "/mnt/backups"
 	serviceAccountNameEnvVar = "SERVICE_ACCOUNT_NAME"
+
+	CredentialsTypeRoleBased = "role-based"
 )
 
 var (

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -24,8 +24,8 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: dc1Namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dc1Key, f)
-	checkBucketKeyPresent(t, f, ctx, klusterNamespace, dc1Key.K8sContext, k8ssandra)
-	checkBucketKeyPresent(t, f, ctx, dc1Key.Namespace, dc1Key.K8sContext, k8ssandra)
+	verifyBucketKeyPresent(t, f, ctx, klusterNamespace, dc1Key.K8sContext, k8ssandra)
+	verifyBucketKeyPresent(t, f, ctx, dc1Key.Namespace, dc1Key.K8sContext, k8ssandra)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
@@ -44,7 +44,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: dc2Namespace, Name: "dc2"}}
 	checkDatacenterReady(t, ctx, dc2Key, f)
-	checkBucketKeyPresent(t, f, ctx, dc2Namespace, dc2Key.K8sContext, k8ssandra)
+	verifyBucketKeyPresent(t, f, ctx, dc2Namespace, dc2Key.K8sContext, k8ssandra)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {

--- a/test/e2e/cluster_scope_test.go
+++ b/test/e2e/cluster_scope_test.go
@@ -24,8 +24,8 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc1Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[0], NamespacedName: types.NamespacedName{Namespace: dc1Namespace, Name: "dc1"}}
 	checkDatacenterReady(t, ctx, dc1Key, f)
-	verifyBucketKeyPresent(t, f, ctx, klusterNamespace, dc1Key.K8sContext, k8ssandra)
-	verifyBucketKeyPresent(t, f, ctx, dc1Key.Namespace, dc1Key.K8sContext, k8ssandra)
+	verifyBucketKeyPresent(t, f, ctx, k8ssandra, klusterNamespace, dc1Key.K8sContext, multiClusterBucketSecretName)
+	verifyBucketKeyPresent(t, f, ctx, k8ssandra, dc1Key.Namespace, dc1Key.K8sContext, multiClusterBucketSecretName)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
@@ -44,7 +44,7 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 
 	dc2Key := framework.ClusterKey{K8sContext: f.DataPlaneContexts[1], NamespacedName: types.NamespacedName{Namespace: dc2Namespace, Name: "dc2"}}
 	checkDatacenterReady(t, ctx, dc2Key, f)
-	verifyBucketKeyPresent(t, f, ctx, dc2Namespace, dc2Key.K8sContext, k8ssandra)
+	verifyBucketKeyPresent(t, f, ctx, k8ssandra, dc2Namespace, dc2Key.K8sContext, multiClusterBucketSecretName)
 
 	t.Log("check k8ssandra cluster status")
 	require.Eventually(func() bool {
@@ -70,8 +70,8 @@ func multiDcMultiCluster(t *testing.T, ctx context.Context, klusterNamespace str
 	}, polling.k8ssandraClusterStatus.timeout, polling.k8ssandraClusterStatus.interval, "timed out waiting for K8ssandraCluster status to get updated")
 
 	t.Log("check replicated secret mounted")
-	checkReplicatedSecretMounted(t, ctx, f, dc1Key, dc1Namespace, k8ssandra)
-	checkReplicatedSecretMounted(t, ctx, f, dc2Key, dc2Namespace, k8ssandra)
+	checkReplicatedSecretMounted(t, ctx, f, dc1Key, multiClusterBucketSecretName)
+	checkReplicatedSecretMounted(t, ctx, f, dc2Key, multiClusterBucketSecretName)
 
 	t.Log("retrieve database credentials")
 	username, password, err := f.RetrieveDatabaseCredentials(ctx, f.DataPlaneContexts[0], dc1Namespace, k8ssandra.SanitizedName())

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	backupName             = "backup1"
-	clusterName            = "test"
-	globalBucketSecretName = "global-bucket-key"
+	backupName            = "backup1"
+	clusterName           = "test"
+	localBucketSecretName = "medusa-bucket-key"
 )
 
 func createSingleMedusaJob(t *testing.T, ctx context.Context, namespace string, f *framework.E2eFramework) {
@@ -89,7 +89,7 @@ func createMultiMedusaJob(t *testing.T, ctx context.Context, namespace string, f
 
 	// Check that Medusa's bucket key has been replicated to the current namespace
 	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
-		checkBucketKeyPresent(t, f, ctx, namespace, dcKey.K8sContext, kc)
+		verifyBucketKeyPresent(t, f, ctx, namespace, dcKey.K8sContext, kc)
 	}
 
 	// Check that both DCs are ready and have Medusa containers
@@ -134,16 +134,12 @@ func createMultiDcSingleMedusaJob(t *testing.T, ctx context.Context, namespace s
 	checkNoPurgeCronJob(t, ctx, namespace, dcKey, f, kc)
 }
 
-func checkBucketKeyPresent(t *testing.T, f *framework.E2eFramework, ctx context.Context, namespace string, k8sContext string, kc *k8ssandraapi.K8ssandraCluster) {
+func verifyBucketKeyPresent(t *testing.T, f *framework.E2eFramework, ctx context.Context, namespace string, k8sContext string, kc *k8ssandraapi.K8ssandraCluster) {
 	require := require.New(t)
 
-	// work out the name of the replicated bucket key. should be "clusterName-<original-bucket-key-name>"
-	localBucketKeyName := "test-" + globalBucketSecretName
-
-	// Check that the bucket key has been replicated to the current namespace
 	bucketKey := &corev1.Secret{}
 	require.Eventually(func() bool {
-		err := f.Get(ctx, framework.NewClusterKey(k8sContext, namespace, localBucketKeyName), bucketKey)
+		err := f.Get(ctx, framework.NewClusterKey(k8sContext, namespace, localBucketSecretName), bucketKey)
 		return err == nil
 	}, polling.medusaConfigurationReady.timeout, polling.medusaConfigurationReady.interval,
 		fmt.Sprintf("Error getting the Medusa bucket key secret. Context: %s, ClusterName: %s, Namespace: %s", k8sContext, kc.SanitizedName(), namespace),
@@ -158,7 +154,7 @@ func checkReplicatedSecretMounted(t *testing.T, ctx context.Context, f *framewor
 	index, found := cassandra.FindContainer(dc.Spec.PodTemplateSpec, "medusa")
 	require.True(found, fmt.Sprintf("%s doesn't have medusa container", dc.Name))
 	medusaContainer := dc.Spec.PodTemplateSpec.Spec.Containers[index]
-	hasMount := f.ContainerHasVolumeMount(medusaContainer, fmt.Sprintf("%s-%s", clusterName, globalBucketSecretName), "/etc/medusa-secrets")
+	hasMount := f.ContainerHasVolumeMount(medusaContainer, localBucketSecretName, "/etc/medusa-secrets")
 	assert.True(t, hasMount, "Missing Volume Mount for Medusa bucket key")
 }
 

--- a/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # need this one to be created in namespace test-1
-  # the one from ../medusa-bucket-key.yaml is created in namespace test-0
   - medusa-bucket-key.yaml
   - medusa-config.yaml
   - reaper.yaml

--- a/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # need this one to be created in namespace test-1
+  # the one from ../medusa-bucket-key.yaml is created in namespace test-0
+  - medusa-bucket-key.yaml
   - medusa-config.yaml
   - reaper.yaml
   - k8ssandra.yaml

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
@@ -1,36 +1,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: medusa-bucket-key
-  namespace: test-0
-type: Opaque
-stringData:
-
-  credentials: |-
-    [default]
-    aws_access_key_id = k8ssandra
-    aws_secret_access_key = k8ssandra
----
-apiVersion: v1
-kind: Secret
-metadata:
- name: medusa-bucket-key
- namespace: test-1
-type: Opaque
-stringData:
-
- credentials: |-
-   [default]
-   aws_access_key_id = k8ssandra
-   aws_secret_access_key = k8ssandra
----
-apiVersion: v1
-kind: Secret
-metadata:
-  # technically, we need this only in the data plane context, but it's not too easy way to create it just there
-  # so we create it everywhere
-  name: medusa-bucket-key
-  namespace: test-2
+  name: multicluster-medusa-bucket-key
+  # these labels tell the k8ssandra-operator to replicate the secret to each context and namespace the "test" cluster needs
+  # it's ironic that we are removing the code in the operator that did this automatically in the same PR as adding this
+  # yet kustomization has no good way of ensuring these secrets get create everywhere (it runs just with one NS and one cannot go elsehwere)
+  labels:
+    k8ssandra.io/replicated-by: "k8ssandracluster-controller"
+    "k8ssandra.io/cluster-name": "test"
+    k8ssandra.io/cluster-namespace: "test-0"
 type: Opaque
 stringData:
   credentials: |-

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
@@ -1,6 +1,19 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: medusa-bucket-key
+  namespace: test-0
+type: Opaque
+stringData:
+
+  credentials: |-
+    [default]
+    aws_access_key_id = k8ssandra
+    aws_secret_access_key = k8ssandra
+---
+apiVersion: v1
+kind: Secret
+metadata:
  name: medusa-bucket-key
  namespace: test-1
 type: Opaque
@@ -14,7 +27,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  # technically, we need this onl in the data plane context, but it's not too easy way to create it just there
+  # technically, we need this only in the data plane context, but it's not too easy way to create it just there
   # so we create it everywhere
   name: medusa-bucket-key
   namespace: test-2

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-bucket-key.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+ name: medusa-bucket-key
+ namespace: test-1
+type: Opaque
+stringData:
+
+ credentials: |-
+   [default]
+   aws_access_key_id = k8ssandra
+   aws_secret_access_key = k8ssandra
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  # technically, we need this onl in the data plane context, but it's not too easy way to create it just there
+  # so we create it everywhere
+  name: medusa-bucket-key
+  namespace: test-2
+type: Opaque
+stringData:
+  credentials: |-
+    [default]
+    aws_access_key_id = k8ssandra
+    aws_secret_access_key = k8ssandra

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
@@ -8,7 +8,7 @@ spec:
     storageProvider: s3_compatible
     bucketName: k8ssandra-medusa
     storageSecretRef:
-      name: medusa-bucket-key
+      name: multicluster-medusa-bucket-key
     host: minio-service.minio.svc.cluster.local
     port: 9000
     secure: false

--- a/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
+++ b/test/testdata/fixtures/multi-dc-cluster-scope/medusa-config.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: global-bucket-key
-  namespace: test-0
-type: Opaque
-stringData:
-  # Note that this currently has to be set to credentials!
-  credentials: |-
-    [default]
-    aws_access_key_id = k8ssandra
-    aws_secret_access_key = k8ssandra
----
 apiVersion: medusa.k8ssandra.io/v1alpha1
 kind: MedusaConfiguration
 metadata:
@@ -21,7 +8,7 @@ spec:
     storageProvider: s3_compatible
     bucketName: k8ssandra-medusa
     storageSecretRef:
-      name: global-bucket-key
+      name: medusa-bucket-key
     host: minio-service.minio.svc.cluster.local
     port: 9000
     secure: false

--- a/test/testdata/fixtures/multi-dc-encryption-medusa/medusa-config.yaml
+++ b/test/testdata/fixtures/multi-dc-encryption-medusa/medusa-config.yaml
@@ -1,15 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: global-bucket-key
-type: Opaque
-stringData:
-  # Note that this currently has to be set to credentials!
-  credentials: |-
-    [default]
-    aws_access_key_id = k8ssandra
-    aws_secret_access_key = k8ssandra
----
 apiVersion: medusa.k8ssandra.io/v1alpha1
 kind: MedusaConfiguration
 metadata:
@@ -19,7 +7,7 @@ spec:
     storageProvider: s3_compatible
     bucketName: k8ssandra-medusa
     storageSecretRef:
-      name: global-bucket-key
+      name: medusa-bucket-key
     host: minio-service.minio.svc.cluster.local
     port: 9000
     secure: false


### PR DESCRIPTION
**What this PR does**:
This PR allows reconciling k8ssandra clusters that use Medusa without credential files. This is useful for role-based identity situations, where the credentials come from the _environment_.
The main fix lies in not creating the k8s secret to hold the credential.

The PR also removes some deprecated code about replicating secrets used by Medusa to talk to storage backends. As a consequence of this, some e2e tests go back to using the manually used secrets instead of the created ones.

**Which issue(s) this PR fixes**:
Fixes #1489 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
