### PR TITLE
Remove legacy medusa purge

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [ENHANCEMENT] [#1591](https://github.com/k8ssandra/k8ssandra-operator/issues/1591) Remove the old medusa purge cronjob in favor of scheduled tasks

--- a/config/components/single-namespace/kustomization.yaml
+++ b/config/components/single-namespace/kustomization.yaml
@@ -40,6 +40,11 @@ replacements:
       fieldPaths:
       - webhooks.0.clientConfig.service.namespace
     - select:
+        name: k8ssandra-operator-validating-webhook-configuration
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+      - webhooks.1.clientConfig.service.namespace
+    - select:
         name: k8ssandra-operator-mutating-webhook-configuration
         kind: MutatingWebhookConfiguration
       fieldPaths:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -15,10 +15,10 @@ patchesJson6902:
     kind: ValidatingWebhookConfiguration
   patch: |-
     - op: replace
-      path: /webhooks/1/clientConfig/service/name
+      path: /webhooks/0/clientConfig/service/name
       value: k8ssandra-operator-webhook-service
     - op: replace
-      path: /webhooks/0/clientConfig/service/name
+      path: /webhooks/1/clientConfig/service/name
       value: k8ssandra-operator-webhook-service
 - target:
     group: admissionregistration.k8s.io

--- a/controllers/config/clientconfig_controller_test.go
+++ b/controllers/config/clientconfig_controller_test.go
@@ -58,7 +58,7 @@ func TestClientConfigReconciler(t *testing.T) {
 		// reconciler.secretFilter = secretFilter
 		usedMgr = mgr
 		return reconciler.SetupWithManager(mgr, shutDownFunc)
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("failed to start test environment: %s", err)
 	}

--- a/controllers/control/k8ssandratask_controller_test.go
+++ b/controllers/control/k8ssandratask_controller_test.go
@@ -59,7 +59,7 @@ func TestK8ssandraTask(t *testing.T) {
 			Recorder:         mgr.GetEventRecorderFor("k8ssandratask-controller"),
 		}).SetupWithManager(mgr, clusters)
 		return err
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("failed to start test environment: %s", err)
 	}

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -214,6 +214,11 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 				}
 			}
 
+			// Create Medusa purge schedule
+			if medusaResult := r.reconcileMedusaPurgeSchedule(ctx, kc, actualDc, remoteClient, dcLogger); medusaResult.Completed() {
+				return medusaResult, actualDcs
+			}
+
 			// DC is in the process of being upgraded but hasn't completed yet. Let's wait for it to go through.
 			if actualDc.GetGeneration() != actualDc.Status.ObservedGeneration {
 				dcLogger.Info("CassandraDatacenter is being updated. Requeuing the reconcile.", "Generation", actualDc.GetGeneration(), "ObservedGeneration", actualDc.Status.ObservedGeneration)

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -83,7 +83,7 @@ func TestK8ssandraCluster(t *testing.T) {
 			Recorder:         mgr.GetEventRecorderFor("k8ssandracluster-controller"),
 		}).SetupWithManager(mgr, clusters)
 		return err
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("failed to start test environment: %s", err)
 	}

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -2,22 +2,16 @@ package medusa
 
 import (
 	"context"
-	"crypto/tls"
 	"testing"
 	"time"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ssandractrl "github.com/k8ssandra/k8ssandra-operator/controllers/k8ssandra"
-	secretswebhook "github.com/k8ssandra/k8ssandra-operator/controllers/secrets-webhook"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	testutils "github.com/k8ssandra/k8ssandra-operator/pkg/test"
 )
