### PR TITLE
Bump reaper to 4.2.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.32.md
+++ b/CHANGELOG/CHANGELOG-1.32.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [CHANGE] (#1731)[https://github.com/k8ssandra/k8ssandra-operator/issues/1713] Bump Medusa to 0.28.0
+* [CHANGE] (#1706)[https://github.com/k8ssandra/k8ssandra-operator/issues/1706] Bump Reaper to 4.2.0 (with sqlite-backed local storage)

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -19,7 +19,7 @@ global:
       reaper:
         repository: "thelastpickle"
         name: "cassandra-reaper"
-        tag: "4.1.1"
+        tag: "4.2.0"
       medusa:
         repository: "k8ssandra"
         name: "medusa"

--- a/config/cass-operator/imageconfig/fragments/reaper.yaml
+++ b/config/cass-operator/imageconfig/fragments/reaper.yaml
@@ -2,5 +2,5 @@ images:
   reaper:
     repository: "thelastpickle"
     name: "cassandra-reaper"
-    tag: "4.1.1"
+    tag: "4.2.0"
 

--- a/config/cass-operator/imageconfig/patch-image-config.yaml
+++ b/config/cass-operator/imageconfig/patch-image-config.yaml
@@ -30,7 +30,7 @@ data:
         reaper:
             repository: "thelastpickle"
             name: "cassandra-reaper"
-            tag: "4.1.1"
+            tag: "4.2.0"
     # -- defaults are used when other no override is present for the configured image or image type. All these values can be overridden under any image or image type.
     defaults:
         registry: "docker.io"

--- a/controllers/k8ssandra/schemas.go
+++ b/controllers/k8ssandra/schemas.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/annotations"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	kerrors "github.com/k8ssandra/k8ssandra-operator/pkg/errors"
@@ -51,8 +52,11 @@ func (r *K8ssandraClusterReconciler) checkSchemas(
 	// we only want to reconcile the Reaper schema if we're deploying Reaper together with k8ssandra cluster
 	// otherwise we just register the k8ssandra cluster with an external reaper (happens after reconciling the DCs)
 	if kc.Spec.Reaper != nil && !kc.Spec.Reaper.HasReaperRef() {
-		if recResult := r.reconcileReaperSchema(ctx, kc, mgmtApi, logger); recResult.Completed() {
-			return recResult
+		// and even in this case, we only want to do this if the cluster itself is going to be used for reaper's storage
+		if kc.Spec.Reaper.StorageType == reaperapi.StorageTypeCassandra {
+			if recResult := r.reconcileReaperSchema(ctx, kc, mgmtApi, logger); recResult.Completed() {
+				return recResult
+			}
 		}
 	}
 

--- a/controllers/reaper/reaper_controller_test.go
+++ b/controllers/reaper/reaper_controller_test.go
@@ -613,19 +613,23 @@ func testCreateReaperWithLocalStorageType(t *testing.T, ctx context.Context, k8s
 		return k8sClient.Get(ctx, stsKey, sts) == nil
 	}, timeout, interval, "stateful set creation check failed")
 
-	// when deployed as STS, Reaper has no init container
+	// when deployed as STS, Reaper has an init container to handle sqlitle in case of local storage
 	assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
-	assert.Len(t, sts.Spec.Template.Spec.InitContainers, 0)
+	assert.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 
 	// Reaper's API does not allow specifying replica count, so we have no easy way to increase this
 	assert.Equal(t, ptr.To[int32](1), sts.Spec.Replicas)
 
 	// In this configuration, we expect Reaper to have a config volume mount, and a data volume mount
-	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 3)
+	assert.Len(t, sts.Spec.Template.Spec.Containers[0].VolumeMounts, 4)
 	confVolumeMount := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].DeepCopy()
 	assert.Equal(t, "conf", confVolumeMount.Name)
-	dataVolumeMount := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].DeepCopy()
-	assert.Equal(t, "reaper-data", dataVolumeMount.Name)
+	tempDirVolumeMount := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].DeepCopy()
+	assert.Equal(t, "temp-dir", tempDirVolumeMount.Name)
+	reperDataVolumeMount := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].DeepCopy()
+	assert.Equal(t, "reaper-data", reperDataVolumeMount.Name)
+	dbTempDirVolumeMount := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].DeepCopy()
+	assert.Equal(t, "db-temp-dir", dbTempDirVolumeMount.Name)
 }
 
 // Check if env var exists

