### PR TITLE
Remove sanitization from cluster name when configuring reaper.

### DIFF
--- a/CHANGELOG/CHANGELOG-1.30.md
+++ b/CHANGELOG/CHANGELOG-1.30.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1643](https://github.com/k8ssandra/k8ssandra-operator/issues/1643) Allow configuration of Endpoint in the agent config for metrics endpoint and use that information when creating the Vector output
 * [BUGFIX] [#1644](https://github.com/k8ssandra/k8ssandra-operator/issues/1644) Fix failures when decommissioning DCs with Cassandra 4.1/5.x
 * [BUGFIX] [#1645](https://github.com/k8ssandra/k8ssandra-operator/issues/1645) Modify the VRL program parsing the Cassandra log to output the original logline if parsing fails
+* [BUGFIX] [#1652](https://github.com/k8ssandra/k8ssandra-operator/issues/1652) Fix problem with reaper configuration, that happens when some characters (like underscore) appears in the name of the cluster

--- a/pkg/reaper/manager.go
+++ b/pkg/reaper/manager.go
@@ -3,11 +3,13 @@ package reaper
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
@@ -67,9 +69,15 @@ func (r *restReaperManager) connect(ctx context.Context, reaperSvc, username, pa
 	return nil
 }
 
+func cleanReaperName(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, " ", "")
+	return s
+}
+
 func (r *restReaperManager) AddClusterToReaper(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) error {
 	namespacedServiceName := cassdc.GetSeedServiceName() + "." + cassdc.Namespace
-	return r.reaperClient.AddCluster(ctx, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName), namespacedServiceName)
+	return r.reaperClient.AddCluster(ctx, cleanReaperName(cassdc.Spec.ClusterName), namespacedServiceName)
 }
 
 func (r *restReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassdc *cassdcapi.CassandraDatacenter) (bool, error) {
@@ -77,7 +85,7 @@ func (r *restReaperManager) VerifyClusterIsConfigured(ctx context.Context, cassd
 	if err != nil {
 		return false, err
 	}
-	return utils.SliceContains(clusters, cassdcapi.CleanupForKubernetes(cassdc.Spec.ClusterName)), nil
+	return utils.SliceContains(clusters, cleanReaperName(cassdc.Spec.ClusterName)), nil
 }
 
 func (r *restReaperManager) GetUiCredentials(ctx context.Context, uiUserSecretRef *corev1.LocalObjectReference, namespace string) (string, string, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes problem with reaper configuration, that happens when some characters (like underscore) appears in the name of the cluster

**Which issue(s) this PR fixes**:
Fixes #1652 

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/) - started the process, waiting for email
