### PR TITLE
Bump default Medusa image to 0.24.1

### DIFF
--- a/CHANGELOG/CHANGELOG-1.24.md
+++ b/CHANGELOG/CHANGELOG-1.24.md
@@ -18,3 +18,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] [#1560](https://github.com/k8ssandra/k8ssandra-operator/pull/1560) Upgrade cass-operator to v1.25.0 and allow making the ClusterRole/Binding resources optional in the helm chart
 * [BUGFIX] [#2121](https://github.com/riptano/mission-control/issues/2121) Add cluster's common L&A to replicated secrets and Vector's config map
 * [BUGFIX] [#1558](https://github.com/k8ssandra/k8ssandra-operator/issues/1558) Authentication settings aren't applied correctly to cassandra.yaml
+* [CHANGE] [#1561](https://github.com/k8ssandra/k8ssandra-operator/issues/1561) Bump Medusa to 0.24.1

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -25,7 +25,7 @@ import (
 const (
 	DefaultMedusaImageRepository = "k8ssandra"
 	DefaultMedusaImageName       = "medusa"
-	DefaultMedusaVersion         = "0.24.0"
+	DefaultMedusaVersion         = "0.24.1"
 	DefaultMedusaPort            = 50051
 	DefaultProbeInitialDelay     = 10
 	DefaultProbeTimeout          = 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Bumps default cassandra-medusa image from 0.24.0 to 0.24.1, which is a release bringing in a number of CVE fixes.

**Which issue(s) this PR fixes**:
Fixes #1561

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
