### PR TITLE
bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -16,3 +16,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## unreleased
 
 * [CHANGE] Update cass-operator to v1.31.0
+* [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -19,11 +19,11 @@ global:
       reaper:
         repository: "thelastpickle"
         name: "cassandra-reaper"
-        tag: "4.2.3"
+        tag: "4.2.4"
       medusa:
         repository: "k8ssandra"
         name: "medusa"
-        tag: "0.28.0"
+        tag: "0.29.0"
 # -- A name in place of the chart name which is used in the metadata.name of
 # objects created by this chart.
 nameOverride: ''
@@ -97,7 +97,7 @@ client:
     # -- Image repository for the client
     repository: k8ssandra/k8ssandra-client
     # -- Tag of the client image to pull from
-    tag: v0.8.6
+    tag: v0.8.13
     # -- Pull policy for the client container
     pullPolicy: IfNotPresent
   # -- HTTPS proxy address to use for communication to helm.k8ssandra.io

--- a/config/cass-operator/imageconfig/fragments/medusa.yaml
+++ b/config/cass-operator/imageconfig/fragments/medusa.yaml
@@ -2,4 +2,4 @@ images:
   medusa: 
     repository: "k8ssandra"
     name: "medusa"
-    tag: "0.28.0"
+    tag: "0.29.0"

--- a/config/cass-operator/imageconfig/fragments/reaper.yaml
+++ b/config/cass-operator/imageconfig/fragments/reaper.yaml
@@ -2,5 +2,5 @@ images:
   reaper:
     repository: "thelastpickle"
     name: "cassandra-reaper"
-    tag: "4.2.3"
+    tag: "4.2.4"
 

--- a/config/cass-operator/imageconfig/patch-image-config.yaml
+++ b/config/cass-operator/imageconfig/patch-image-config.yaml
@@ -20,17 +20,17 @@ data:
         k8ssandra-client:
             repository: "k8ssandra"
             name: "k8ssandra-client"
-            tag: "v0.8.12"
+            tag: "v0.8.13"
             # pullSecret: "k8ssandra-client-pull-secret" # Use of pullSecret removes the default pullSecrets for this image
             # pullPolicy: Always
         medusa:
             repository: "k8ssandra"
             name: "medusa"
-            tag: "0.28.0"
+            tag: "0.29.0"
         reaper:
             repository: "thelastpickle"
             name: "cassandra-reaper"
-            tag: "4.2.3"
+            tag: "4.2.4"
     # -- defaults are used when other no override is present for the configured image or image type. All these values can be overridden under any image or image type.
     defaults:
         registry: "docker.io"

--- a/config/cass-operator/imageconfig/patch-image-config.yaml
+++ b/config/cass-operator/imageconfig/patch-image-config.yaml
@@ -20,7 +20,7 @@ data:
         k8ssandra-client:
             repository: "k8ssandra"
             name: "k8ssandra-client"
-            tag: "v0.8.13"
+            tag: "v0.8.12"
             # pullSecret: "k8ssandra-client-pull-secret" # Use of pullSecret removes the default pullSecrets for this image
             # pullPolicy: Always
         medusa:


### PR DESCRIPTION
**What this PR does**:
bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4


**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CHANGELOG.md updated (not required for documentation PRs)
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
