### PR TITLE
Upgrade linter and fix linting issue

### DIFF
--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -15,6 +15,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [TESTING] Upgrade linter and fix CI linting issue
+
 ## v1.21.1 - 2025-02-10
 
 * [CHANGE] [#1484](https://github.com/k8ssandra/k8ssandra-operator/issues/1484) Update Medusa version to 0.23.0

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ VECTOR ?= $(LOCALBIN)/bin/vector
 CERT_MANAGER_VERSION ?= v1.12.2
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOLINT_VERSION ?= 1.61.0
+GOLINT_VERSION ?= 1.64.8
 
 cert-manager: ## Install cert-manager to the cluster
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml

--- a/pkg/secret/replicated.go
+++ b/pkg/secret/replicated.go
@@ -150,7 +150,7 @@ func HasReplicatedSecrets(ctx context.Context, c client.Client, kcKey client.Obj
 	}
 
 	repSec := &replicationapi.ReplicatedSecret{}
-	err := c.Get(ctx, types.NamespacedName{Name: kcKey.Name, Namespace: kcKey.Namespace}, repSec)
+	err := c.Get(ctx, kcKey, repSec)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
**What this PR does**:
Upgrades the linter in the Makefile to match what runs in CI, and fix a linter error which breaks CI.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
