### PR TITLE
Add namespace selector to the StatefulSet fetcher in restore

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1245](https://github.com/k8ssandra/k8ssandra-operator/issues/1245) Ensure ReplicatedSecret targets are cleaned up correctly
 * [BUGFIX] [#1603](https://github.com/k8ssandra/k8ssandra-operator/issues/1603) Fix the crd-upgrader to update cass-operator CRDs also as part of the Helm upgrade
 * [BUGFIX] [#1610](https://github.com/k8ssandra/k8ssandra-operator/issues/1610) Replace all Medusa setControllerReference with setOwnerReference when targetting CassandraDatacenter objects
+* [BUGFIX] [#1618](https://github.com/k8ssandra/k8ssandra-operator/issues/1618) If two datacenters with same clusterName were present in different namespaces, it was possible that the wrong one was picked when checking the status of the restore. 

--- a/controllers/medusa/medusarestorejob_controller.go
+++ b/controllers/medusa/medusarestorejob_controller.go
@@ -242,7 +242,7 @@ func (r *MedusaRestoreJobReconciler) podTemplateSpecUpdateComplete(ctx context.C
 	statefulsetList := &appsv1.StatefulSetList{}
 	labels := client.MatchingLabels{cassdcapi.ClusterLabel: cassdcapi.CleanLabelValue(req.Datacenter.Spec.ClusterName), cassdcapi.DatacenterLabel: req.Datacenter.Name}
 
-	if err := r.List(ctx, statefulsetList, labels); err != nil {
+	if err := r.List(ctx, statefulsetList, labels, client.InNamespace(req.Datacenter.Namespace)); err != nil {
 		req.Log.Error(err, "Failed to get StatefulSets")
 		return false, err
 	}


### PR DESCRIPTION
…oller to ensure we target the correct datacenter when checking the status

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds a namespace filter to the client when fetching StatefulSets. This should avoid alphabetic ordering issues when fetching the same cluster+namespace combination from a Kubernetes cluster that might have overlapping instances.

**Which issue(s) this PR fixes**:
Fixes #1618 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
