### PR TITLE
Bump cassandra-medusa version to 0.27.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.30.md
+++ b/CHANGELOG/CHANGELOG-1.30.md
@@ -19,3 +19,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1643](https://github.com/k8ssandra/k8ssandra-operator/issues/1643) Allow configuration of Endpoint in the agent config for metrics endpoint and use that information when creating the Vector output
 * [BUGFIX] [#1644](https://github.com/k8ssandra/k8ssandra-operator/issues/1644) Fix failures when decommissioning DCs with Cassandra 4.1/5.x
 * [BUGFIX] [#1645](https://github.com/k8ssandra/k8ssandra-operator/issues/1645) Modify the VRL program parsing the Cassandra log to output the original logline if parsing fails
+* [CHANGE] Upgrade cassandra-medusa to 0.27.0

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -23,7 +23,7 @@ global:
       medusa:
         repository: "k8ssandra"
         name: "medusa"
-        tag: "0.26.0"
+        tag: "0.27.0"
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''

--- a/config/cass-operator/imageconfig/fragments/medusa.yaml
+++ b/config/cass-operator/imageconfig/fragments/medusa.yaml
@@ -2,4 +2,4 @@ images:
   medusa: 
     repository: "k8ssandra"
     name: "medusa"
-    tag: "21fe8b3b"
+    tag: "0.27.0"

--- a/config/cass-operator/imageconfig/patch-image-config.yaml
+++ b/config/cass-operator/imageconfig/patch-image-config.yaml
@@ -26,7 +26,7 @@ data:
         medusa:
             repository: "k8ssandra"
             name: "medusa"
-            tag: "21fe8b3b"
+            tag: "0.27.0"
         reaper:
             repository: "thelastpickle"
             name: "cassandra-reaper"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Bumps the default medusa version from 0.26 to 0.27

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
