### PR TITLE
MC-1605 K8OP-321 Replace yq:4 with k8ssadra-client images

### DIFF
--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-* [CHANGE](https://github.com/k8ssandra/k8ssandra-operator/issues/1499) Bump cassandra-operator to v1.23.2 / 0.55.2 Helm chart
+* [CHANGE] [#1499](https://github.com/k8ssandra/k8ssandra-operator/issues/1499) Bump cassandra-operator to v1.23.2 / 0.55.2 Helm chart
+* [CHANGE] [#1505](https://github.com/k8ssandra/k8ssandra-operator/issues/1505) Replace yq Docker images with k8ssandra-client ones

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -436,9 +436,9 @@ type DatacenterOptions struct {
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
 	// configuration. This is only useful when PerNodeConfigMapRef is set.
-	// The default is "mikefarah/yq:4".
+	// The default is "k8ssandra/k8ssandra-client:v0.6.3".
 	// +optional
-	// +kubebuilder:default="mikefarah/yq:4"
+	// +kubebuilder:default="k8ssandra/k8ssandra-client:v0.6.3"
 	PerNodeConfigInitContainerImage string `json:"perNodeConfigInitContainerImage,omitempty"`
 
 	// The k8s service account to use for the Cassandra pods

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -9530,11 +9530,11 @@ spec:
                               type: object
                           type: object
                         perNodeConfigInitContainerImage:
-                          default: mikefarah/yq:4
+                          default: k8ssandra/k8ssandra-client:v0.6.3
                           description: |-
                             The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                             configuration. This is only useful when PerNodeConfigMapRef is set.
-                            The default is "mikefarah/yq:4".
+                            The default is "k8ssandra/k8ssandra-client:v0.6.3".
                           type: string
                         perNodeConfigMapRef:
                           description: |-
@@ -22014,11 +22014,11 @@ spec:
                         type: object
                     type: object
                   perNodeConfigInitContainerImage:
-                    default: mikefarah/yq:4
+                    default: k8ssandra/k8ssandra-client:v0.6.3
                     description: |-
                       The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                       configuration. This is only useful when PerNodeConfigMapRef is set.
-                      The default is "mikefarah/yq:4".
+                      The default is "k8ssandra/k8ssandra-client:v0.6.3".
                     type: string
                   podPriorityClassName:
                     description: PodPriorityClassName defines the priority class name

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -9468,11 +9468,11 @@ spec:
                               type: object
                           type: object
                         perNodeConfigInitContainerImage:
-                          default: mikefarah/yq:4
+                          default: k8ssandra/k8ssandra-client:v0.6.3
                           description: |-
                             The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                             configuration. This is only useful when PerNodeConfigMapRef is set.
-                            The default is "mikefarah/yq:4".
+                            The default is "k8ssandra/k8ssandra-client:v0.6.3".
                           type: string
                         perNodeConfigMapRef:
                           description: |-
@@ -21952,11 +21952,11 @@ spec:
                         type: object
                     type: object
                   perNodeConfigInitContainerImage:
-                    default: mikefarah/yq:4
+                    default: k8ssandra/k8ssandra-client:v0.6.3
                     description: |-
                       The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                       configuration. This is only useful when PerNodeConfigMapRef is set.
-                      The default is "mikefarah/yq:4".
+                      The default is "k8ssandra/k8ssandra-client:v0.6.3".
                     type: string
                   podPriorityClassName:
                     description: PodPriorityClassName defines the priority class name

--- a/pkg/nodeconfig/mount.go
+++ b/pkg/nodeconfig/mount.go
@@ -25,7 +25,7 @@ func MountPerNodeConfig(dcConfig *cassandra.DatacenterConfig) {
 }
 
 const (
-	defaultPerNodeConfigInitContainerImage = "mikefarah/yq:4"
+	defaultPerNodeConfigInitContainerImage = "k8ssandra/k8ssandra-client:v0.6.3"
 )
 
 func newPerNodeConfigInitContainer(image string) v1.Container {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Replaces yq Docker images by k8ssandra-client ones. 
I'm not updating any tests because tests like PerNodeConfig/InitialTokens already cover this. 

**Which issue(s) this PR fixes**:
Fixes #1505 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