@@ -41,10 +35,7 @@ func TestCassandraBackupRestore(t *testing.T) {
 	testEnv := setupMedusaBackupTestEnv(t, ctx)
 	defer testEnv.Stop(t)
 	t.Run("TestMedusaBackupDatacenter", testEnv.ControllerTest(ctx, testMedusaBackupDatacenter))
-
-	// TODO: Uncomment this when we have a way to test medusa tasks without flakes
-	// t.Run("TestMedusaTasks", testEnv.ControllerTest(ctx, testMedusaTasks))
-
+	t.Run("TestMedusaTasks", testEnv.ControllerTest(ctx, testMedusaTasks))
 	t.Run("TestMedusaRestoreDatacenter", testEnv.ControllerTest(ctx, testMedusaRestoreDatacenter))
 	t.Run("TestValidationErrorStopsRestore", testEnv.ControllerTest(ctx, testValidationErrorStopsRestore))
 	t.Run("TestMedusaConfiguration", testEnv.ControllerTest(ctx, testMedusaConfiguration))
@@ -88,67 +79,41 @@ func setupMedusaBackupTestEnv(t *testing.T, ctx context.Context) *testutils.Mult
 		if err != nil {
 			return err
 		}
+		return nil
+	}, func(dataPlaneMgr manager.Manager, clientCache *clientcache.ClientCache, clusters []cluster.Cluster) error {
+		if err := (&MedusaBackupJobReconciler{
+			ReconcilerConfig: reconcilerConfig,
+			Client:           dataPlaneMgr.GetClient(),
+			Scheme:           scheme.Scheme,
+			ClientFactory:    medusaClientFactory,
+		}).SetupWithManager(dataPlaneMgr); err != nil {
+			return err
+		}
 
-		for _, env := range testEnv.GetDataPlaneEnvTests() {
-			whServer := webhook.NewServer(webhook.Options{
-				Port:    env.WebhookInstallOptions.LocalServingPort,
-				Host:    env.WebhookInstallOptions.LocalServingHost,
-				CertDir: env.WebhookInstallOptions.LocalServingCertDir,
-				TLSOpts: []func(*tls.Config){func(config *tls.Config) {}},
-			})
+		if err := (&MedusaTaskReconciler{
+			ReconcilerConfig: reconcilerConfig,
+			Client:           dataPlaneMgr.GetClient(),
+			Scheme:           scheme.Scheme,
+			ClientFactory:    medusaClientFactory,
+		}).SetupWithManager(dataPlaneMgr); err != nil {
+			return err
+		}
 
-			dataPlaneMgr, err := ctrl.NewManager(env.Config, ctrl.Options{
-				Scheme:         scheme.Scheme,
-				WebhookServer:  whServer,
-				Metrics:        metricsserver.Options{BindAddress: "0"},
-				LeaderElection: false,
-			})
-			if err != nil {
-				return err
-			}
-			if err := (&MedusaBackupJobReconciler{
-				ReconcilerConfig: reconcilerConfig,
-				Client:           dataPlaneMgr.GetClient(),
-				Scheme:           scheme.Scheme,
-				ClientFactory:    medusaClientFactory,
-			}).SetupWithManager(dataPlaneMgr); err != nil {
-				return err
-			}
+		if err := (&MedusaRestoreJobReconciler{
+			ReconcilerConfig: reconcilerConfig,
+			Client:           dataPlaneMgr.GetClient(),
+			Scheme:           scheme.Scheme,
+			ClientFactory:    medusaRestoreClientFactory,
+		}).SetupWithManager(dataPlaneMgr); err != nil {
+			return err
+		}
 
-			if err := (&MedusaTaskReconciler{
-				ReconcilerConfig: reconcilerConfig,
-				Client:           dataPlaneMgr.GetClient(),
-				Scheme:           scheme.Scheme,
-				ClientFactory:    medusaClientFactory,
-			}).SetupWithManager(dataPlaneMgr); err != nil {
-				return err
-			}
-
-			if err := (&MedusaRestoreJobReconciler{
-				ReconcilerConfig: reconcilerConfig,
-				Client:           dataPlaneMgr.GetClient(),
-				Scheme:           scheme.Scheme,
-				ClientFactory:    medusaRestoreClientFactory,
-			}).SetupWithManager(dataPlaneMgr); err != nil {
-				return err
-			}
-
-			if err := (&MedusaConfigurationReconciler{
-				ReconcilerConfig: reconcilerConfig,
-				Client:           dataPlaneMgr.GetClient(),
-				Scheme:           scheme.Scheme,
-			}).SetupWithManager(dataPlaneMgr); err != nil {
-				return err
-			}
-
-			secretswebhook.SetupSecretsInjectorWebhook(dataPlaneMgr)
-
-			go func() {
-				err := dataPlaneMgr.Start(ctx)
-				if err != nil {
-					t.Errorf("failed to start manager: %s", err)
-				}
-			}()
+		if err := (&MedusaConfigurationReconciler{
+			ReconcilerConfig: reconcilerConfig,
+			Client:           dataPlaneMgr.GetClient(),
+			Scheme:           scheme.Scheme,
+		}).SetupWithManager(dataPlaneMgr); err != nil {
+			return err
 		}
 		return nil
 	})

--- a/controllers/medusa/medusatask_controller_test.go
+++ b/controllers/medusa/medusatask_controller_test.go
@@ -1,279 +1,293 @@
 package medusa
 
