### PR TITLE
Back Medusa's /tmp with an empty dir to allow read-only FS

### DIFF
--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -18,3 +18,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] [#1499](https://github.com/k8ssandra/k8ssandra-operator/issues/1499) Bump cassandra-operator to v1.23.2 / 0.55.2 Helm chart
 * [CHANGE] [#1505](https://github.com/k8ssandra/k8ssandra-operator/issues/1505) Replace yq Docker images with k8ssandra-client ones
 * [CHANGE] [#1508](https://github.com/k8ssandra/k8ssandra-operator/issues/1508) Bump Medusa to 0.24.0
+* [CHANGE] [#1903](https://github.com/riptano/mission-control/issues/1903) Add support for read-only file systems to Medusa containers

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -304,6 +304,10 @@ func medusaVolumeMounts(dcConfig *cassandra.DatacenterConfig, medusaSpec *api.Me
 			Name:      "podinfo",
 			MountPath: "/etc/podinfo",
 		},
+		{ // Medusa's /tmp backed by emptyDir to support RO FS
+			Name:      "medusa-tmp",
+			MountPath: "/tmp",
+		},
 	}
 
 	// Mount client encryption certificates if the secret ref is provided.
@@ -493,6 +497,20 @@ func GenerateMedusaVolumes(dcConfig *cassandra.DatacenterConfig, medusaSpec *api
 			Exists:      found,
 		})
 	}
+
+	// empty dir to back /tmp
+	emptyDirVolumeIndex, found := cassandra.FindVolume(&dcConfig.PodTemplateSpec, "medusa-tmp")
+	emptyDirVolume := &corev1.Volume{
+		Name: "medusa-tmp",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	newVolumes = append(newVolumes, medusaVolume{
+		Volume:      emptyDirVolume,
+		VolumeIndex: emptyDirVolumeIndex,
+		Exists:      found,
+	})
 
 	return newVolumes
 }

--- a/test/testdata/fixtures/single-dc-encryption-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-encryption-medusa/k8ssandra.yaml
@@ -27,6 +27,14 @@ spec:
       secure: false 
     certificatesSecretRef:
       name: client-certificates
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsUser: 999
+      runAsNonRoot: true
   cassandra:
     clusterName: "First Cluster"
     serverVersion: 4.1.5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: This PR adds a volume and a volume mount to Medusa containers. The volume is backed by an empty dir, and the volme is mounted on `/tmp`. This way, Medusa can operate in environments with read-only root file systems.

To test this:
- switch to main branch
- run `make single-up`
- moditfy `test/testdata/fixtures/single-dc-encryption-medusa/k8ssandra.yaml`
- add the following to the `medusa` block:
```
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop: ["ALL"]
      privileged: false
      readOnlyRootFilesystem: true
      runAsUser: 999
      runAsNonRoot: true
```
- this is the same thing we add to the e2e tests in this PR
- run `E2E_TEST="TestOperator/CreateSingleMedusaJob" make e2e-test`
- watch medusa containers never properly come up
- switch back to this branch
- run `make cleanup && make single-up`
- re-run the e2e test
- watch everything work

**Which issue(s) this PR fixes**:
Fixes #1903

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
