### PR TITLE
Preserve container customizations during reconciliation

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -17,3 +17,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [CHANGE] Update cass-operator to v1.31.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
+* [BUGFIX] [#1734](https://github.com/k8ssandra/k8ssandra-operator/issues/1734) Preserve custom environment variables and volume mounts when reconciling Medusa containers

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -10,6 +10,7 @@ import (
 	cassimages "github.com/k8ssandra/cass-operator/pkg/images"
 	k8ss "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
+	goalesceutils "github.com/k8ssandra/k8ssandra-operator/pkg/goalesce"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/images"
 	corev1 "k8s.io/api/core/v1"
 
@@ -215,6 +216,12 @@ func UpdateMedusaInitContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec 
 	restoreContainer.Env = medusaEnvVars(medusaSpec, k8cName, useExternalSecrets, "RESTORE")
 	restoreContainer.VolumeMounts = medusaVolumeMounts(dcConfig, medusaSpec, k8cName)
 	restoreContainer.Resources = medusaInitContainerResources(medusaSpec)
+	if found {
+		*restoreContainer = goalesceutils.MergeCRs(
+			dcConfig.PodTemplateSpec.Spec.InitContainers[restoreContainerIndex],
+			*restoreContainer,
+		)
+	}
 
 	if !found {
 		logger.Info("Couldn't find medusa-restore init container")
@@ -301,7 +308,7 @@ func CreateMedusaMainContainer(dcConfig *cassandra.DatacenterConfig, medusaSpec 
 
 func UpdateMedusaMainContainer(dcConfig *cassandra.DatacenterConfig, medusaContainer *corev1.Container) {
 	cassandra.UpdateContainer(&dcConfig.PodTemplateSpec, "medusa", func(c *corev1.Container) {
-		*c = *medusaContainer
+		*c = goalesceutils.MergeCRs(*c, *medusaContainer)
 	})
 }
 

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -576,9 +576,98 @@ func TestInitContainerDefaultResources(t *testing.T) {
 	assert.True(t, hasTmpVolume(dcConfig.PodTemplateSpec.Spec.InitContainers[medusaInitContainerIndex].VolumeMounts))
 }
 
+func TestMedusaContainersPreserveCustomEnvAndVolumeMounts(t *testing.T) {
+	medusaSpec := &medusaapi.MedusaClusterTemplate{
+		StorageProperties: medusaapi.Storage{
+			StorageProvider: "s3",
+			StorageSecretRef: corev1.LocalObjectReference{
+				Name: "secret",
+			},
+			BucketName: "bucket",
+		},
+		CassandraUserSecretRef: corev1.LocalObjectReference{
+			Name: "test-superuser",
+		},
+	}
+	dcConfig := cassandra.DatacenterConfig{
+		PodTemplateSpec: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "medusa",
+						Env: []corev1.EnvVar{
+							{Name: "AWS_CONFIG_FILE", Value: "/home/cassandra/.aws/config"},
+							{Name: "MEDUSA_MODE", Value: "CUSTOM"},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "medusa-aws-config", MountPath: "/home/cassandra/.aws"},
+						},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name: "medusa-restore",
+						Env: []corev1.EnvVar{
+							{Name: "AWS_CONFIG_FILE", Value: "/home/cassandra/.aws/config"},
+							{Name: "MEDUSA_MODE", Value: "CUSTOM"},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "medusa-aws-config", MountPath: "/home/cassandra/.aws"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	logger := logr.New(logr.Discard().GetSink())
+	medusaContainer, err := CreateMedusaMainContainer(&dcConfig, medusaSpec, false, "test", logger, getTestImageRegistry(t))
+	assert.NoError(t, err)
+	UpdateMedusaInitContainer(&dcConfig, medusaSpec, false, "test", logger, getTestImageRegistry(t))
+	UpdateMedusaMainContainer(&dcConfig, medusaContainer)
+
+	medusaContainerIndex, found := cassandra.FindContainer(&dcConfig.PodTemplateSpec, "medusa")
+	assert.True(t, found, "Couldn't find medusa container")
+	medusaInitContainerIndex, found := cassandra.FindInitContainer(&dcConfig.PodTemplateSpec, "medusa-restore")
+	assert.True(t, found, "Couldn't find medusa-restore init container")
+
+	mainContainer := dcConfig.PodTemplateSpec.Spec.Containers[medusaContainerIndex]
+	restoreContainer := dcConfig.PodTemplateSpec.Spec.InitContainers[medusaInitContainerIndex]
+
+	assert.True(t, hasEnvVarWithValue(mainContainer.Env, "AWS_CONFIG_FILE", "/home/cassandra/.aws/config"))
+	assert.True(t, hasEnvVarWithValue(restoreContainer.Env, "AWS_CONFIG_FILE", "/home/cassandra/.aws/config"))
+	assert.True(t, hasEnvVarWithValue(mainContainer.Env, "MEDUSA_MODE", "GRPC"))
+	assert.True(t, hasEnvVarWithValue(restoreContainer.Env, "MEDUSA_MODE", "RESTORE"))
+	assert.False(t, hasEnvVarWithValue(mainContainer.Env, "MEDUSA_MODE", "CUSTOM"))
+	assert.False(t, hasEnvVarWithValue(restoreContainer.Env, "MEDUSA_MODE", "CUSTOM"))
+
+	assert.True(t, hasVolumeMount(mainContainer.VolumeMounts, "medusa-aws-config", "/home/cassandra/.aws"))
+	assert.True(t, hasVolumeMount(restoreContainer.VolumeMounts, "medusa-aws-config", "/home/cassandra/.aws"))
+	assert.True(t, hasTmpVolume(mainContainer.VolumeMounts))
+	assert.True(t, hasTmpVolume(restoreContainer.VolumeMounts))
+}
+
 func hasTmpVolume(volumeMounts []corev1.VolumeMount) bool {
 	for _, vm := range volumeMounts {
 		if vm.Name == "medusa-tmp" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMount(volumeMounts []corev1.VolumeMount, name, mountPath string) bool {
+	for _, vm := range volumeMounts {
+		if vm.Name == name && vm.MountPath == mountPath {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEnvVarWithValue(envVars []corev1.EnvVar, name, value string) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == name && envVar.Value == value {
 			return true
 		}
 	}


### PR DESCRIPTION
**What this PR does**:

This PR preserves existing container customizations when the Medusa containers are reconciled.

Previously, the `medusa` main container was replaced with the generated container spec, and the existing `medusa-restore` init container had its `env` and `volumeMounts` overwritten. As a result, user-provided customizations from the CassandraDatacenter/K8ssandraCluster pod template, such as additional environment variables or volume mounts, could be lost.

The change updates Medusa reconciliation to merge the existing container spec with the generated Medusa container spec. Generated Medusa settings still take precedence for managed fields such as `MEDUSA_MODE`, while user-provided non-conflicting values like custom AWS config mounts are preserved.

A regression test was added to verify that custom `env` and `volumeMounts` are retained for both:
- `medusa`
- `medusa-restore`

**Which issue(s) this PR fixes**:
Fixes #1734

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)