-// const (
-// 	backup1 = "good-backup1"
-// 	backup2 = "good-backup2"
-// 	backup3 = "good-backup3"
-// 	backup4 = "good-backup4"
-// 	backup5 = "bad-backup5"
-// 	backup6 = "missing-backup6"
-// )
+import (
+	"context"
+	"testing"
 
-//func testMedusaTasks(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
-//	require := require.New(t)
-//
-//	k8sCtx0 := f.DataPlaneContexts[0]
-//
-//	kc := &k8ss.K8ssandraCluster{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Namespace: namespace,
-//			Name:      "test",
-//		},
-//		Spec: k8ss.K8ssandraClusterSpec{
-//			Cassandra: &k8ss.CassandraClusterTemplate{
-//				Datacenters: []k8ss.CassandraDatacenterTemplate{
-//					{
-//						Meta: k8ss.EmbeddedObjectMeta{
-//							Name: "dc1",
-//						},
-//						K8sContext: k8sCtx0,
-//						Size:       3,
-//						DatacenterOptions: k8ss.DatacenterOptions{
-//							ServerVersion: "3.11.14",
-//							StorageConfig: &cassdcapi.StorageConfig{
-//								CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
-//									StorageClassName: &defaultStorageClass,
-//								},
-//							},
-//						},
-//					},
-//					{
-//						Meta: k8ss.EmbeddedObjectMeta{
-//							Name: "dc2",
-//						},
-//						K8sContext: k8sCtx0,
-//						Size:       3,
-//						DatacenterOptions: k8ss.DatacenterOptions{
-//							ServerVersion: "3.11.14",
-//							StorageConfig: &cassdcapi.StorageConfig{
-//								CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
-//									StorageClassName: &defaultStorageClass,
-//								},
-//							},
-//						},
-//					},
-//				},
-//			},
-//			Medusa: &api.MedusaClusterTemplate{
-//				ContainerImage: &images.Image{
-//					Repository: medusaImageRepo,
-//				},
-//				StorageProperties: api.Storage{
-//					StorageProvider: "s3_compatible",
-//					BucketName:      "not-real",
-//					StorageSecretRef: corev1.LocalObjectReference{
-//						Name: cassandraUserSecret,
-//					},
-//					MaxBackupCount: 1,
-//				},
-//				ServiceProperties: api.Service{
-//					GrpcPort: 7890,
-//				},
-//				CassandraUserSecretRef: corev1.LocalObjectReference{
-//					Name: cassandraUserSecret,
-//				},
-//			},
-//		},
-//	}
-//
-//	t.Log("Creating k8ssandracluster test1 with Medusa")
-//	err := f.Client.Create(ctx, kc)
-//	require.NoError(err, "failed to create K8ssandraCluster")
-//
-//	kcKey := framework.NewClusterKey(f.ControlPlaneContext, namespace, "test")
-//
-//	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc1")
-//	dc2Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc2")
-//
-//	reconcileReplicatedSecret(ctx, t, f, kc)
-//
-//	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
-//		t.Logf("check that %s was created", dcKey.Name)
-//		require.Eventually(f.DatacenterExists(ctx, dcKey), timeout, interval)
-//
-//		t.Log("update datacenter status to scaling up")
-//		err = f.PatchDatacenterStatus(ctx, dcKey, func(dc *cassdcapi.CassandraDatacenter) {
-//			dc.SetCondition(cassdcapi.DatacenterCondition{
-//				Type:               cassdcapi.DatacenterScalingUp,
-//				Status:             corev1.ConditionTrue,
-//				LastTransitionTime: metav1.Now(),
-//			})
-//		})
-//		require.NoError(err, "failed to patch datacenter status")
-//
-//		t.Log("check that the K8ssandraCluster status is updated")
-//		require.Eventually(func() bool {
-//			kc := &k8ss.K8ssandraCluster{}
-//			err = f.Get(ctx, kcKey, kc)
-//
-//			if err != nil {
-//				t.Logf("failed to get K8ssandraCluster: %v", err)
-//				return false
-//			}
-//
-//			if len(kc.Status.Datacenters) == 0 {
-//				return false
-//			}
-//
-//			k8ssandraStatus, found := kc.Status.Datacenters[dcKey.Name]
-//			if !found {
-//				t.Logf("status for datacenter %s not found", dcKey)
-//				return false
-//			}
-//			condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
-//			return condition != nil && condition.Status == corev1.ConditionTrue
-//		}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
-//
-//		err = f.SetDatacenterStatusReady(ctx, dcKey)
-//		require.NoError(err, "failed to set dcKey status ready")
-//	}
-//
-//	dc1 := &cassdcapi.CassandraDatacenter{}
-//	err = f.Get(ctx, dc1Key, dc1)
-//	require.NoError(err, "failed to get dc1")
-//
-//	dc2 := &cassdcapi.CassandraDatacenter{}
-//	err = f.Get(ctx, dc2Key, dc2)
-//	require.NoError(err, "failed to get dc2")
-//
-//	backup1Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup1)
-//	require.True(backup1Created, "failed to create backup1")
-//	backup2Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup2)
-//	require.True(backup2Created, "failed to create backup2")
-//	backup3Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup3)
-//	require.True(backup3Created, "failed to create backup3")
-//	backup4Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup4)
-//	require.True(backup4Created, "failed to create backup4")
-//	backup5Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup5)
-//	require.False(backup5Created, "failed to fail backup5")
-//	backup6Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup6)
-//	require.False(backup6Created, "failed to fail backup6")
-//
-//	// Ensure that 6 backups jobs, but only 4 backups were created (two jobs did not succeed on some pods)
-//	checkBackupsAndJobs(require, ctx, 6, 4, namespace, f, []string{})
-//
-//	checkSyncTask(require, ctx, namespace, "dc2", f)
-//
-//	// Ensure the sync task did not create backups for the failed jobs
-//	checkBackupsAndJobs(require, ctx, 6, 4, namespace, f, []string{})
-//
-//	// Purge backups and verify that only one out of three remains
-//	t.Log("purge backups")
-//
-//	purgeTask := &api.MedusaTask{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Namespace: namespace,
-//			Name:      "purge-backups",
-//			Labels: map[string]string{
-//				"app": "medusa",
-//			},
-//		},
-//		Spec: api.MedusaTaskSpec{
-//			CassandraDatacenter: "dc1",
-//			Operation:           "purge",
-//		},
-//	}
-//
-//	purgeKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "purge-backups")
-//
-//	err = f.Create(ctx, purgeKey, purgeTask)
-//	require.NoError(err, "failed to create purge task")
-//
-//	require.Eventually(func() bool {
-//		updated := &api.MedusaTask{}
-//		err := f.Get(ctx, purgeKey, updated)
-//		if err != nil {
-//			t.Logf("failed to get purge task: %v", err)
-//			return false
-//		}
-//
-//		return !updated.Status.FinishTime.IsZero() && updated.Status.Finished[0].NbBackupsPurged == 2 && len(updated.Status.Finished) == 3
-//	}, timeout, interval)
-//
-//	// After a purge, a sync should get created
-//	purgeSyncKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "purge-backups-sync")
-//	require.Eventually(func() bool {
-//		updated := &api.MedusaTask{}
-//		err := f.Get(ctx, purgeSyncKey, updated)
-//		if err != nil {
-//			t.Logf("failed to get sync task: %v", err)
-//			return false
-//		}
-//
-//		v, ok := updated.Labels["app"]
-//		if !ok || v != "medusa" {
-//			return false
-//		}
-//
-//		return !updated.Status.FinishTime.IsZero()
-//	}, timeout, interval)
-//
-//	// Ensure that 2 backups and backup jobs were deleted
-//	deletedBackups := []string{backup1, backup2}
-//	checkBackupsAndJobs(require, ctx, 4, 2, namespace, f, deletedBackups)
-//
-//	medusaBackup4Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, backup4)
-//	medusaBackup4 := &api.MedusaBackup{}
-//	err = f.Get(ctx, medusaBackup4Key, medusaBackup4)
-//	require.NoError(err, "failed to get medusaBackup4")
-//
-//	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
-//	require.NoError(err, "failed to delete K8ssandraCluster")
-//	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
-//	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
-//}
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
+	"github.com/k8ssandra/k8ssandra-operator/test/framework"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
-//func checkBackupsAndJobs(require *require.Assertions, ctx context.Context, expectedJobsLen, expectedBackupsLen int, namespace string, f *framework.Framework, deleted []string) {
-//	var backups api.MedusaBackupList
-//	err := f.List(ctx, framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "list-backups"), &backups)
-//	require.NoError(err, "failed to list medusabackup")
-//	require.Len(backups.Items, expectedBackupsLen, "expected %d backups, got %d", expectedBackupsLen, len(backups.Items))
-//
-//	var jobs api.MedusaBackupJobList
-//	err = f.List(ctx, framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "list-backup-jobs"), &jobs)
-//	require.NoError(err, "failed to list medusabackupjobs")
-//	require.Len(jobs.Items, expectedJobsLen, "expected %d jobs, got %d", expectedJobsLen, len(jobs.Items))
-//
-//	for _, d := range deleted {
-//		require.NotContains(backups.Items, d, "MedusaBackup %s to have been deleted", d)
-//		require.NotContains(jobs.Items, d, "MedusaBackupJob %s to have been deleted", d)
-//	}
-//}
-//
-//func checkSyncTask(require *require.Assertions, ctx context.Context, namespace, dc string, f *framework.Framework) {
-//	syncTaskName := "sync-backups"
-//
-//	// create a sync task
-//	syncTask := &api.MedusaTask{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Namespace: namespace,
-//			Name:      syncTaskName,
-//			Labels: map[string]string{
-//				"app": "medusa",
-//			},
-//		},
-//		Spec: api.MedusaTaskSpec{
-//			CassandraDatacenter: dc,
-//			Operation:           "sync",
-//		},
-//	}
-//	syncTaskKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, syncTaskName)
-//	err := f.Create(ctx, syncTaskKey, syncTask)
-//	require.NoError(err, "failed to create sync task")
-//
-//	// wait for sync task to finish
-//	require.Eventually(func() bool {
-//		updated := &api.MedusaTask{}
-//		err := f.Get(ctx, syncTaskKey, updated)
-//		if err != nil {
-//			return false
-//		}
-//
-//		v, ok := updated.Labels["app"]
-//		if !ok || v != "medusa" {
-//			return false
-//		}
-//
-//		return !updated.Status.FinishTime.IsZero()
-//	}, timeout, interval)
-//}
+const (
+	backup1 = "good-backup1"
+	backup2 = "good-backup2"
+	backup3 = "good-backup3"
+	backup4 = "good-backup4"
+	backup5 = "bad-backup5"
+	backup6 = "missing-backup6"
+)
+
+func testMedusaTasks(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	require := require.New(t)
+
+	k8sCtx0 := f.DataPlaneContexts[0]
+
+	kc := &k8ss.K8ssandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test",
+		},
+		Spec: k8ss.K8ssandraClusterSpec{
+			Cassandra: &k8ss.CassandraClusterTemplate{
+				Datacenters: []k8ss.CassandraDatacenterTemplate{
+					{
+						Meta: k8ss.EmbeddedObjectMeta{
+							Name: "dc1",
+						},
+						K8sContext: k8sCtx0,
+						Size:       3,
+						DatacenterOptions: k8ss.DatacenterOptions{
+							ServerVersion: "3.11.14",
+							StorageConfig: &cassdcapi.StorageConfig{
+								CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
+									StorageClassName: &defaultStorageClass,
+								},
+							},
+						},
+					},
+					{
+						Meta: k8ss.EmbeddedObjectMeta{
+							Name: "dc2",
+						},
+						K8sContext: k8sCtx0,
+						Size:       3,
+						DatacenterOptions: k8ss.DatacenterOptions{
+							ServerVersion: "3.11.14",
+							StorageConfig: &cassdcapi.StorageConfig{
+								CassandraDataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
+									StorageClassName: &defaultStorageClass,
+								},
+							},
+						},
+					},
+				},
+			},
+			Medusa: &api.MedusaClusterTemplate{
+				ContainerImage: &images.Image{
+					Repository: medusaImageRepo,
+				},
+				StorageProperties: api.Storage{
+					StorageProvider: "s3_compatible",
+					BucketName:      "not-real",
+					StorageSecretRef: corev1.LocalObjectReference{
+						Name: cassandraUserSecret,
+					},
+					MaxBackupCount: 1,
+				},
+				ServiceProperties: api.Service{
+					GrpcPort: 7890,
+				},
+				CassandraUserSecretRef: corev1.LocalObjectReference{
+					Name: cassandraUserSecret,
+				},
+			},
+		},
+	}
+
+	t.Log("Creating k8ssandracluster test1 with Medusa")
+	err := f.Client.Create(ctx, kc)
+	require.NoError(err, "failed to create K8ssandraCluster")
+
+	kcKey := framework.NewClusterKey(f.ControlPlaneContext, namespace, "test")
+
+	dc1Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc1")
+	dc2Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "dc2")
+
+	reconcileReplicatedSecret(ctx, t, f, kc)
+
+	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
+		t.Logf("check that %s was created", dcKey.Name)
+		require.Eventually(f.DatacenterExists(ctx, dcKey), timeout, interval)
+
+		t.Log("update datacenter status to scaling up")
+		err = f.PatchDatacenterStatus(ctx, dcKey, func(dc *cassdcapi.CassandraDatacenter) {
+			dc.SetCondition(cassdcapi.DatacenterCondition{
+				Type:               cassdcapi.DatacenterScalingUp,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			})
+		})
+		require.NoError(err, "failed to patch datacenter status")
+
+		t.Log("check that the K8ssandraCluster status is updated")
+		require.Eventually(func() bool {
+			kc := &k8ss.K8ssandraCluster{}
+			err = f.Get(ctx, kcKey, kc)
+
+			if err != nil {
+				t.Logf("failed to get K8ssandraCluster: %v", err)
+				return false
+			}
+
+			if len(kc.Status.Datacenters) == 0 {
+				return false
+			}
+
+			k8ssandraStatus, found := kc.Status.Datacenters[dcKey.Name]
+			if !found {
+				t.Logf("status for datacenter %s not found", dcKey)
+				return false
+			}
+			condition := findDatacenterCondition(k8ssandraStatus.Cassandra, cassdcapi.DatacenterScalingUp)
+			return condition != nil && condition.Status == corev1.ConditionTrue
+		}, timeout, interval, "timed out waiting for K8ssandraCluster status update")
+
+		err = f.SetDatacenterStatusReady(ctx, dcKey)
+		require.NoError(err, "failed to set dcKey status ready")
+	}
+
+	dc1 := &cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dc1Key, dc1)
+	require.NoError(err, "failed to get dc1")
+
+	dc2 := &cassdcapi.CassandraDatacenter{}
+	err = f.Get(ctx, dc2Key, dc2)
+	require.NoError(err, "failed to get dc2")
+
+	backup1Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup1)
+	require.True(backup1Created, "failed to create backup1")
+	backup2Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup2)
+	require.True(backup2Created, "failed to create backup2")
+	backup3Created := createAndVerifyMedusaBackup(dc1Key, dc1, f, ctx, require, t, namespace, backup3)
+	require.True(backup3Created, "failed to create backup3")
+	backup4Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup4)
+	require.True(backup4Created, "failed to create backup4")
+	backup5Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup5)
+	require.False(backup5Created, "failed to fail backup5")
+	backup6Created := createAndVerifyMedusaBackup(dc2Key, dc2, f, ctx, require, t, namespace, backup6)
+	require.False(backup6Created, "failed to fail backup6")
+
+	// Ensure that 6 backups jobs, but only 4 backups were created (two jobs did not succeed on some pods)
+	checkBackupsAndJobs(require, ctx, 6, 4, namespace, f, []string{})
+
+	checkSyncTask(require, ctx, namespace, "dc2", f)
+
+	// Ensure the sync task did not create backups for the failed jobs
+	checkBackupsAndJobs(require, ctx, 6, 4, namespace, f, []string{})
+
+	// Purge backups and verify that only one out of three remains
+	t.Log("purge backups")
+
+	purgeTask := &api.MedusaTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "purge-backups",
+			Labels: map[string]string{
+				"app": "medusa",
+			},
+		},
+		Spec: api.MedusaTaskSpec{
+			CassandraDatacenter: "dc1",
+			Operation:           "purge",
+		},
+	}
+
+	purgeKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "purge-backups")
+
+	err = f.Create(ctx, purgeKey, purgeTask)
+	require.NoError(err, "failed to create purge task")
+
+	require.Eventually(func() bool {
+		updated := &api.MedusaTask{}
+		err := f.Get(ctx, purgeKey, updated)
+		if err != nil {
+			t.Logf("failed to get purge task: %v", err)
+			return false
+		}
+
+		return !updated.Status.FinishTime.IsZero() && updated.Status.Finished[0].NbBackupsPurged == 2 && len(updated.Status.Finished) == 3
+	}, timeout, interval)
+
+	// After a purge, a sync should get created
+	purgeSyncKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "purge-backups-sync")
+	require.Eventually(func() bool {
+		updated := &api.MedusaTask{}
+		err := f.Get(ctx, purgeSyncKey, updated)
+		if err != nil {
+			t.Logf("failed to get sync task: %v", err)
+			return false
+		}
+
+		v, ok := updated.Labels["app"]
+		if !ok || v != "medusa" {
+			return false
+		}
+
+		return !updated.Status.FinishTime.IsZero()
+	}, timeout, interval)
+
+	// Ensure that 2 backups and backup jobs were deleted
+	deletedBackups := []string{backup1, backup2}
+	checkBackupsAndJobs(require, ctx, 4, 2, namespace, f, deletedBackups)
+
+	medusaBackup4Key := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, backup4)
+	medusaBackup4 := &api.MedusaBackup{}
+	err = f.Get(ctx, medusaBackup4Key, medusaBackup4)
+	require.NoError(err, "failed to get medusaBackup4")
+
+	err = f.DeleteK8ssandraCluster(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: kc.Name}, timeout, interval)
+	require.NoError(err, "failed to delete K8ssandraCluster")
+	verifyObjectDoesNotExist(ctx, t, f, dc1Key, &cassdcapi.CassandraDatacenter{})
+	verifyObjectDoesNotExist(ctx, t, f, dc2Key, &cassdcapi.CassandraDatacenter{})
+}
+func checkBackupsAndJobs(require *require.Assertions, ctx context.Context, expectedJobsLen, expectedBackupsLen int, namespace string, f *framework.Framework, deleted []string) {
+	var backups api.MedusaBackupList
+	err := f.List(ctx, framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "list-backups"), &backups)
+	require.NoError(err, "failed to list medusabackup")
+	require.Len(backups.Items, expectedBackupsLen, "expected %d backups, got %d", expectedBackupsLen, len(backups.Items))
+
+	var jobs api.MedusaBackupJobList
+	err = f.List(ctx, framework.NewClusterKey(f.DataPlaneContexts[0], namespace, "list-backup-jobs"), &jobs)
+	require.NoError(err, "failed to list medusabackupjobs")
+	require.Len(jobs.Items, expectedJobsLen, "expected %d jobs, got %d", expectedJobsLen, len(jobs.Items))
+
+	for _, d := range deleted {
+		require.NotContains(backups.Items, d, "MedusaBackup %s to have been deleted", d)
+		require.NotContains(jobs.Items, d, "MedusaBackupJob %s to have been deleted", d)
+	}
+}
+
+func checkSyncTask(require *require.Assertions, ctx context.Context, namespace, dc string, f *framework.Framework) {
+	syncTaskName := "sync-backups"
+
+	// create a sync task
+	syncTask := &api.MedusaTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      syncTaskName,
+			Labels: map[string]string{
+				"app": "medusa",
+			},
+		},
+		Spec: api.MedusaTaskSpec{
+			CassandraDatacenter: dc,
+			Operation:           "sync",
+		},
+	}
+	syncTaskKey := framework.NewClusterKey(f.DataPlaneContexts[0], namespace, syncTaskName)
+	err := f.Create(ctx, syncTaskKey, syncTask)
+	require.NoError(err, "failed to create sync task")
+
+	// wait for sync task to finish
+	require.Eventually(func() bool {
+		updated := &api.MedusaTask{}
+		err := f.Get(ctx, syncTaskKey, updated)
+		if err != nil {
+			return false
+		}
+
+		v, ok := updated.Labels["app"]
+		if !ok || v != "medusa" {
+			return false
+		}
+
+		return !updated.Status.FinishTime.IsZero()
+	}, timeout, interval)
+}

