### PR TITLE
Add PullSecret string field for the Image instead of PullSecretRef

### DIFF
--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -9822,12 +9822,20 @@ spec:
                               - IfNotPresent
                               - Never
                               type: string
+                            pullSecret:
+                              description: |-
+                                The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                secrets are honored. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                              type: string
                             pullSecretRef:
                               description: |-
                                 The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                 individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                 secrets are honored. More info:
                                 https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                DEPRECATED Use pullSecret instead
                               properties:
                                 name:
                                   default: ""
@@ -12347,12 +12355,20 @@ spec:
                                   - IfNotPresent
                                   - Never
                                   type: string
+                                pullSecret:
+                                  description: |-
+                                    The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                    individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                    secrets are honored. More info:
+                                    https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                  type: string
                                 pullSecretRef:
                                   description: |-
                                     The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                     individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                     secrets are honored. More info:
                                     https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                    DEPRECATED Use pullSecret instead
                                   properties:
                                     name:
                                       default: ""
@@ -13643,12 +13659,20 @@ spec:
                                         - IfNotPresent
                                         - Never
                                         type: string
+                                      pullSecret:
+                                        description: |-
+                                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                          secrets are honored. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                        type: string
                                       pullSecretRef:
                                         description: |-
                                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                           secrets are honored. More info:
                                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                          DEPRECATED Use pullSecret instead
                                         properties:
                                           name:
                                             default: ""
@@ -22903,12 +22927,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -27164,12 +27196,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -29151,12 +29191,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -29239,12 +29287,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -31982,12 +32038,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -35580,12 +35644,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""
@@ -35689,12 +35761,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""
@@ -38805,12 +38885,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""
@@ -40079,12 +40167,20 @@ spec:
                           - IfNotPresent
                           - Never
                           type: string
+                        pullSecret:
+                          description: |-
+                            The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                            individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                            secrets are honored. More info:
+                            https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: string
                         pullSecretRef:
                           description: |-
                             The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                             individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                             secrets are honored. More info:
                             https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                            DEPRECATED Use pullSecret instead
                           properties:
                             name:
                               default: ""

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -9757,12 +9757,20 @@ spec:
                               - IfNotPresent
                               - Never
                               type: string
+                            pullSecret:
+                              description: |-
+                                The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                secrets are honored. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                              type: string
                             pullSecretRef:
                               description: |-
                                 The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                 individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                 secrets are honored. More info:
                                 https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                DEPRECATED Use pullSecret instead
                               properties:
                                 name:
                                   default: ""
@@ -12282,12 +12290,20 @@ spec:
                                   - IfNotPresent
                                   - Never
                                   type: string
+                                pullSecret:
+                                  description: |-
+                                    The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                    individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                    secrets are honored. More info:
+                                    https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                  type: string
                                 pullSecretRef:
                                   description: |-
                                     The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                     individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                     secrets are honored. More info:
                                     https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                    DEPRECATED Use pullSecret instead
                                   properties:
                                     name:
                                       default: ""
@@ -13578,12 +13594,20 @@ spec:
                                         - IfNotPresent
                                         - Never
                                         type: string
+                                      pullSecret:
+                                        description: |-
+                                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                                          secrets are honored. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                        type: string
                                       pullSecretRef:
                                         description: |-
                                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                                           secrets are honored. More info:
                                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                          DEPRECATED Use pullSecret instead
                                         properties:
                                           name:
                                             default: ""
@@ -22838,12 +22862,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -27099,12 +27131,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -29086,12 +29126,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -29174,12 +29222,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""
@@ -31917,12 +31973,20 @@ spec:
                         - IfNotPresent
                         - Never
                         type: string
+                      pullSecret:
+                        description: |-
+                          The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                          individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                          secrets are honored. More info:
+                          https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        type: string
                       pullSecretRef:
                         description: |-
                           The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                           individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                           secrets are honored. More info:
                           https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          DEPRECATED Use pullSecret instead
                         properties:
                           name:
                             default: ""

--- a/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
+++ b/config/crd/bases/reaper.k8ssandra.io_reapers.yaml
@@ -1280,12 +1280,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""
@@ -1389,12 +1397,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""

