### PR TITLE
Fix MAAC metrics port in documentation

### DIFF
--- a/docs/content/en/tasks/monitor/metrics-endpoints/_index.md
+++ b/docs/content/en/tasks/monitor/metrics-endpoints/_index.md
@@ -7,7 +7,7 @@ description: "Available metrics endpoints for Apache Cassandra®"
 
 Until the v1.5.0 release, k8ssandra-operator was using the [Metric Collector for Apache Cassandra® (MCAC)](https://github.com/datastax/metric-collector-for-apache-cassandra) exclusively to scrape metrics from Cassandra. Starting with v1.5.0, a new metrics endpoint was introduced in the [Management API for Apache Cassandra® (MAAC)](https://github.com/k8ssandra/management-api-for-apache-cassandra) and is available as an alpha feature. The new endpoint is available in the Management API since v0.1.57.
 
-This new metrics endpoint is hooking directly into the Cassandra metrics registry and exposing the metrics through a Prometheus compliant http endpoint at http://localhost:9103/metrics.
+This new metrics endpoint is hooking directly into the Cassandra metrics registry and exposing the metrics through a Prometheus compliant http endpoint at http://localhost:9000/metrics.
 
 MCAC is still enabled by default in v1.5.0 and will be deprecated (and then removed) in a future release. To disable MCAC, you need to set the `spec.cassandra.telemetry.mcac.enabled` field to `false` in the `K8ssandraCluster` manifest:
 


### PR DESCRIPTION
Updated the metrics endpoint URL from 9103 to 9000.

Port 9103 is for MSAC and 9000 is for MAAC

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
