### PR TITLE
Add --charts to the crd_upgrader Helm Job

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [ENHANCEMENT] [#1591](https://github.com/k8ssandra/k8ssandra-operator/issues/1591) Remove the old medusa purge cronjob in favor of scheduled tasks
+* [BUGFIX] [#1603](https://github.com/k8ssandra/k8ssandra-operator/issues/1603) Fix the crd-upgrader to update cass-operator CRDs also as part of the Helm upgrade

--- a/charts/k8ssandra-operator/templates/crd/batch_job.yaml
+++ b/charts/k8ssandra-operator/templates/crd/batch_job.yaml
@@ -49,6 +49,8 @@ spec:
             - {{ .Chart.Name }}
             - --chartRepo
             - k8ssandra
+            - --charts
+            - cass-operator
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
We only update the main chart on the crd-upgrader these days without the --charts indicating additional subcharts to update also. Adding cass-operator here to ensure its CRDs are also upgraded when Helm upgrade is called.

**Which issue(s) this PR fixes**:
Fixes #1603
Fixes #1536 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
