### PR TITLE
Replace use of setControllerReference with setOwnerReference

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -17,3 +17,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [ENHANCEMENT] [#1591](https://github.com/k8ssandra/k8ssandra-operator/issues/1591) Remove the old medusa purge cronjob in favor of scheduled tasks
 * [BUGFIX] [#1603](https://github.com/k8ssandra/k8ssandra-operator/issues/1603) Fix the crd-upgrader to update cass-operator CRDs also as part of the Helm upgrade
+* [BUGFIX] [#1610](https://github.com/k8ssandra/k8ssandra-operator/issues/1610) Replace all Medusa setControllerReference with setOwnerReference when targetting CassandraDatacenter objects

--- a/controllers/medusa/medusabackupjob_controller.go
+++ b/controllers/medusa/medusabackupjob_controller.go
@@ -88,7 +88,7 @@ func (r *MedusaBackupJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Set an owner reference on the backup job so that it can be cleaned up when the cassandra datacenter is deleted
 	if backupJob.OwnerReferences == nil {
-		if err = controllerutil.SetControllerReference(cassdc, backupJob, r.Scheme); err != nil {
+		if err = controllerutil.SetOwnerReference(cassdc, backupJob, r.Scheme); err != nil {
 			logger.Error(err, "failed to set controller reference", "CassandraDatacenter", cassdcKey)
 			return ctrl.Result{}, err
 		}

--- a/controllers/medusa/medusabackupschedule_controller.go
+++ b/controllers/medusa/medusabackupschedule_controller.go
@@ -19,8 +19,9 @@ package medusa
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,7 +84,7 @@ func (r *MedusaBackupScheduleReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Set an owner reference on the task so that it can be cleaned up when the cassandra datacenter is deleted
 	if backupSchedule.OwnerReferences == nil {
-		if err = controllerutil.SetControllerReference(dc, backupSchedule, r.Scheme); err != nil {
+		if err = controllerutil.SetOwnerReference(dc, backupSchedule, r.Scheme); err != nil {
 			logger.Error(err, "failed to set controller reference", "CassandraDatacenter", dcKey)
 			return ctrl.Result{}, err
 		}

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -97,7 +97,7 @@ func (r *MedusaRestoreJobReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Set an owner reference on the restore job so that it can be cleaned up when the cassandra datacenter is deleted
 	if request.RestoreJob.OwnerReferences == nil {
-		if err = controllerutil.SetControllerReference(cassdc, request.RestoreJob, r.Scheme); err != nil {
+		if err = controllerutil.SetOwnerReference(cassdc, request.RestoreJob, r.Scheme); err != nil {
 			logger.Error(err, "failed to set controller reference", "CassandraDatacenter", cassdcKey)
 			return ctrl.Result{}, err
 		}

--- a/controllers/medusa/medusatask_controller.go
+++ b/controllers/medusa/medusatask_controller.go
@@ -88,7 +88,7 @@ func (r *MedusaTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Set an owner reference on the task so that it can be cleaned up when the cassandra datacenter is deleted
 	if task.OwnerReferences == nil {
-		if err = controllerutil.SetControllerReference(cassdc, task, r.Scheme); err != nil {
+		if err = controllerutil.SetOwnerReference(cassdc, task, r.Scheme); err != nil {
 			logger.Error(err, "failed to set controller reference", "CassandraDatacenter", cassdcKey)
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Removes the use of setControllerReference(cassdc, ..) from Medusa controllers to reduce the RBAC requirements in Openshift and remove the incorrect controller reference in the CassDc objects.

**Which issue(s) this PR fixes**:
Fixes #1610 
Fixes #1609


**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
