### PR TITLE
fix(reaper): use datacenter native port for Reaper contact points

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [CHANGE] Update cass-operator to v1.31.0
+* [BUGFIX] [#1739] Use the datacenter native port for Reaper contact points so Reaper works when NodePort is enabled (cass-operator moves native_transport_port off 9042)

--- a/pkg/reaper/deployment.go
+++ b/pkg/reaper/deployment.go
@@ -74,10 +74,18 @@ func computeEnvVars(reaper *api.Reaper, dc *cassdcapi.CassandraDatacenter, regis
 			Value: reaper.Spec.Keyspace,
 		})
 		if isReaperPostV4(reaper, registry) {
+			// The native CQL port follows the datacenter: when NodePort is enabled, cass-operator
+			// moves native_transport_port to the configured NodePort value (e.g. 30942), so 9042 is
+			// no longer listening. Mirror cass-operator's own service logic (see construct_service.go)
+			// to keep Reaper's contact point in sync instead of hardcoding 9042.
+			nativePort := cassdcapi.DefaultNativePort
+			if dc.IsNodePortEnabled() {
+				nativePort = dc.GetNodePortNativePort()
+			}
 			// For Reaper v4 and above, we need to specify the contact points as a JSON array of objects, with the host and port
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  "REAPER_CASS_CONTACT_POINTS",
-				Value: fmt.Sprintf("[{\"host\": \"%s\", \"port\": 9042}]", dc.GetDatacenterServiceName()),
+				Value: fmt.Sprintf("[{\"host\": \"%s\", \"port\": %d}]", dc.GetDatacenterServiceName(), nativePort),
 			})
 		} else {
 			// For Reaper v3 and below, we can use the old format

--- a/pkg/reaper/deployment_test.go
+++ b/pkg/reaper/deployment_test.go
@@ -1210,6 +1210,41 @@ func TestReaperV4ContactPointsFormat(t *testing.T) {
 		"REAPER_CASS_CONTACT_POINTS should be formatted as a JSON array with host and port for Reaper v4")
 }
 
+func TestReaperV4ContactPointsFormatWithNodePort(t *testing.T) {
+	reaper := newTestReaper()
+	reaper.Spec.ContainerImage = &images.Image{
+		Repository: "test",
+		Name:       "reaper",
+		Tag:        "4.0.1",
+		PullPolicy: corev1.PullAlways,
+	}
+	dc := newTestDatacenter()
+	// When NodePort is enabled, cass-operator moves native_transport_port to the configured
+	// NodePort value, so Reaper's contact point must follow it instead of the default 9042.
+	dc.Spec.Networking = &cassdcapi.NetworkingConfig{
+		NodePort: &cassdcapi.NodePortConfig{
+			Native:    30942,
+			Internode: 30943,
+		},
+	}
+	logger := testlogr.NewTestLogger(t)
+
+	deployment := NewDeployment(reaper, dc, nil, nil, logger, getTestImageRegistry(t))
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	var contactPointsEnvVar *corev1.EnvVar
+	for _, env := range container.Env {
+		if env.Name == "REAPER_CASS_CONTACT_POINTS" {
+			contactPointsEnvVar = &env
+			break
+		}
+	}
+
+	assert.NotNil(t, contactPointsEnvVar, "REAPER_CASS_CONTACT_POINTS environment variable not found")
+	assert.Equal(t, "[{\"host\": \"cluster1-dc1-service\", \"port\": 30942}]", contactPointsEnvVar.Value,
+		"REAPER_CASS_CONTACT_POINTS must use the NodePort native port when NodePort is enabled")
+}
+
 func TestDefaultReaperContactPointsFormat(t *testing.T) {
 	reaper := newTestReaper()
 	dc := newTestDatacenter()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does**:

The Reaper `Deployment` hardcoded the Cassandra CQL port `9042` in the `REAPER_CASS_CONTACT_POINTS` environment variable. When a `CassandraDatacenter` enables NodePort (`networking.nodePort.native`, e.g. `30942`), cass-operator moves Cassandra's `native_transport_port` to the configured NodePort value, so `9042` is no longer listening. As a result Reaper (v4+) could not connect to its storage Cassandra, never finished `reaper_db` schema initialization, and crash-looped on its `:8081` liveness probe. This is the issue originally reported in #1144.

This derives the native port the same way cass-operator does for its own services (`pkg/reconciliation/construct_service.go`):

```go
nativePort := cassdcapi.DefaultNativePort
if dc.IsNodePortEnabled() {
    nativePort = dc.GetNodePortNativePort()
}
```

Behaviour is unchanged for clusters without NodePort (still `9042`). A unit test `TestReaperV4ContactPointsFormatWithNodePort` is added; the existing default-port tests still pass.

**Which issue(s) this PR fixes**:
Fixes #1739
Fixes #1144

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)