--- a/controllers/replication/secret_controller_test.go
+++ b/controllers/replication/secret_controller_test.go
@@ -53,7 +53,7 @@ func TestSecretController(t *testing.T) {
 			ReconcilerConfig: config.InitConfig(),
 			ClientCache:      clientCache,
 		}).SetupWithManager(mgr, clusters, logger)
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("failed to start test environment: %s", err)
 	}

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -1,7 +1,6 @@
 package medusa
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -706,36 +705,4 @@ func TestGenerateMedusaProbe(t *testing.T) {
 	probe, err := generateMedusaProbe(rejectedProbe, 55055)
 	assert.Error(t, err)
 	assert.Nil(t, probe)
-}
-
-func TestPurgeCronJob(t *testing.T) {
-	// Define your test inputs
-	dcConfig := &cassandra.DatacenterConfig{
-		DatacenterName: "testDc",
-	}
-	clusterName := "testCluster"
-	namespace := "testNamespace"
-	logger := logr.New(logr.Discard().GetSink())
-
-	// Call the function with the test inputs
-	actualCronJob, err := PurgeCronJob(dcConfig, clusterName, namespace, logger)
-	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%s-%s-medusa-purge", "testcluster", "testdc"), actualCronJob.ObjectMeta.Name)
-	assert.Equal(t, 3, len(actualCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command))
-	assert.Contains(t, actualCronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command[2], "\\nspec:\\n  cassandraDatacenter: testdc")
-	assert.Equal(t, "default", actualCronJob.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName)
-}
-
-func TestPurgeCronJobNameTooLong(t *testing.T) {
-	// Define your test inputs
-	dcConfig := &cassandra.DatacenterConfig{
-		DatacenterName: "testDatacentercWithAReallyLongNameToTestThatTheCharacterCountOfTheNameGoesOverTwoHundredFiftyThreeCharactersTestTestTestTest",
-	}
-	clusterName := "testClusterNameBeingWayTooLongToTestThatTheCharacterCountOfTheNameGoesOverTwoHundredFiftyThreeCharactersTestTestTestTest"
-	namespace := "testNamespace"
-	logger := logr.New(logr.Discard().GetSink())
-
-	// Call the function with the test inputs
-	_, err := PurgeCronJob(dcConfig, clusterName, namespace, logger)
-	assert.NotNil(t, err)
 }

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -110,8 +110,6 @@ func createMultiMedusaJob(t *testing.T, ctx context.Context, namespace string, f
 	// Restore the backup in each DC and verify it finished correctly
 	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
 		restoreBackupJob(t, ctx, namespace, f, dcKey)
-	}
-	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
 		verifyRestoreJobFinished(t, ctx, f, dcKey, backupKey)
 	}
 }
