### PR TITLE
Bump cass-operator to v1.30.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.31.md
+++ b/CHANGELOG/CHANGELOG-1.31.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [CHANGE] [1704](https://github.com/k8ssandra/k8ssandra-operator/issues/1704) Bump cass-operator to v1.30.0
 * [FEATURE] [#1695](https://github.com/k8ssandra/k8ssandra-operator/issues/1695) Add new CRD option Config for Vector. This accepts the input as TOML and sets it at the server-system-logger's Vector instance. Used for global configuration of Vector.

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ help: ## Display this help.
 
 ##@ Development
 
-CASS_OPERATOR_TAG ?= v1.29.0
+CASS_OPERATOR_TAG ?= v1.30.0
 
 .PHONY: manifests
 manifests: controller-gen kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.

--- a/config/cass-operator/cluster-scoped/kustomization.yaml
+++ b/config/cass-operator/cluster-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.29.0
+- github.com/k8ssandra/cass-operator/config/deployments/cluster?ref=v1.30.0
 
 components:
   - ../imageconfig

--- a/config/cass-operator/imageconfig/patch-image-config.yaml
+++ b/config/cass-operator/imageconfig/patch-image-config.yaml
@@ -12,7 +12,7 @@ data:
         system-logger:
             repository: "k8ssandra"
             name: "system-logger"
-            tag: "v1.29.0"
+            tag: "v1.30.0"
         config-builder:
             repository: "datastax"
             name: "cass-config-builder"

--- a/config/cass-operator/ns-scoped/kustomization.yaml
+++ b/config/cass-operator/ns-scoped/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.29.0
+- github.com/k8ssandra/cass-operator/config/deployments/default?ref=v1.30.0
 
 components:
   - ../imageconfig

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.48.2
-	github.com/k8ssandra/cass-operator v1.29.0
+	github.com/k8ssandra/cass-operator v1.30.0
 	github.com/k8ssandra/reaper-client-go v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.1

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/k8ssandra/cass-operator v1.29.0 h1:T0sDdTFKQ3J+52DJQrtJz+RfWKR1x9anQS9gHARof+8=
-github.com/k8ssandra/cass-operator v1.29.0/go.mod h1:0gXWg/3O8jiigoWJK7SINyLLxxqpOQEhBcSODC0D4kc=
+github.com/k8ssandra/cass-operator v1.30.0 h1:ksINVH+BOTd5UqGurdLHu0RAcIdXwryanb560v4Lbc8=
+github.com/k8ssandra/cass-operator v1.30.0/go.mod h1:0gXWg/3O8jiigoWJK7SINyLLxxqpOQEhBcSODC0D4kc=
 github.com/k8ssandra/reaper-client-go v0.4.0 h1:8Ucco65qgGonYMUiY9wSN+KpR6IPLc09I/RtLHEMorE=
 github.com/k8ssandra/reaper-client-go v0.4.0/go.mod h1:EztqEX3nW6EfsVgQoI/BK7eTnXMxvNU/35NoELd6HuU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/test/testenv.go
+++ b/pkg/test/testenv.go
@@ -46,7 +46,7 @@ import (
 const (
 	clustersToCreate          = 3
 	clusterProtoName          = "cluster-%d-%s"
-	cassOperatorVersion       = "v1.29.0"
+	cassOperatorVersion       = "v1.30.0"
 	prometheusOperatorVersion = "v0.9.0"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Bumps the cass-operator version from 1.29.0 to 1.30.0.

**Which issue(s) this PR fixes**:
Fixes #1704

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
