### PR TITLE
Apply auth settings even if JMX is not used by Reaper

### DIFF
--- a/CHANGELOG/CHANGELOG-1.24.md
+++ b/CHANGELOG/CHANGELOG-1.24.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [BUGFIX] [#2121](https://github.com/riptano/mission-control/issues/2121) Add cluster's common L&A to replicated secrets and Vector's config map
+* [BUGFIX] [#1558](https://github.com/k8ssandra/k8ssandra-operator/issues/1558) Authentication settings aren't applied correctly to cassandra.yaml

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -51,10 +51,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 			return nil, err
 		}
 
-		reaperRequiresJmx := kc.Spec.Reaper != nil && !kc.Spec.Reaper.HttpManagement.Enabled
-		if reaperRequiresJmx {
-			cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled(), kc.Spec.UseExternalSecrets())
-		}
+		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled(), kc.Spec.UseExternalSecrets(), reaperRequiresJmx)
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on
 		// unauthenticated clusters.

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -51,6 +51,7 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 			return nil, err
 		}
 
+		reaperRequiresJmx := kc.Spec.Reaper != nil && !kc.Spec.Reaper.HttpManagement.Enabled
 		cassandra.ApplyAuth(dcConfig, kc.Spec.IsAuthEnabled(), kc.Spec.UseExternalSecrets(), reaperRequiresJmx)
 
 		// This is only really required when auth is enabled, but it doesn't hurt to apply system replication on

--- a/pkg/cassandra/auth_test.go
+++ b/pkg/cassandra/auth_test.go
@@ -1,10 +1,11 @@
 package cassandra
 
 import (
+	"testing"
+
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/unstructured"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestApplyAuthSettings(t *testing.T) {
@@ -81,4 +82,319 @@ func TestApplyAuthSettings(t *testing.T) {
 			assert.Equal(t, tt.want, actual)
 		})
 	}
