### PR TITLE
Support endpointslices in OpenShift

### DIFF
--- a/CHANGELOG/CHANGELOG-1.26.md
+++ b/CHANGELOG/CHANGELOG-1.26.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [CHANGE] [#1588](https://github.com/k8ssandra/k8ssandra-operator/issues/1588) Use ubi9-micro as the base image for the operator
+* [BUGFIX] Support endpointslices in OpenShift

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -73,8 +73,8 @@ type K8ssandraClusterReconciler struct {
 // +kubebuilder:rbac:groups=stargate.k8ssandra.io,namespace="k8ssandra",resources=stargates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=reaper.k8ssandra.io,namespace="k8ssandra",resources=reapers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=pods;secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=endpoints,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=discovery.k8s.io,namespace="k8ssandra",resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=endpoints;endpoints/restricted,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=discovery.k8s.io,namespace="k8ssandra",resources=endpointslices;endpointslices/restricted,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,namespace="k8ssandra",resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,namespace="k8ssandra",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace="k8ssandra",resources=events,verbs=create;patch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This pull request introduces a bug fix for supporting endpointslices in OpenShift and updates RBAC rules to include restricted access for endpoints and endpointslices. Below is a summary of the most important changes:

### Bug Fixes:
* Added a changelog entry for supporting endpointslices in OpenShift in the `CHANGELOG-1.26.md` file.

### RBAC Updates:
* Updated RBAC rules in `k8ssandracluster_controller.go` to include `endpoints/restricted` and `endpointslices/restricted` resources, ensuring finer-grained access control.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