--- a/pkg/reaper/deployment.go
+++ b/pkg/reaper/deployment.go
@@ -257,6 +257,16 @@ func computeVolumes(reaper *api.Reaper) ([]corev1.Volume, []corev1.VolumeMount) 
 			Name:      "reaper-data",
 			MountPath: "/var/lib/cassandra-reaper/storage",
 		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "db-temp-dir",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "db-temp-dir",
+			MountPath: "/var/tmp/cassandra-reaper",
+		})
 	}
 
 	if reaper.Spec.Encryption != nil && reaper.Spec.Encryption.ServerCertName != "" {
@@ -473,13 +483,15 @@ func NewStatefulSet(reaper *api.Reaper, dc *cassdcapi.CassandraDatacenter, logge
 		return nil
 	}
 
+	initContainerResources := computeInitContainerResources(reaper.Spec.InitContainerResources)
+
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: makeObjectMeta(reaper),
 		Spec: appsv1.StatefulSetSpec{
 			Selector: makeSelector(reaper),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: computePodMeta(reaper),
-				Spec:       computePodSpec(reaper, dc, nil, nil, nil, registry),
+				Spec:       computePodSpec(reaper, dc, initContainerResources, nil, nil, registry),
 			},
 			VolumeClaimTemplates: computeVolumeClaims(reaper),
 			Replicas:             ptr.To[int32](1),

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -658,6 +658,7 @@ func TestDeploymentTypes(t *testing.T) {
 	reaper.Spec.StorageType = reaperapi.StorageTypeCassandra
 	deployment := NewDeployment(reaper, newTestDatacenter(), nil, nil, logger, getTestImageRegistry(t))
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
 	assert.Equal(t, reaperapi.StorageTypeCassandra, deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
 
 	// asking for a deployment with memory backend does not work
@@ -680,6 +681,7 @@ func TestDeploymentTypes(t *testing.T) {
 	}
 	sts := NewStatefulSet(reaper, newTestDatacenter(), logger, getTestImageRegistry(t))
 	assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
+	assert.Len(t, sts.Spec.Template.Spec.InitContainers, 1)
 	assert.Equal(t, "memory", sts.Spec.Template.Spec.Containers[0].Env[0].Value)
 
 	// asking for a stateful set with cassandra backend does not work

--- a/test/e2e/reaper_test.go
+++ b/test/e2e/reaper_test.go
@@ -93,9 +93,6 @@ func createSingleReaper(t *testing.T, ctx context.Context, namespace string, f *
 	t.Log("check Reaper app type")
 	checkReaperAppType(t, ctx, f, reaperKey, kc)
 
-	t.Log("check Reaper keyspace created")
-	checkKeyspaceExists(t, f, ctx, f.DataPlaneContexts[0], namespace, kc.SanitizedName(), dcPrefix+"-default-sts-0", "reaper_db")
-
 	testDeleteReaperManually(t, f, ctx, kcKey, dcKey, reaperKey)
 	testRemoveReaperFromK8ssandraCluster(t, f, ctx, kcKey, dcKey, reaperKey)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: 
* Bumps Reaper to 4.2.0
* When local storage is used, adds an init container to handle sqlitle requirements (new in 4.2.0)
* Removes `reaper_db` creation in the db cluster if local storage is used

**Which issue(s) this PR fixes**:
Fixes #1706


**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
