### PR TITLE
Add useCrt storageProperty to enable AWS CRT transfer support in Medusa

### DIFF
--- a/CHANGELOG/CHANGELOG-1.32.md
+++ b/CHANGELOG/CHANGELOG-1.32.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-* [CHANGE] (#1731)[https://github.com/k8ssandra/k8ssandra-operator/issues/1713] Bump Medusa to 0.28.0
+* [FEATURE] [#1716][https://github.com/k8ssandra/k8ssandra-operator/issues/1716] Add useCrt storageProperty to enable AWS CRT transfer support in Medusa
+* [CHANGE] [#1713][https://github.com/k8ssandra/k8ssandra-operator/issues/1713] Bump Medusa to 0.28.0

--- a/apis/medusa/v1alpha1/medusa_types.go
+++ b/apis/medusa/v1alpha1/medusa_types.go
@@ -73,6 +73,12 @@ type Storage struct {
 	// +optional
 	TransferMaxBandwidth string `json:"transferMaxBandwidth,omitempty"`
 
+	// Use AWS CRT (Common Runtime) for faster S3 transfers.
+	// Only applicable when storageProvider is s3 or s3_rgw.
+	// Defaults to false.
+	// +optional
+	UseCrt bool `json:"useCrt,omitempty"`
+
 	// Number of concurrent uploads.
 	// Helps maximizing the speed of uploads but puts more pressure on the network.
 	// Defaults to 0.

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -29228,6 +29228,12 @@ spec:
                           Max upload bandwidth in MB/s.
                           Defaults to 50 MB/s.
                         type: string
+                      useCrt:
+                        description: |-
+                          Use AWS CRT (Common Runtime) for faster S3 transfers.
+                          Only applicable when storageProvider is s3 or s3_rgw.
+                          Defaults to false.
+                        type: boolean
                     type: object
                 type: object
               reaper:
@@ -35465,6 +35471,12 @@ spec:
                       Max upload bandwidth in MB/s.
                       Defaults to 50 MB/s.
                     type: string
+                  useCrt:
+                    description: |-
+                      Use AWS CRT (Common Runtime) for faster S3 transfers.
+                      Only applicable when storageProvider is s3 or s3_rgw.
+                      Defaults to false.
+                    type: boolean
                 type: object
             type: object
           status:

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -29163,6 +29163,12 @@ spec:
                           Max upload bandwidth in MB/s.
                           Defaults to 50 MB/s.
                         type: string
+                      useCrt:
+                        description: |-
+                          Use AWS CRT (Common Runtime) for faster S3 transfers.
+                          Only applicable when storageProvider is s3 or s3_rgw.
+                          Defaults to false.
+                        type: boolean
                     type: object
                 type: object
               reaper:

--- a/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
@@ -164,6 +164,12 @@ spec:
                       Max upload bandwidth in MB/s.
                       Defaults to 50 MB/s.
                     type: string
+                  useCrt:
+                    description: |-
+                      Use AWS CRT (Common Runtime) for faster S3 transfers.
+                      Only applicable when storageProvider is s3 or s3_rgw.
+                      Defaults to false.
+                    type: boolean
                 type: object
             type: object
           status:

--- a/config/crd/bases/medusa.k8ssandra.io_medusas.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusas.yaml
@@ -294,6 +294,12 @@ spec:
                     default: 50MB/s
                     description: Max upload bandwidth in MB/s. Defaults to 50 MB/s.
                     type: string
+                  useCrt:
+                    description: |-
+                      Use AWS CRT (Common Runtime) for faster S3 transfers.
+                      Only applicable when storageProvider is s3 or s3_rgw.
+                      Defaults to false.
+                    type: boolean
                 type: object
             type: object
         type: object

--- a/docs/content/en/tasks/backup-restore/_index.md
+++ b/docs/content/en/tasks/backup-restore/_index.md
@@ -66,6 +66,10 @@ spec:
       # apiProfile: 
       # transferMaxBandwidth: 50MB/s
 
+      # Use AWS CRT (Common Runtime) for faster S3 transfers.
+      # Only applicable for s3 and s3_rgw storage providers.
+      # useCrt: false
+
       # Number of concurrent uploads.
       # Helps maximizing the speed of uploads but puts more pressure on the network.
       # Defaults to 1.

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -105,6 +105,9 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster, dcConfig *cassandra.DatacenterCo
     {{- if .Spec.Medusa.StorageProperties.TransferMaxBandwidth }}
     transfer_max_bandwidth = {{ .Spec.Medusa.StorageProperties.TransferMaxBandwidth }}
     {{- end }}
+    {{- if .Spec.Medusa.StorageProperties.UseCrt }}
+    use_crt = True
+    {{- end }}
     {{- if .Spec.Medusa.StorageProperties.ConcurrentTransfers }}
     concurrent_transfers = {{ .Spec.Medusa.StorageProperties.ConcurrentTransfers }}
     {{- end }}


### PR DESCRIPTION
**What this PR does**: Adds a `useCrt` boolean field to the Medusa `StorageProperties` spec. When set to `true`, the operator writes `use_crt = True` into the generated medusa.ini configmap, enabling the AWS Common Runtime (CRT) transfer client for S3 uploads and downloads via `s3transfer.crt.CRTTransferManager`. This bypasses boto3's instance-type gating and provides higher-throughput transfers on standard EC2 instances.

Only applicable when `storageProvider` is `s3` or `s3_rgw`. Silently ignored for `s3_compatible`.

**Which issue(s) this PR fixes**:
Closes #1716
Related to thelastpickle/cassandra-medusa#954

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)