--- a/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
+++ b/config/crd/bases/stargate.k8ssandra.io_stargates.yaml
@@ -1246,12 +1246,20 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  pullSecret:
+                    description: |-
+                      The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                      individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                      secrets are honored. More info:
+                      https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                    type: string
                   pullSecretRef:
                     description: |-
                       The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                       individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                       secrets are honored. More info:
                       https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                      DEPRECATED Use pullSecret instead
                     properties:
                       name:
                         default: ""
@@ -2520,12 +2528,20 @@ spec:
                           - IfNotPresent
                           - Never
                           type: string
+                        pullSecret:
+                          description: |-
+                            The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
+                            individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
+                            secrets are honored. More info:
+                            https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: string
                         pullSecretRef:
                           description: |-
                             The secret to use when pulling the image from private repositories. If specified, this secret will be passed to
                             individual puller implementations for them to use. For example, in the case of Docker, only DockerConfig type
                             secrets are honored. More info:
                             https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                            DEPRECATED Use pullSecret instead
                           properties:
                             name:
                               default: ""

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -14,6 +14,7 @@ var (
 		"default-name",
 		"default-tag",
 		"",
+		"",
 		nil,
 	}
 	latestImage = Image{
@@ -22,6 +23,7 @@ var (
 		"latest-name",
 		"latest",
 		"",
+		"latest-pull-secret",
 		&corev1.LocalObjectReference{Name: "latest-pull-secret"},
 	}
 	customImage = Image{
@@ -30,6 +32,7 @@ var (
 		"custom-name",
 		"",
 		corev1.PullAlways,
+		"custom-pull-secret",
 		&corev1.LocalObjectReference{Name: "custom-pull-secret"},
 	}
 	coalescedImage1 = Image{
@@ -38,6 +41,7 @@ var (
 		"default-name",
 		"default-tag",
 		corev1.PullIfNotPresent,
+		"",
 		nil,
 	}
 	coalescedImage2 = Image{
@@ -46,6 +50,7 @@ var (
 		customImage.Name,
 		defaultImage.Tag,
 		customImage.PullPolicy,
+		customImage.PullSecretRef.Name,
 		customImage.PullSecretRef,
 	}
 	coalescedImage3 = Image{
@@ -54,6 +59,7 @@ var (
 		latestImage.Name,
 		latestImage.Tag,
 		corev1.PullAlways,
+		latestImage.PullSecretRef.Name,
 		latestImage.PullSecretRef,
 	}
 	emptyImage = Image{}

--- a/pkg/stargate/deployments_test.go
+++ b/pkg/stargate/deployments_test.go
@@ -826,6 +826,23 @@ func testImages(t *testing.T) {
 		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
 		assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
 	})
+	t.Run("custom image 5", func(t *testing.T) {
+		stargate := stargate.DeepCopy()
+		image := &images.Image{
+			Repository: "my-custom-repo",
+			Tag:        "latest",
+			PullSecret: "my-secret",
+		}
+		stargate.Spec.ContainerImage = image
+		logger := testlogr.NewTestLogger(t)
+		deployments := NewDeployments(stargate, dc, logger)
+		require.Len(t, deployments, 1)
+		deployment := deployments["cluster1-dc1-default-stargate-deployment"]
+		assert.Equal(t, "docker.io/my-custom-repo/stargate-3_11:latest", deployment.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, corev1.PullAlways, deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+		assert.Contains(t, deployment.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: "my-secret"})
+		assert.Len(t, deployment.Spec.Template.Spec.ImagePullSecrets, 1)
+	})
 	t.Run("default image DSE 6.8", func(t *testing.T) {
 		stargate := stargate.DeepCopy()
 		stargate.Spec.ContainerImage = &images.Image{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds "PullSecret" to the Image struct that has precedence over PullSecretRef. This is to ensure the compatibility with the cass-operator Image type (and to allow easier migration in the future) and adheres to the API documentation in Kubernetes which states for LocalObjectReference:

"// New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs."

Also, deprecate PullSecretRef so we can in the future migrate away from it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
