### PR TITLE
Fix Vector Telemetry creation to take into account Datacenter configs…

### DIFF
--- a/CHANGELOG/CHANGELOG-1.32.md
+++ b/CHANGELOG/CHANGELOG-1.32.md
@@ -15,4 +15,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
-* [CHANGE] (#1731)[https://github.com/k8ssandra/k8ssandra-operator/issues/1713] Bump Medusa to 0.28.0
+* [CHANGE] [#1731](https://github.com/k8ssandra/k8ssandra-operator/issues/1713) Bump Medusa to 0.28.0
+* [BUGFIX] [#1717](https://github.com/k8ssandra/k8ssandra-operator/issues/1717) When creating Telemetry config for Vector, take into account Datacenter level as well as Cluster level settings

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -322,6 +322,22 @@ func (in *CassandraDatacenterTemplate) CassDcName() string {
 	return in.Meta.Name
 }
 
+// MergeTelemetry returns the cluster-level Cassandra telemetry settings merged with the
+// datacenter-level settings with datacenter values taking precedence.
+func (in *CassandraDatacenterTemplate) MergeTelemetry(clusterTemplate *CassandraClusterTemplate) *telemetryapi.TelemetrySpec {
+	var clusterTelemetry *telemetryapi.TelemetrySpec
+	if clusterTemplate != nil {
+		clusterTelemetry = clusterTemplate.Telemetry
+	}
+
+	var dcTelemetry *telemetryapi.TelemetrySpec
+	if in != nil {
+		dcTelemetry = in.Telemetry
+	}
+
+	return dcTelemetry.MergeWith(clusterTelemetry)
+}
+
 // DatacenterOptions are configuration settings that are can be set at the Cluster level and overridden for a single DC
 type DatacenterOptions struct {
 	// ServerVersion is the Cassandra or DSE version. The following versions are supported:

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types_test.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types_test.go
@@ -9,6 +9,7 @@ import (
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
+	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,6 +132,35 @@ func TestNetworkingConfig_ToCassNetworkingConfig(t *testing.T) {
 			assert.Equal(t, tt.want, tt.in.ToCassNetworkingConfig())
 		})
 	}
+}
+
+func TestCassandraDcAndClusterTelemetryMerging(t *testing.T) {
+	cluster := &CassandraClusterTemplate{
+		DatacenterOptions: DatacenterOptions{
+			Telemetry: &telemetryapi.TelemetrySpec{
+				Vector: &telemetryapi.VectorSpec{
+					Enabled: ptr.To(true),
+				},
+				Mcac: &telemetryapi.McacTelemetrySpec{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+	}
+	dc := &CassandraDatacenterTemplate{
+		DatacenterOptions: DatacenterOptions{
+			Telemetry: &telemetryapi.TelemetrySpec{
+				Vector: &telemetryapi.VectorSpec{
+					Enabled: ptr.To(false),
+				},
+			},
+		},
+	}
+
+	merged := dc.MergeTelemetry(cluster)
+
+	assert.False(t, merged.IsVectorEnabled())
+	assert.True(t, merged.IsMcacEnabled())
 }
 
 // TestUnmarshallDatacenterMeta checks that user-provided labels and annotations are properly set when unmarshalling

--- a/apis/telemetry/v1alpha1/telemetry_methods.go
+++ b/apis/telemetry/v1alpha1/telemetry_methods.go
@@ -1,10 +1,35 @@
 package v1alpha1
 
-import goalesceutils "github.com/k8ssandra/k8ssandra-operator/pkg/goalesce"
+import (
+	"strings"
+
+	goalesceutils "github.com/k8ssandra/k8ssandra-operator/pkg/goalesce"
+)
 
 // MergeWith merges the given cluster-level template into this (DC-level) template.
 func (in *TelemetrySpec) MergeWith(clusterTemplate *TelemetrySpec) *TelemetrySpec {
-	return goalesceutils.MergeCRs(clusterTemplate, in)
+	merged := goalesceutils.MergeCRs(clusterTemplate, in)
+	components := mergeVectorComponents(vectorComponents(clusterTemplate), vectorComponents(in))
+	if components != nil {
+		if merged == nil {
+			merged = &TelemetrySpec{}
+		}
+		if merged.Vector == nil {
+			merged.Vector = &VectorSpec{}
+		}
+		merged.Vector.Components = components
+	}
+	config := mergeVectorConfig(vectorConfig(clusterTemplate), vectorConfig(in))
+	if config != "" {
+		if merged == nil {
+			merged = &TelemetrySpec{}
+		}
+		if merged.Vector == nil {
+			merged.Vector = &VectorSpec{}
+		}
+		merged.Vector.Config = config
+	}
+	return merged
 }
 
 func (in *TelemetrySpec) IsPrometheusEnabled() bool {
@@ -17,4 +42,49 @@ func (in *TelemetrySpec) IsMcacEnabled() bool {
 
 func (in *TelemetrySpec) IsVectorEnabled() bool {
 	return in != nil && in.Vector != nil && in.Vector.Enabled != nil && *in.Vector.Enabled
+}
+
+func vectorComponents(spec *TelemetrySpec) *VectorComponentsSpec {
+	if spec == nil || spec.Vector == nil {
+		return nil
+	}
+	return spec.Vector.Components
+}
+
+func vectorConfig(spec *TelemetrySpec) string {
+	if spec == nil || spec.Vector == nil {
+		return ""
+	}
+	return spec.Vector.Config
+}
+
+func mergeVectorConfig(cluster, dc string) string {
+	switch {
+	case cluster == "":
+		return dc
+	case dc == "":
+		return cluster
+	default:
+		// This is to ensure our TOMLs have enough separation
+		return strings.TrimRight(cluster, "\n") + "\n" + strings.TrimLeft(dc, "\n")
+	}
+}
+
+func mergeVectorComponents(cluster, dc *VectorComponentsSpec) *VectorComponentsSpec {
+	if cluster == nil && dc == nil {
+		return nil
+	}
+
+	merged := &VectorComponentsSpec{}
+	if cluster != nil {
+		merged.Sources = append(merged.Sources, cluster.Sources...)
+		merged.Sinks = append(merged.Sinks, cluster.Sinks...)
+		merged.Transforms = append(merged.Transforms, cluster.Transforms...)
+	}
+	if dc != nil {
+		merged.Sources = append(merged.Sources, dc.Sources...)
+		merged.Sinks = append(merged.Sinks, dc.Sinks...)
+		merged.Transforms = append(merged.Transforms, dc.Transforms...)
+	}
+	return merged
 }

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/result"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/telemetry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,7 +24,7 @@ func (r *K8ssandraClusterReconciler) reconcileCassandraDCTelemetry(
 ) result.ReconcileResult {
 	logger.V(1).Info("reconciling telemetry")
 
-	mergedSpec := MergeTelemetrySpecs(kc, dcTemplate)
+	mergedSpec := dcTemplate.MergeTelemetry(kc.Spec.Cassandra)
 	commonLabels := make(map[string]string)
 
 	if mergedSpec != nil && mergedSpec.Prometheus != nil {
@@ -96,12 +95,4 @@ func mustLabels(klusterName string, klusterNamespace string, dcName string, addi
 	additionalLabels[k8ssandraapi.K8ssandraClusterNamespaceLabel] = klusterNamespace
 	additionalLabels[k8ssandraapi.ComponentLabel] = k8ssandraapi.ComponentLabelTelemetry
 	return additionalLabels
-}
-
-// MergeTelemetrySpecs merges the cluster and dc level telemetry specs, prioritizing the dc level spec.
-func MergeTelemetrySpecs(kc *k8ssandraapi.K8ssandraCluster, dcTemplate k8ssandraapi.CassandraDatacenterTemplate) *v1alpha1.TelemetrySpec {
-	clusterSpec := kc.Spec.Cassandra.Telemetry
-	dcSpec := dcTemplate.Telemetry
-	mergedSpec := dcSpec.MergeWith(clusterSpec)
-	return mergedSpec
 }

--- a/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
+++ b/controllers/k8ssandra/cassandra_telemetry_reconciler_test.go
@@ -104,7 +104,8 @@ func Test_mergeTelemetrySpecs(t *testing.T) {
 		},
 	}
 
-	merged := MergeTelemetrySpecs(&kc, kc.Spec.Cassandra.Datacenters[0])
+	// This test probably shouldn't be here anymore, but help with PR review, I'll keep it here for now
+	merged := kc.Spec.Cassandra.Datacenters[0].MergeTelemetry(kc.Spec.Cassandra)
 	assert.NotNil(t, merged)
 	assert.False(t, *merged.Mcac.Enabled)
 	assert.True(t, *merged.Prometheus.Enabled)

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -109,7 +109,7 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 			desiredDc.Annotations[cassdcapi.SkipUserCreationAnnotation] = "true"
 		}
 
-		mergedTelemetrySpec := kc.Spec.Cassandra.Datacenters[idx].Telemetry.MergeWith(kc.Spec.Cassandra.Telemetry)
+		mergedTelemetrySpec := dcConfig.Telemetry
 		if mergedTelemetrySpec == nil {
 			mergedTelemetrySpec = &telemetryapi.TelemetrySpec{}
 		}

--- a/controllers/k8ssandra/dcconfigs.go
+++ b/controllers/k8ssandra/dcconfigs.go
@@ -76,19 +76,18 @@ func (r *K8ssandraClusterReconciler) createDatacenterConfigs(
 		}
 
 		// Inject MCAC metrics filters
-		if kc.Spec.Cassandra.Telemetry.IsMcacEnabled() {
-			telemetry.InjectCassandraTelemetryFilters(kc.Spec.Cassandra.Telemetry, dcConfig)
+		if dcConfig.Telemetry.IsMcacEnabled() {
+			telemetry.InjectCassandraTelemetryFilters(dcConfig.Telemetry, dcConfig)
 		}
 
 		// The new metrics endpoint is available since 3.11.13 and 4.0.4.
 		// If MCAC is disabled and the new metrics endpoint is not available then we should return an error.
-		mergedTelemetrySpec := MergeTelemetrySpecs(kc, dcTemplate)
-		if !mergedTelemetrySpec.IsMcacEnabled() && !telemetry.IsNewMetricsEndpointAvailable(dcConfig.ServerVersion.String()) && kc.Spec.Cassandra.ServerType == api.ServerDistributionCassandra {
+		if !dcConfig.Telemetry.IsMcacEnabled() && !telemetry.IsNewMetricsEndpointAvailable(dcConfig.ServerVersion.String()) && kc.Spec.Cassandra.ServerType == api.ServerDistributionCassandra {
 			return dcConfigs, errors.New("new metrics endpoint is only available since Cassandra 3.11.13/4.0.4, so MCAC cannot be disabled")
 		}
 
 		// Inject Vector agent
-		if err = telemetry.InjectCassandraVectorAgentConfig(kc.Spec.Cassandra.Telemetry, dcConfig, kc.SanitizedName(), dcLogger); err != nil {
+		if err = telemetry.InjectCassandraVectorAgentConfig(dcConfig.Telemetry, dcConfig, kc.SanitizedName(), dcLogger); err != nil {
 			return nil, err
 		}
 

--- a/controllers/k8ssandra/vector.go
+++ b/controllers/k8ssandra/vector.go
@@ -30,9 +30,9 @@ func (r *K8ssandraClusterReconciler) reconcileVector(
 		Namespace: namespace,
 		Name:      telemetry.VectorAgentConfigMapName(kc.SanitizedName(), dcConfig.CassDcName()),
 	}
-	if kc.Spec.Cassandra.Telemetry.IsVectorEnabled() {
+	if dcConfig.Telemetry.IsVectorEnabled() {
 		// Create the vector toml config content
-		toml, err := telemetry.CreateCassandraVectorToml(kc.Spec.Cassandra.Telemetry, dcConfig.McacEnabled)
+		toml, err := telemetry.CreateCassandraVectorToml(dcConfig.Telemetry, dcConfig.McacEnabled)
 		if err != nil {
 			return result.Error(err)
 		}

--- a/controllers/k8ssandra/vector_test.go
+++ b/controllers/k8ssandra/vector_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	testlogr "github.com/go-logr/logr/testing"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/telemetry"
+	pkgtest "github.com/k8ssandra/k8ssandra-operator/pkg/test"
 	"github.com/k8ssandra/k8ssandra-operator/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +20,98 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestSmokeVectorConfigMerge(t *testing.T) {
+	ctx := context.Background()
+	kc := &api.K8ssandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "test",
+		},
+		Spec: api.K8ssandraClusterSpec{
+			Cassandra: &api.CassandraClusterTemplate{
+				DatacenterOptions: api.DatacenterOptions{
+					Telemetry: &telemetryapi.TelemetrySpec{
+						Vector: &telemetryapi.VectorSpec{
+							Enabled: ptr.To(true),
+							Config: `[api]
+enabled = true
+`,
+							Components: &telemetryapi.VectorComponentsSpec{
+								Sinks: []telemetryapi.VectorSinkSpec{
+									{
+										Name:   "metrics_output",
+										Type:   "prometheus_remote_write",
+										Inputs: []string{"cassandra_metrics"},
+										Config: "endpoint = \"http://cluster\"",
+									},
+								},
+							},
+						},
+						Cassandra: &telemetryapi.CassandraAgentSpec{
+							Endpoint: &telemetryapi.Endpoint{
+								Port: "9103",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	dcTemplate := api.CassandraDatacenterTemplate{
+		Meta: api.EmbeddedObjectMeta{
+			Namespace: "test",
+			Name:      "dc1",
+		},
+		DatacenterOptions: api.DatacenterOptions{
+			Telemetry: &telemetryapi.TelemetrySpec{
+				Vector: &telemetryapi.VectorSpec{
+					Config: "data_dir = /var/lib/vector-big",
+					Components: &telemetryapi.VectorComponentsSpec{
+						Sinks: []telemetryapi.VectorSinkSpec{
+							{
+								Name:   "dc_metrics_output",
+								Type:   "console",
+								Inputs: []string{"cassandra_metrics"},
+								Config: "target = \"stdout\"",
+							},
+						},
+					},
+				},
+				Cassandra: &telemetryapi.CassandraAgentSpec{
+					Endpoint: &telemetryapi.Endpoint{
+						Port: "9443",
+					},
+				},
+			},
+		},
+	}
+	dcConfig := &cassandra.DatacenterConfig{
+		Meta:      dcTemplate.Meta,
+		Telemetry: dcTemplate.MergeTelemetry(kc.Spec.Cassandra),
+	}
+	fakeClient := pkgtest.NewFakeClientWRestMapper()
+	r := newDummyK8ssandraClusterReconciler()
+
+	recResult := r.reconcileVector(ctx, kc, dcConfig, fakeClient, testlogr.NewTestLogger(t))
+	require.False(t, recResult.IsError(), "reconcileVector failed: %v", recResult.GetError())
+
+	vectorConfigMap := &corev1.ConfigMap{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Namespace: "test",
+		Name:      telemetry.VectorAgentConfigMapName(kc.SanitizedName(), "dc1"),
+	}, vectorConfigMap))
+
+	vectorToml := vectorConfigMap.Data["vector.toml"]
+	assert.Contains(t, vectorToml, "[api]\nenabled = true\ndata_dir = /var/lib/vector-big")
+	assert.Contains(t, vectorToml, "http://localhost:9443/metrics")
+	assert.Contains(t, vectorToml, "[sinks.dc_metrics_output]")
+	assert.Contains(t, vectorToml, "type = \"console\"")
+	assert.Contains(t, vectorToml, "target = \"stdout\"")
+	assert.Contains(t, vectorToml, "[sinks.metrics_output]")
+	assert.Contains(t, vectorToml, "prometheus_remote_write")
+	assert.Contains(t, vectorToml, "http://cluster")
+}
 
 // createSingleDcCluster verifies that the CassandraDatacenter is created and that the
 // expected status updates happen on the K8ssandraCluster.

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -8,6 +8,7 @@ import (
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/reconciliation"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/encryption"
 	goalesceutils "github.com/k8ssandra/k8ssandra-operator/pkg/goalesce"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
@@ -114,6 +115,7 @@ type DatacenterConfig struct {
 	ServiceAccount            string
 	ExternalSecrets           bool
 	McacEnabled               bool
+	Telemetry                 *telemetryapi.TelemetrySpec
 	DatacenterName            string
 	ReadOnlyRootFilesystem    *bool
 	// InitialTokensByPodName is a list of initial tokens for the RF first pods in the cluster. It
@@ -404,7 +406,8 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 	// we need to declare at least one container, otherwise the PodTemplateSpec struct will be invalid
 	UpdateCassandraContainer(&dcConfig.PodTemplateSpec, func(c *corev1.Container) {})
 
-	dcConfig.McacEnabled = mergedOptions.Telemetry.IsMcacEnabled()
+	dcConfig.Telemetry = dcTemplate.MergeTelemetry(clusterTemplate)
+	dcConfig.McacEnabled = dcConfig.Telemetry.IsMcacEnabled()
 
 	return dcConfig
 }

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -7,7 +7,7 @@ import (
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/cass-operator/pkg/reconciliation"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
-	"github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
+	telemetryapi "github.com/k8ssandra/k8ssandra-operator/apis/telemetry/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/meta"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/unstructured"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
@@ -346,8 +346,8 @@ func TestCoalesce(t *testing.T) {
 				Size: 3,
 				DatacenterOptions: api.DatacenterOptions{
 					MgmtAPIHeap: &mgmtAPIHeap,
-					Telemetry: &v1alpha1.TelemetrySpec{
-						Mcac: &v1alpha1.McacTelemetrySpec{
+					Telemetry: &telemetryapi.TelemetrySpec{
+						Mcac: &telemetryapi.McacTelemetrySpec{
 							Enabled: ptr.To(false),
 						},
 					},
@@ -368,6 +368,11 @@ func TestCoalesce(t *testing.T) {
 				Size:               3,
 				MgmtAPIHeap:        &mgmtAPIHeap,
 				McacEnabled:        false,
+				Telemetry: &telemetryapi.TelemetrySpec{
+					Mcac: &telemetryapi.McacTelemetrySpec{
+						Enabled: ptr.To(false),
+					},
+				},
 				PodTemplateSpec: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "cassandra"}},


### PR DESCRIPTION
… also

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Previously, our Vector Telemetry config only took the Cluster level configuration and output that one. We need to take the Datacenter level also and merge them.

**Which issue(s) this PR fixes**:
Fixes #1717

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
