### PR TITLE
change default k8ssandra-client version

### DIFF
--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -436,9 +436,9 @@ type DatacenterOptions struct {
 
 	// The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
 	// configuration. This is only useful when PerNodeConfigMapRef is set.
-	// The default is "k8ssandra/k8ssandra-client:v0.8.1".
+	// The default is "k8ssandra/k8ssandra-client:v0.8.2".
 	// +optional
-	// +kubebuilder:default="k8ssandra/k8ssandra-client:v0.8.1"
+	// +kubebuilder:default="k8ssandra/k8ssandra-client:v0.8.2"
 	PerNodeConfigInitContainerImage string `json:"perNodeConfigInitContainerImage,omitempty"`
 
 	// The k8s service account to use for the Cassandra pods

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -10004,11 +10004,11 @@ spec:
                               type: object
                           type: object
                         perNodeConfigInitContainerImage:
-                          default: k8ssandra/k8ssandra-client:v0.8.1
+                          default: k8ssandra/k8ssandra-client:v0.8.2
                           description: |-
                             The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                             configuration. This is only useful when PerNodeConfigMapRef is set.
-                            The default is "k8ssandra/k8ssandra-client:v0.8.1".
+                            The default is "k8ssandra/k8ssandra-client:v0.8.2".
                           type: string
                         perNodeConfigMapRef:
                           description: |-
@@ -23080,11 +23080,11 @@ spec:
                         type: object
                     type: object
                   perNodeConfigInitContainerImage:
-                    default: k8ssandra/k8ssandra-client:v0.8.1
+                    default: k8ssandra/k8ssandra-client:v0.8.2
                     description: |-
                       The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                       configuration. This is only useful when PerNodeConfigMapRef is set.
-                      The default is "k8ssandra/k8ssandra-client:v0.8.1".
+                      The default is "k8ssandra/k8ssandra-client:v0.8.2".
                     type: string
                   podPriorityClassName:
                     description: PodPriorityClassName defines the priority class name

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -86,7 +86,7 @@ client:
     # -- Image repository for the client
     repository: k8ssandra/k8ssandra-client
     # -- Tag of the client image to pull from
-    tag: v0.8.1
+    tag: v0.8.2
     # -- Pull policy for the client container
     pullPolicy: IfNotPresent
   # -- HTTPS proxy address to use for communication to helm.k8ssandra.io

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -9939,11 +9939,11 @@ spec:
                               type: object
                           type: object
                         perNodeConfigInitContainerImage:
-                          default: k8ssandra/k8ssandra-client:v0.8.1
+                          default: k8ssandra/k8ssandra-client:v0.8.2
                           description: |-
                             The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                             configuration. This is only useful when PerNodeConfigMapRef is set.
-                            The default is "k8ssandra/k8ssandra-client:v0.8.1".
+                            The default is "k8ssandra/k8ssandra-client:v0.8.2".
                           type: string
                         perNodeConfigMapRef:
                           description: |-
@@ -23015,11 +23015,11 @@ spec:
                         type: object
                     type: object
                   perNodeConfigInitContainerImage:
-                    default: k8ssandra/k8ssandra-client:v0.8.1
+                    default: k8ssandra/k8ssandra-client:v0.8.2
                     description: |-
                       The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
                       configuration. This is only useful when PerNodeConfigMapRef is set.
-                      The default is "k8ssandra/k8ssandra-client:v0.8.1".
+                      The default is "k8ssandra/k8ssandra-client:v0.8.2".
                     type: string
                   podPriorityClassName:
                     description: PodPriorityClassName defines the priority class name

--- a/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md
+++ b/docs/content/en/reference/crd/k8ssandra-operator-crds-latest/_index.md
@@ -1190,9 +1190,9 @@ api heap.<br/>
         <td>
           The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
 configuration. This is only useful when PerNodeConfigMapRef is set.
-The default is "k8ssandra/k8ssandra-client:v0.8.1".<br/>
+The default is "k8ssandra/k8ssandra-client:v0.8.2".<br/>
           <br/>
-            <i>Default</i>: k8ssandra/k8ssandra-client:v0.8.1<br/>
+            <i>Default</i>: k8ssandra/k8ssandra-client:v0.8.2<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5584,9 +5584,9 @@ api heap.<br/>
         <td>
           The image to use in each Cassandra pod for the (short-lived) init container that merges global and perNodeConfig
 configuration. This is only useful when PerNodeConfigMapRef is set.
-The default is "k8ssandra/k8ssandra-client:v0.8.1".<br/>
+The default is "k8ssandra/k8ssandra-client:v0.8.2".<br/>
           <br/>
-            <i>Default</i>: k8ssandra/k8ssandra-client:v0.8.1<br/>
+            <i>Default</i>: k8ssandra/k8ssandra-client:v0.8.2<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/nodeconfig/mount.go
+++ b/pkg/nodeconfig/mount.go
@@ -25,7 +25,7 @@ func MountPerNodeConfig(dcConfig *cassandra.DatacenterConfig) {
 }
 
 const (
-	defaultPerNodeConfigInitContainerImage = "k8ssandra/k8ssandra-client:v0.8.1"
+	defaultPerNodeConfigInitContainerImage = "k8ssandra/k8ssandra-client:v0.8.2"
 )
 
 func newPerNodeConfigInitContainer(image string) v1.Container {


### PR DESCRIPTION
Change default k8ssandra-client version trying to fix an issue experienced during a update process.
Below the error obtained during the crd-upgrader process:
```
2025/08/25 12:34:07 INFO Processing request to upgrade project CustomResourceDefinitions repoName=k8ssandra chartName=k8ssandra-operator chartVersion=1.26.0
2025/08/25 12:34:07 INFO Downloading chart release from remote repository repoURL=https://helm.k8ssandra.io/ chartName=k8ssandra-operator chartVersion=1.26.0 chartDir=/.cache/k8ssandra/k8ssandra-operator
2025/08/25 12:34:07 ERRO Error upgrading CustomResourceDefinitions error="Get \"https://helm.k8ssandra.io/index.yaml\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
Error: Get "https://helm.k8ssandra.io/index.yaml": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

**What this PR does**: 
It should be fix the issue reported above using the last k8ssandra-client version. In the last version of the tool was added a missing ca-certificate package in his Dockerfile. See https://github.com/k8ssandra/k8ssandra-client/pull/97.

**Which issue(s) this PR fixes**:
I hope this modification fixes the issue reported in the ticket #1602

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