@@ -184,9 +182,9 @@ func checkPurgeBackupScheduleExists(t *testing.T, ctx context.Context, namespace
 	// Get the Cassandra pod
 	dc := &cassdcapi.CassandraDatacenter{}
 	err := f.Get(ctx, dcKey, dc)
-	t.Log("Checking that the purge Cron Job exists")
+	t.Log("Checking that the purge schedule exists")
 	require.NoError(err, "Error getting the CassandraDatacenter")
-	// check that the cronjob exists
+	// check that the purge schedule exists
 	backupSchedule := &medusa.MedusaBackupSchedule{}
 	err = f.Get(ctx, framework.NewClusterKey(dcKey.K8sContext, dcNamespace, medusapkg.MedusaPurgeScheduleName(kc.SanitizedName(), dc.DatacenterName())), backupSchedule)
 	require.NoErrorf(err, "Error getting the Medusa purge schedule. ClusterName: %s, DatacenterName: %s", kc.SanitizedName(), dcKey.Name)

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -95,7 +95,7 @@ func createMultiMedusaJob(t *testing.T, ctx context.Context, namespace string, f
 	for _, dcKey := range []framework.ClusterKey{dc1Key, dc2Key} {
 		checkDatacenterReady(t, ctx, dcKey, f)
 		checkMedusaContainersExist(t, ctx, namespace, dcKey, f, kc)
-		checkNoPurgeBackupSchedule(t, ctx, namespace, dcKey, f, kc)
+		checkPurgeBackupScheduleExists(t, ctx, namespace, dcKey, f, kc)
 		checkReplicatedSecretMounted(t, ctx, f, dcKey, localBucketSecretName)
 	}
 

--- a/test/e2e/medusa_test.go
+++ b/test/e2e/medusa_test.go
@@ -176,30 +176,18 @@ func checkMedusaContainersExist(t *testing.T, ctx context.Context, namespace str
 
 func checkPurgeBackupScheduleExists(t *testing.T, ctx context.Context, namespace string, dcKey framework.ClusterKey, f *framework.E2eFramework, kc *api.K8ssandraCluster) {
 	require := require.New(t)
-	// Get the Cassandra pod
-	dc1 := &cassdcapi.CassandraDatacenter{}
-	err := f.Get(ctx, dcKey, dc1)
-	// check medusa containers exist
-	require.NoError(err, "Error getting the CassandraDatacenter")
-	t.Log("Checking that the purge Backup Schedule exists")
 	// check that the cronjob exists
 	backupSchedule := &medusa.MedusaBackupSchedule{}
-	err = f.Get(ctx, framework.NewClusterKey(dcKey.K8sContext, namespace, medusapkg.MedusaPurgeScheduleName(kc.SanitizedName(), dc1.DatacenterName())), backupSchedule)
-	require.NoErrorf(err, "Error getting the Medusa purge schedule. ClusterName: %s, DatacenterName: %s", kc.SanitizedName(), dc1.LabelResourceName())
+	err := f.Get(ctx, dcKey, backupSchedule)
+	require.NoErrorf(err, "Error getting the Medusa purge schedule. ClusterName: %s, DatacenterName: %s", kc.SanitizedName(), dcKey.Name)
 }
 
 func checkNoPurgeBackupSchedule(t *testing.T, ctx context.Context, namespace string, dcKey framework.ClusterKey, f *framework.E2eFramework, kc *api.K8ssandraCluster) {
 	require := require.New(t)
 	t.Log("Checking that the purge Cron Job doesn't exist")
-	// Get the Cassandra pod
-	dc1 := &cassdcapi.CassandraDatacenter{}
-	err := f.Get(ctx, dcKey, dc1)
-	// check medusa containers exist
-	require.NoError(err, "Error getting the CassandraDatacenter")
-	// ensure the cronjob was not created
 	backupSchedule := &medusa.MedusaBackupSchedule{}
-	err = f.Get(ctx, framework.NewClusterKey(dcKey.K8sContext, namespace, medusapkg.MedusaPurgeScheduleName(kc.SanitizedName(), dc1.DatacenterName())), backupSchedule)
-	require.Error(err, "MedusaBackupSchedule for purge should not exist")
+	err := f.Get(ctx, dcKey, backupSchedule)
+	require.Error(err, "MedusaBackupSchedule for purge should not exist for datacenter %s", dcKey.Name)
 }
 
 func checkPurgeBackupScheduleDeleted(t *testing.T, ctx context.Context, namespace string, dcKey framework.ClusterKey, f *framework.E2eFramework, kc *api.K8ssandraCluster) {

--- a/test/framework/e2e_framework.go
+++ b/test/framework/e2e_framework.go
@@ -18,7 +18,6 @@ import (
 
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/encryption"
-	"github.com/stretchr/testify/require"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	replicationapi "github.com/k8ssandra/k8ssandra-operator/apis/replication/v1alpha1"
@@ -686,7 +685,7 @@ func (f *E2eFramework) DumpClusterInfo(test string, namespaces ...string) error 
 
 			// Dump all objects that we need to investigate failures as a flat list and as yaml manifests
 			for _, objectType := range []string{"K8ssandraCluster", "CassandraDatacenter", "Stargate", "Reaper", "StatefulSet", "Secrets",
-				"ReplicatedSecret", "ClientConfig", "CassandraTask", "MedusaBackup", "MedusaBackupJob", "MedusaRestoreJob", "MedusaTask", "ConfigMaps"} {
+				"ReplicatedSecret", "ClientConfig", "CassandraTask", "MedusaBackup", "MedusaBackupJob", "MedusaRestoreJob", "MedusaTask", "ConfigMaps", "MedusaBackupSchedule"} {
 				if err := os.MkdirAll(fmt.Sprintf("%s/%s/objects/%s", outputDir, namespace, objectType), 0755); err != nil {
 					return err
 				}
@@ -887,10 +886,8 @@ func (f *E2eFramework) GetCassandraDatacenterPods(t *testing.T, ctx context.Cont
 	podList := &corev1.PodList{}
 	labels := client.MatchingLabels{cassdcapi.DatacenterLabel: dcName}
 	err := f.List(ctx, dcKey, podList, labels)
-	require.NoError(t, err, "failed to get pods for cassandradatacenter", "CassandraDatacenter", dcKey.Name)
-
 	pods := make([]corev1.Pod, 0)
 	pods = append(pods, podList.Items...)
 
-	return pods, nil
+	return pods, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR removes the old cron job that was created to trigger purges in favor of a MedusaBackupSchedule object.
This CR will be created for each DC when medusa is enabled, and owned by the cassdc for proper cleanup on deletion.
As tests started failing due to a missing webhook in the remote clusters, some refactoring had to happen in the test framework to properly start the webhook servers in all dataplanes (MedusaBackupSchedule objects are reconciled locally in the dataplanes).
This led to a simplification of the other Medusa integration tests to create the test environments consistently with the other tests (and hopefully stabilize them).


**Which issue(s) this PR fixes**:
Fixes #1591 
Fixes #1507
Fixes #1356
Fixes #1278
Fixes #1230

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