+}
+
+func TestApplyAuth(t *testing.T) {
+	tests := []struct {
+		name                  string
+		authEnabled           bool
+		useExternalSecrets    bool
+		reaperRequiresJmx     bool
+		initialConfig         *DatacenterConfig
+		expectedJvmOptions    []string
+		expectedAuthenticator string
+		expectedAuthorizer    string
+		expectedRoleManager   string
+	}{
+		{
+			name:               "auth disabled, no external secrets, no reaper JMX",
+			authEnabled:        false,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  false,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{},
+			expectedAuthenticator: "AllowAllAuthenticator",
+			expectedAuthorizer:    "AllowAllAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth disabled, no external secrets, reaper JMX enabled",
+			authEnabled:        false,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  true,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{"-Dcom.sun.management.jmxremote.authenticate=false"},
+			expectedAuthenticator: "AllowAllAuthenticator",
+			expectedAuthorizer:    "AllowAllAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth disabled, external secrets, no reaper JMX",
+			authEnabled:        false,
+			useExternalSecrets: true,
+			reaperRequiresJmx:  false,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{},
+			expectedAuthenticator: "AllowAllAuthenticator",
+			expectedAuthorizer:    "AllowAllAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth disabled, external secrets, reaper JMX enabled",
+			authEnabled:        false,
+			useExternalSecrets: true,
+			reaperRequiresJmx:  true,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{"-Dcom.sun.management.jmxremote.authenticate=false"},
+			expectedAuthenticator: "AllowAllAuthenticator",
+			expectedAuthorizer:    "AllowAllAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth enabled, no external secrets, no reaper JMX",
+			authEnabled:        true,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  false,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{},
+			expectedAuthenticator: "PasswordAuthenticator",
+			expectedAuthorizer:    "CassandraAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth enabled, no external secrets, reaper JMX enabled",
+			authEnabled:        true,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  true,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions: []string{
+				"-Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy",
+				"-Djava.security.auth.login.config=$CASSANDRA_HOME/conf/cassandra-jaas.config",
+				"-Dcassandra.jmx.remote.login.config=CassandraLogin",
+				"-Dcom.sun.management.jmxremote.authenticate=true",
+			},
+			expectedAuthenticator: "PasswordAuthenticator",
+			expectedAuthorizer:    "CassandraAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth enabled, external secrets, no reaper JMX",
+			authEnabled:        true,
+			useExternalSecrets: true,
+			reaperRequiresJmx:  false,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{},
+			expectedAuthenticator: "PasswordAuthenticator",
+			expectedAuthorizer:    "CassandraAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "auth enabled, external secrets, reaper JMX enabled",
+			authEnabled:        true,
+			useExternalSecrets: true,
+			reaperRequiresJmx:  true,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionCassandra,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{"-Dcom.sun.management.jmxremote.authenticate=true"},
+			expectedAuthenticator: "PasswordAuthenticator",
+			expectedAuthorizer:    "CassandraAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+		{
+			name:               "DSE auth enabled, no external secrets, reaper JMX enabled",
+			authEnabled:        true,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  true,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionDse,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions: []string{
+				"-Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy",
+				"-Djava.security.auth.login.config=$CASSANDRA_HOME/conf/cassandra-jaas.config",
+				"-Dcassandra.jmx.remote.login.config=CassandraLogin",
+				"-Dcom.sun.management.jmxremote.authenticate=true",
+			},
+			expectedAuthenticator: "com.datastax.bdp.cassandra.auth.DseAuthenticator",
+			expectedAuthorizer:    "com.datastax.bdp.cassandra.auth.DseAuthorizer",
+			expectedRoleManager:   "com.datastax.bdp.cassandra.auth.DseRoleManager",
+		},
+		{
+			name:               "DSE auth disabled, no external secrets, no reaper JMX",
+			authEnabled:        false,
+			useExternalSecrets: false,
+			reaperRequiresJmx:  false,
+			initialConfig: &DatacenterConfig{
+				ServerType: k8ssandraapi.ServerDistributionDse,
+				CassandraConfig: k8ssandraapi.CassandraConfig{
+					CassandraYaml: unstructured.Unstructured{},
+					JvmOptions: k8ssandraapi.JvmOptions{
+						AdditionalOptions: []string{},
+					},
+				},
+			},
+			expectedJvmOptions:    []string{},
+			expectedAuthenticator: "AllowAllAuthenticator",
+			expectedAuthorizer:    "AllowAllAuthorizer",
+			expectedRoleManager:   "CassandraRoleManager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of the initial config to avoid modifying the original
+			dcConfig := *tt.initialConfig
+			dcConfig.CassandraConfig = k8ssandraapi.CassandraConfig{
+				CassandraYaml: unstructured.Unstructured{},
+				DseYaml:       unstructured.Unstructured{},
+				JvmOptions: k8ssandraapi.JvmOptions{
+					AdditionalOptions: []string{},
+				},
+			}
+
+			// Apply the auth settings
+			ApplyAuth(&dcConfig, tt.authEnabled, tt.useExternalSecrets, tt.reaperRequiresJmx)
+
+			// Verify JVM options
+			assert.ElementsMatch(t, tt.expectedJvmOptions, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions,
+				"JVM options should match expected values")
+
+			// Verify authenticator, authorizer, and role manager settings
+			assert.Equal(t, tt.expectedAuthenticator, dcConfig.CassandraConfig.CassandraYaml["authenticator"],
+				"Authenticator should be set correctly")
+			assert.Equal(t, tt.expectedAuthorizer, dcConfig.CassandraConfig.CassandraYaml["authorizer"],
+				"Authorizer should be set correctly")
+			assert.Equal(t, tt.expectedRoleManager, dcConfig.CassandraConfig.CassandraYaml["role_manager"],
+				"Role manager should be set correctly")
+
+			// Verify DSE-specific settings if applicable
+			if tt.initialConfig.ServerType == k8ssandraapi.ServerDistributionDse && tt.authEnabled {
+				authOptions, exists := dcConfig.CassandraConfig.DseYaml["authentication_options"]
+				assert.True(t, exists, "DSE authentication_options should exist")
+				if authOptionsMap, ok := authOptions.(map[string]interface{}); ok {
+					assert.Equal(t, "true", authOptionsMap["enabled"], "DSE authentication should be enabled")
+				}
+
+				authzOptions, exists := dcConfig.CassandraConfig.DseYaml["authorization_options"]
+				assert.True(t, exists, "DSE authorization_options should exist")
+				if authzOptionsMap, ok := authzOptions.(map[string]interface{}); ok {
+					assert.Equal(t, "true", authzOptionsMap["enabled"], "DSE authorization should be enabled")
+				}
+
+				roleOptions, exists := dcConfig.CassandraConfig.DseYaml["role_management_options"]
+				assert.True(t, exists, "DSE role_management_options should exist")
+				if roleOptionsMap, ok := roleOptions.(map[string]interface{}); ok {
+					assert.Equal(t, "internal", roleOptionsMap["mode"], "DSE role management should be set to internal")
+				}
+			}
+		})
+	}
+}
+
+func TestApplyAuth_WithExistingOptions(t *testing.T) {
+	// Test that existing JVM options are preserved and new ones are added
+	dcConfig := &DatacenterConfig{
+		ServerType: k8ssandraapi.ServerDistributionCassandra,
+		CassandraConfig: k8ssandraapi.CassandraConfig{
+			CassandraYaml: unstructured.Unstructured{},
+			JvmOptions: k8ssandraapi.JvmOptions{
+				AdditionalOptions: []string{"-Xmx2g", "-Xms2g"},
+			},
+		},
+	}
+
+	ApplyAuth(dcConfig, true, false, true)
+
+	// Verify that existing options are preserved
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Xmx2g")
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Xms2g")
+
+	// Verify that new auth-related options are added
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Dcom.sun.management.jmxremote.authenticate=true")
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Dcassandra.jmx.remote.login.config=CassandraLogin")
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Djava.security.auth.login.config=$CASSANDRA_HOME/conf/cassandra-jaas.config")
+	assert.Contains(t, dcConfig.CassandraConfig.JvmOptions.AdditionalOptions, "-Dcassandra.jmx.authorizer=org.apache.cassandra.auth.jmx.AuthorizationProxy")
+}
+
+func TestApplyAuth_NoDuplicateOptions(t *testing.T) {
+	// Test that duplicate options are not added
+	dcConfig := &DatacenterConfig{
+		ServerType: k8ssandraapi.ServerDistributionCassandra,
+		CassandraConfig: k8ssandraapi.CassandraConfig{
+			CassandraYaml: unstructured.Unstructured{},
+			JvmOptions: k8ssandraapi.JvmOptions{
+				AdditionalOptions: []string{"-Dcom.sun.management.jmxremote.authenticate=true"},
+			},
+		},
+	}
+
+	ApplyAuth(dcConfig, true, false, true)
+
+	// Count occurrences of the authenticate option
+	count := 0
+	for _, option := range dcConfig.CassandraConfig.JvmOptions.AdditionalOptions {
+		if option == "-Dcom.sun.management.jmxremote.authenticate=true" {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count, "Should not add duplicate JVM options")
 }

--- a/test/e2e/dse_test.go
+++ b/test/e2e/dse_test.go
@@ -40,6 +40,11 @@ func createSingleDseDatacenterCluster(t *testing.T, ctx context.Context, namespa
 		"SELECT * FROM system.local")
 	require.NoError(t, err, "failed to execute CQL query against DSE")
 
+	t.Log("Check that we cannot communicate through CQL without auth")
+	_, err = f.ExecuteCqlNoAuth(f.DataPlaneContexts[0], namespace, dcPrefix+"-default-sts-0",
+		"SELECT * FROM system.local")
+	require.Error(t, err, "expected CQL query without auth to fail")
+
 	// modify server_id in dse.yaml and verify that the modification was applied by querying the server_id from system.local
 
 	err = f.Client.Get(ctx, kcKey, kc)
@@ -89,6 +94,11 @@ func createSingleHcdDatacenterCluster(t *testing.T, ctx context.Context, namespa
 	_, err = f.ExecuteCql(ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), dcPrefix+"-default-sts-0",
 		"SELECT * FROM system.local")
 	require.NoError(t, err, "failed to execute CQL query against HCD", err)
+	t.Log("Check that we cannot communicate through CQL without auth")
+	_, err = f.ExecuteCqlNoAuth(f.DataPlaneContexts[0], namespace, dcPrefix+"-default-sts-0",
+		"SELECT * FROM system.local")
+	require.Error(t, err, "expected CQL query without auth to fail")
+
 	opts := kubectl.Options{
 		Namespace: namespace,
 		Context:   f.DataPlaneContexts[0],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request introduces updates to authentication handling in Cassandra and DSE configurations, along with corresponding unit and integration tests. The changes aim to enhance the flexibility and correctness of authentication settings, particularly in scenarios involving Reaper's JMX requirements. Additionally, new e2e tests verify expected behavior for unauthorized CQL queries.

### Authentication Handling Updates:

* [`pkg/cassandra/auth.go`](diffhunk://#diff-ff7f918a641d4cfd08de1c6706fb16603827539b4a17b83b9b304cf77d310ef7L12-R12): Modified the `ApplyAuth` function to accept a new `reaperRequiresJmx` parameter, enabling finer control over JMX-related authentication settings. [[1]](diffhunk://#diff-ff7f918a641d4cfd08de1c6706fb16603827539b4a17b83b9b304cf77d310ef7L12-R12) [[2]](diffhunk://#diff-ff7f918a641d4cfd08de1c6706fb16603827539b4a17b83b9b304cf77d310ef7R26) [[3]](diffhunk://#diff-ff7f918a641d4cfd08de1c6706fb16603827539b4a17b83b9b304cf77d310ef7R38)
* [`controllers/k8ssandra/dcconfigs.go`](diffhunk://#diff-b4e2d9663b4d33f62fda7bd11533b1f9bc9ec910ce11a6c22fd787bc4c69e51dL54-R54): Updated the invocation of `ApplyAuth` to include the `reaperRequiresJmx` parameter, ensuring proper handling during datacenter configuration creation.

### Unit Tests:

* [`pkg/cassandra/auth_test.go`](diffhunk://#diff-d236824c54b4cfb2452efd304b790d2f8525e34ba8a441269ca32b5adb0c26d9R86-R400): Added comprehensive test cases for the `ApplyAuth` function, covering various combinations of authentication, external secrets, and Reaper JMX requirements. Tests also verify the preservation of existing JVM options and prevention of duplicate entries. [[1]](diffhunk://#diff-d236824c54b4cfb2452efd304b790d2f8525e34ba8a441269ca32b5adb0c26d9R86-R400) [[2]](diffhunk://#diff-d236824c54b4cfb2452efd304b790d2f8525e34ba8a441269ca32b5adb0c26d9R4-L7)

### Integration Tests:

* [`test/e2e/dse_test.go`](diffhunk://#diff-b4973944757bfbf18031d24aafea42cd88c099367286c632fdd836aa8c4814b1R43-R47): Added checks to ensure that unauthorized CQL queries fail as expected in both DSE and HCD clusters. [[1]](diffhunk://#diff-b4973944757bfbf18031d24aafea42cd88c099367286c632fdd836aa8c4814b1R43-R47) [[2]](diffhunk://#diff-b4973944757bfbf18031d24aafea42cd88c099367286c632fdd836aa8c4814b1R97-R101)

### Documentation Updates:

* [`CHANGELOG/CHANGELOG-1.24.md`](diffhunk://#diff-c1c23dcaa625895f147f51e4b71d419e0e0c07374d94a498da4d431cc98405f1R19): Added an entry for bugfix #1558, documenting the correction of authentication settings in `cassandra.yaml`.


**Which issue(s) this PR fixes**:
Fixes #1558 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
