### PR TITLE
Helm cluster level resources removal

### DIFF
--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -51,6 +51,13 @@ jobs:
       - name: Run Vector tests
         run: |
           make vector-install vector-test
+      - name: Ensure the helm chart allows not generating cluster scoped resources
+        run: |
+          helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false |grep ClusterRole
+          if [ $? -eq 0 ]; then
+            echo "ClusterRole found in the helm chart"
+            exit 1
+          fi
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
   build_image:

--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -53,6 +53,9 @@ jobs:
           make vector-install vector-test
       - name: Ensure the helm chart allows not generating cluster scoped resources
         run: |
+          cd charts/k8ssandra-operator
+          helm dependency update
+          cd ../..
           helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false |grep ClusterRole
           if [ $? -eq 0 ]; then
             echo "ClusterRole found in the helm chart"

--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -55,9 +55,9 @@ jobs:
         run: |
           cd charts/k8ssandra-operator
           helm dependency update
-          cd ../..
-          helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false | grep -q ClusterRole
-          if [ $? -eq 0 ]; then
+      - name: Check that the helm chart does not generate ClusterRole resources
+        run: |
+          if [ "$(helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false | grep -c ClusterRole)" != "0" ]; then
             echo "ClusterRole found in the helm chart"
             exit 1
           else

--- a/.github/workflows/test_and_build_image.yaml
+++ b/.github/workflows/test_and_build_image.yaml
@@ -56,11 +56,17 @@ jobs:
           cd charts/k8ssandra-operator
           helm dependency update
           cd ../..
-          helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false |grep ClusterRole
+          helm template k8c charts/k8ssandra-operator  --set cass-operator.disableCertManagerCheck=true --set global.clusterScopedResources=false | grep -q ClusterRole
           if [ $? -eq 0 ]; then
             echo "ClusterRole found in the helm chart"
             exit 1
+          else
+            echo "ClusterRole not found in the helm chart"
           fi
+      - name: Setup tmate session
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
   build_image:

--- a/CHANGELOG/CHANGELOG-1.24.md
+++ b/CHANGELOG/CHANGELOG-1.24.md
@@ -15,5 +15,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [CHANGE] [#1560](https://github.com/k8ssandra/k8ssandra-operator/pull/1560) Upgrade cass-operator to v1.25.0 and allow making the ClusterRole/Binding resources optional in the helm chart
 * [BUGFIX] [#2121](https://github.com/riptano/mission-control/issues/2121) Add cluster's common L&A to replicated secrets and Vector's config map
 * [BUGFIX] [#1558](https://github.com/k8ssandra/k8ssandra-operator/issues/1558) Authentication settings aren't applied correctly to cassandra.yaml

--- a/charts/k8ssandra-operator/Chart.yaml
+++ b/charts/k8ssandra-operator/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     version: 0.29.2
     repository: https://helm.k8ssandra.io
   - name: cass-operator
-    version: 0.57.5
+    version: 0.59.0
     repository: https://helm.k8ssandra.io
 home: https://github.com/k8ssandra/k8ssandra-operator
 sources:

--- a/charts/k8ssandra-operator/templates/clusterrole.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.clusterScoped }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -295,4 +296,5 @@ rules:
     - get
     - patch
     - update
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
+++ b/charts/k8ssandra-operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.clusterScoped }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "k8ssandra-common.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra-operator/templates/crd/cluster_role.yaml
+++ b/charts/k8ssandra-operator/templates/crd/cluster_role.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.disableCrdUpgraderJob }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -26,4 +27,5 @@ rules:
       - list
       - update
       - patch
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra-operator/templates/crd/cluster_role_binding.yaml
+++ b/charts/k8ssandra-operator/templates/crd/cluster_role_binding.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.disableCrdUpgraderJob }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -19,4 +20,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "k8ssandra-common.fullname" . }}-crd-upgrader-k8ssandra
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra-operator/templates/crd/service_account.yaml
+++ b/charts/k8ssandra-operator/templates/crd/service_account.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.disableCrdUpgraderJob }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,4 +12,5 @@ metadata:
     {{- with include "k8ssandra-common.annotations" . }}
     {{- . | nindent 4 }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -10,6 +10,8 @@ global:
   # -- List of namespaces to watch for K8ssandraCluster resources.
   # If empty, the operator will watch all namespaces in cluster-scope installation.
   # watchNamespaces: []
+  # -- If true, the helm chart will generate ClusterRoles and ClusterRoleBindings.
+  clusterScopedResources: true
 
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.

--- a/charts/templates/clusterrole.tmpl.yaml
+++ b/charts/templates/clusterrole.tmpl.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.clusterScoped }}
+{{- if .Values.global.clusterScopedResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/k8ssandra/cass-operator v1.24.1
+	github.com/k8ssandra/cass-operator v1.25.0
 	github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/k8ssandra/cass-operator v1.24.1 h1:sLQfngSd08ImZOppNNs2XbgO2RUDyA07tiopKp2hvVU=
 github.com/k8ssandra/cass-operator v1.24.1/go.mod h1:sDLewVG0W4WYFE4CjdJVZ/aBIivVFERiu6a91xQjl4U=
+github.com/k8ssandra/cass-operator v1.25.0 h1:m1WblJ67LnJeCqk0kC4SMw12CVkes08SqE/YAsPfyvY=
+github.com/k8ssandra/cass-operator v1.25.0/go.mod h1:sDLewVG0W4WYFE4CjdJVZ/aBIivVFERiu6a91xQjl4U=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5 h1:Dq0VdM960G3AbhYwFuaebmsE08IzOYHYhngUfDmWaAc=
 github.com/k8ssandra/reaper-client-go v0.3.1-0.20220114183114-6923e077c4f5/go.mod h1:WsQymIaVT39xbcstZhdqynUS13AGzP2p6U9Hsk1oy5M=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/scripts/prepare-helm-release.sh
+++ b/scripts/prepare-helm-release.sh
@@ -23,6 +23,7 @@ echo "{{- end }}" >> build/helm/role.yaml
 cat charts/templates/clusterrole.tmpl.yaml | tee build/helm/clusterrole.yaml > /dev/null
 cat build/helm/k8ssandra-operator-rbac.yaml | yq 'select(di == 1).rules' | tee -a build/helm/clusterrole.yaml > /dev/null
 echo "{{- end }}" >> build/helm/clusterrole.yaml
+echo "{{- end }}" >> build/helm/clusterrole.yaml # yeah, we need to do this twice
 cp build/helm/role.yaml charts/k8ssandra-operator/templates/role.yaml
 cp build/helm/clusterrole.yaml charts/k8ssandra-operator/templates/clusterrole.yaml
 # Generate the leader election role from the RBAC generated manifests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

This pull request introduces changes to the Helm chart for `k8ssandra-operator` to make the generation of cluster-scoped resources (e.g., `ClusterRole`, `ClusterRoleBinding`) optional. It also upgrades dependencies, updates the changelog, and modifies related scripts and templates to support this new functionality.

### Helm Chart Enhancements
* Added a new `clusterScopedResources` value in `values.yaml` to control the generation of cluster-scoped resources. Default is `true`. (`charts/k8ssandra-operator/values.yaml`, [charts/k8ssandra-operator/values.yamlR13-R14](diffhunk://#diff-1f5668f7f0e47f654b9cc505fa2f580c936b7e8bdf1f0ef11aabc96a0c9416feR13-R14))
* Updated templates for `ClusterRole`, `ClusterRoleBinding`, and related resources to respect the `clusterScopedResources` flag. (`charts/k8ssandra-operator/templates/clusterrole.yaml`, [[1]](diffhunk://#diff-35dea4798d77f27510e4d1f8061d7fd64b5321412400fce253ba43f735685ae3R2); `charts/k8ssandra-operator/templates/clusterrolebinding.yaml`, [[2]](diffhunk://#diff-928cde016ac41f1171c4aa11dfc7727484c8e74406140dcc6e6b23753ec2dba1R2); `charts/k8ssandra-operator/templates/crd/cluster_role.yaml`, [[3]](diffhunk://#diff-aea79b6d1adb6a80fb5da8c5c88c797966c43d62eaa1683c64a6cff3c9934876R2); `charts/k8ssandra-operator/templates/crd/cluster_role_binding.yaml`, [[4]](diffhunk://#diff-8256e9dada3e7b8d8638d32a2665690851ea91a3209f4e1203fa0d9b5545bc4fR2); `charts/k8ssandra-operator/templates/crd/service_account.yaml`, [[5]](diffhunk://#diff-73aad57e57295466793316a9b9849d9fa5feab59afc1116e22909accca8d566cR2)

### Dependency Upgrades
* Upgraded `cass-operator` Helm chart dependency to v0.59.0 in `Chart.yaml`. (`charts/k8ssandra-operator/Chart.yaml`, [charts/k8ssandra-operator/Chart.yamlL12-R12](diffhunk://#diff-1ad1e57ec5f65e79d8d2be95719740c89be6217f8733bc146507e340c9d6be4fL12-R12))
* Updated Go module dependency `github.com/k8ssandra/cass-operator` to v1.25.0. (`go.mod`, [go.modL20-R20](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-R20))

### CI/CD Workflow Updates
* Added new steps in the GitHub Actions workflow to test that the Helm chart correctly handles the `clusterScopedResources` flag. (`.github/workflows/test_and_build_image.yaml`, [.github/workflows/test_and_build_image.yamlR54-R69](diffhunk://#diff-d2ad8883b95da052c172ae6b8d3d5cafd7ef56e8d0a117c52b687c3c882163cfR54-R69))

### Documentation and Changelog
* Updated the changelog to document the addition of the `clusterScopedResources` flag and the upgrade to `cass-operator` v1.25.0. (`CHANGELOG/CHANGELOG-1.24.md`, [CHANGELOG/CHANGELOG-1.24.mdR18](diffhunk://#diff-c1c23dcaa625895f147f51e4b71d419e0e0c07374d94a498da4d431cc98405f1R18))

### Script Adjustments
* Adjusted `prepare-helm-release.sh` to handle the new logic for generating cluster-scoped resources. (`scripts/prepare-helm-release.sh`, [scripts/prepare-helm-release.shR26](diffhunk://#diff-240e5bdd1c27d2e4a693ac2226b07a93b6fc91d78638faa8f59426dd4e410eeaR26))

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
