### PR TITLE
Watch multiple namespaces

### DIFF
--- a/CHANGELOG/CHANGELOG-1.23.md
+++ b/CHANGELOG/CHANGELOG-1.23.md
@@ -21,8 +21,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] [#1544](https://github.com/k8ssandra/k8ssandra-operator/issues/1544) Make Reaper use management-api for the connection by default
 * [ENHANCEMENT] Add support for common annotations and labels in the helm chart
 * [BUGFIX] [#1538](https://github.com/k8ssandra/k8ssandra-operator/issues/1538) Fix perNodeConfig init-container to mount Volume "tmp" for the readOnlyRootFilesystem clusters
-* [BUGFIX] [#1538](https://github.com/k8ssandra/k8ssandra-operator/issues/1538) Fix perNodeConfig init-container to mount Volume "tmp" for the readOnlyRootFilesystem clusters
 * [TESTING] [#1532](https://github.com/k8ssandra/k8ssandra-operator/issues/1532) Update the base Cassandra version to 5.0.4 in tests
 * [TESTING] [#955](https://github.com/k8ssandra/k8ssandra-operator/issues/955) Update to kustomize v5.6.0 and fix the tests to correctly render the templates
 * [BUGFIX] [#2805](https://github.com/riptano/mission-control/issues/2085) Add missing propagation of common Labels and Annotations
-
+* [ENHANCEMENT] Add support for watching multiple specific namespaces in cluster scope deployments

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         {{- if .Values.global.clusterScoped}}
         - name: WATCH_NAMESPACE
-          value: ""
+          value: {{ include "cass-operator.watchNamespaces" . }}
         {{- else }}
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -7,6 +7,9 @@ global:
   commonLabels: {}
   # -- Annotations to be added to all deployed resources.
   commonAnnotations: {}
+  # -- List of namespaces to watch for K8ssandraCluster resources.
+  # If empty, the operator will watch all namespaces in cluster-scope installation.
+  # watchNamespaces: []
 
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request introduces support for watching multiple specific namespaces in cluster-scoped deployments of the `k8ssandra-operator`. Key changes include updates to the Helm chart templates, and values configuration to enable this functionality.

### Enhancements to namespace watching:

* [`charts/k8ssandra-operator/templates/deployment.yaml`](diffhunk://#diff-7ceb64b3e6d6f8dc9542ab17603a5d59863acc773488c24e278e32fa4a3109c8L37-R37): Modified the `WATCH_NAMESPACE` environment variable to dynamically include specific namespaces using the `cass-operator.watchNamespaces` template.

* [`charts/k8ssandra-operator/values.yaml`](diffhunk://#diff-1f5668f7f0e47f654b9cc505fa2f580c936b7e8bdf1f0ef11aabc96a0c9416feR6-R9): Introduced a new `watchNamespaces` configuration option under `global`. This allows users to specify a list of namespaces to watch for `K8ssandraCluster` resources. If left empty, the operator will default to watching all namespaces in a cluster-scoped installation.


**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
