### PR TITLE
Upgrade cass-operator helm chart to 0.55.2 (1.23.2)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -13,6 +13,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+
+* [BUGFIX] [#1491](https://github.com/k8ssandra/k8ssandra-operator/issues/1491) Upgrade cass-operator helm chart to 0.55.2 (1.23.2)
+
 ## v1.21.2 - 2025-04-07
 
 * [CHANGE] [#1505](https://github.com/k8ssandra/k8ssandra-operator/issues/1505) Replace yq Docker images with k8ssandra-client ones

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.29.0
     repository: https://helm.k8ssandra.io
   - name: cass-operator
-    version: 0.55.0
+    version: 0.55.2
     repository: https://helm.k8ssandra.io
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:


### PR DESCRIPTION
**What this PR does**:
Jump to cass-operator release 1.23.2 to fix:
Additional extra resources created after upgrading from 1.12 to 1.21.1 #1491

[#1491](https://github.com/k8ssandra/k8ssandra-operator/issues/1491)

**Which issue(s) this PR fixes**:
Fixes #1491

**Checklist**
- [X] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)