### PR TITLE
Fix IPv6 gRPC address formatting in Medusa client connection

### DIFF
--- a/controllers/medusa/common.go
+++ b/controllers/medusa/common.go
@@ -3,6 +3,7 @@ package medusa
 import (
 	"context"
 	"fmt"
+	"net"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
@@ -24,7 +25,7 @@ func newClient(ctx context.Context, c client.Client, cassdc *cassdcapi.Cassandra
 		grpcPort = explicitPort
 	}
 
-	address := fmt.Sprintf("%s:%d", pod.Status.PodIP, grpcPort)
+	address := net.JoinHostPort(pod.Status.PodIP, fmt.Sprint(grpcPort))
 
 	if clientSecretName != "" {
 		secretKey := types.NamespacedName{

--- a/controllers/medusa/common_test.go
+++ b/controllers/medusa/common_test.go
@@ -1,0 +1,80 @@
+package medusa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// recordingClientFactory captures the address passed to NewClient for verification.
+type recordingClientFactory struct {
+	lastAddress string
+}
+
+func (f *recordingClientFactory) NewClient(address string) (medusa.Client, error) {
+	f.lastAddress = address
+	return nil, nil
+}
+
+func (f *recordingClientFactory) NewClientWithTLS(address string, secret *corev1.Secret) (medusa.Client, error) {
+	f.lastAddress = address
+	return nil, nil
+}
+
+func TestNewClientAddressFormatting(t *testing.T) {
+	tests := []struct {
+		name            string
+		podIP           string
+		expectedAddress string
+	}{
+		{
+			name:            "IPv4 address",
+			podIP:           "192.0.2.10", // RFC 5737 documentation range
+			expectedAddress: "192.0.2.10:50051",
+		},
+		{
+			name:            "IPv6 address",
+			podIP:           "2001:db8:ae4:ee06:1310::3", // RFC 3849 documentation range
+			expectedAddress: "[2001:db8:ae4:ee06:1310::3]:50051",
+		},
+		{
+			name:            "IPv6 loopback",
+			podIP:           "::1",
+			expectedAddress: "[::1]:50051",
+		},
+	}
+
+	cassdc := &cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "test-ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &recordingClientFactory{}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-ns",
+				},
+				Status: corev1.PodStatus{
+					PodIP: tt.podIP,
+				},
+			}
+
+			_, _ = newClient(context.Background(), nil, cassdc, pod, factory)
+
+			require.NotEmpty(t, factory.lastAddress)
+			assert.Equal(t, tt.expectedAddress, factory.lastAddress)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Use `net.JoinHostPort()` instead of `fmt.Sprintf()` to correctly format IPv6 addresses when constructing the Medusa gRPC sidecar address in `controllers/medusa/common.go`.

## Problem

In IPv6-only environments (e.g., EKS with IPv6-only networking), the operator fails to connect to the Medusa gRPC sidecar with:

```
invalid target address 2a05:d01c:ae4:ee06:1310::3:50051, error info: address 2a05:d01c:ae4:ee06:1310::3:50051:443: too many colons in address
```

The current code uses `fmt.Sprintf("%s:%d", pod.Status.PodIP, grpcPort)` which produces `<ipv6>:<port>` instead of the required `[<ipv6>]:<port>` format.

## Root Cause

This is a regression of the fix in PR #871, which correctly changed `fmt.Sprintf` → `net.JoinHostPort()` in `medusabackupjob_controller.go` and `medusatask_controller.go`. When the gRPC client creation was later refactored into the shared `newClient()` function in `common.go`, the bug was reintroduced.

## Fix

Replace `fmt.Sprintf("%s:%d", ...)` with `net.JoinHostPort()` which correctly handles both IPv4 and IPv6 addresses:
- IPv4: `10.0.0.1:50051` (unchanged)  
- IPv6: `[2a05:d01c:ae4:ee06::3]:50051` (brackets added)

## Testing

Verified on an IPv6-only EKS cluster (v1.33) running K8ssandra operator v1.30.2 with Cassandra 4.1.3 and Medusa 0.27.0.

Fixes #967
Fixes #870