### PR TITLE
Modify contact-points-service to do correct reconciliation

### DIFF
--- a/CHANGELOG/CHANGELOG-1.25.md
+++ b/CHANGELOG/CHANGELOG-1.25.md
@@ -13,6 +13,10 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
+## unreleased
+
+* [BUGFIX] [#1585](https://github.com/k8ssandra/k8ssandra-operator/issues/1585) If contact-points-service has updates (such as new ports coming from all-pods-service), we do not update it all. Only a delete would cause the service to be generated with new information. Fixed to correctly reconcile the service.
+
 ## v1.25.0 - 2025-07-17
 
 * [CHANGE] [#1582](https://github.com/k8ssandra/k8ssandra-operator/issues/1582) Replace use of Endpoints with EndpointSlices, same as cass-operator v1.26.0. Also, update to cass-operator v1.26.0 and k8ssandra-client v0.8.1

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -926,7 +926,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 
 	t.Log("check that the contact-points Service for dc2 was created in the control plane")
 	require.Eventually(func() bool {
-		_, endpoints, err := f.GetContactPointsService(ctx, kcKey, kc, dc2Key)
+		service, endpoints, err := f.GetContactPointsService(ctx, kcKey, kc, dc2Key)
 		if err != nil {
 			t.Logf("failed to get contact-points Service: %v", err)
 			return false
@@ -934,7 +934,7 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 
 		return len(endpoints) == 1 && len(endpoints[0].Endpoints) == 1 &&
 			endpoints[0].Endpoints[0].Addresses[0] == "10.0.0.2" &&
-			*endpoints[0].Ports[0].Port == 9042
+			*endpoints[0].Ports[0].Port == 9042 && service.Spec.Ports[0].Port == 9042
 	}, timeout, interval, "timed out waiting for creation of contact-points Service for dc2")
 
 	t.Log("simulate a change of Endpoints in dc2")
@@ -943,14 +943,14 @@ func createMultiDcCluster(t *testing.T, ctx context.Context, f *framework.Framew
 
 	t.Log("check that the contact-points Service for dc2 was updated")
 	require.Eventually(func() bool {
-		_, endpoints, err := f.GetContactPointsService(ctx, kcKey, kc, dc2Key)
+		service, endpoints, err := f.GetContactPointsService(ctx, kcKey, kc, dc2Key)
 		if err != nil {
 			t.Logf("failed to get contact-points Service: %v", err)
 			return false
 		}
 		return len(endpoints) == 1 && len(endpoints[0].Endpoints) == 1 &&
 			endpoints[0].Endpoints[0].Addresses[0] == "10.0.0.3" &&
-			*endpoints[0].Ports[0].Port == 9042
+			*endpoints[0].Ports[0].Port == 9042 && service.Spec.Ports[0].Port == 9042
 	}, timeout, interval, "timed out waiting for update of contact-points Service for dc2")
 
 	t.Log("deleting K8ssandraCluster")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds reconciliation logic to the contact-points-service also, not just the endpointslices.

**Which issue(s) this PR fixes**:
Fixes #1585 

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
