### PR TITLE
Set owner reference on co-located CassandraDatacenter (#952)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -15,5 +15,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [ENHANCEMENT] [#952](https://github.com/k8ssandra/k8ssandra-operator/issues/952) Set an owner reference on the CassandraDatacenter pointing to the K8ssandraCluster when they are co-located (same namespace and cluster). This improves visibility in tools like ArgoCD. Cross-namespace/cluster deployments are unaffected and keep relying on labels and finalizers.
 * [CHANGE] Update cass-operator to v1.31.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4

--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -19,6 +19,8 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
 * [CHANGE] Bump cassandra-medusa to v0.30.0
 * [ENHANCEMENT] [#1760](https://github.com/k8ssandra/k8ssandra-operator/issues/1760) Allow setting Medusa's chunk size
+* [ENHANCEMENT] [#952](https://github.com/k8ssandra/k8ssandra-operator/issues/952) Set an owner reference on the CassandraDatacenter pointing to the K8ssandraCluster when they are co-located (same namespace and cluster). This improves visibility in tools like ArgoCD. Cross-namespace/cluster deployments are unaffected and keep relying on labels and finalizers.
+* [BUGFIX] Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1773](https://github.com/k8ssandra/k8ssandra-operator/issues/1773) Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update
 * [BUGFIX] [#1771](https://github.com/k8ssandra/k8ssandra-operator/issues/1771) ContactPoints services was created by polling the potential pods using dc name only, without namespace filtering

--- a/controllers/k8ssandra/datacenters.go
+++ b/controllers/k8ssandra/datacenters.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -134,6 +135,11 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 		// merge in common L&A from the k8ssandra spec
 		desiredDc.SetLabels(goalesce.MustDeepMerge(desiredDc.GetLabels(), kc.Spec.Cassandra.Meta.Labels))
 		desiredDc.SetAnnotations(goalesce.MustDeepMerge(desiredDc.GetAnnotations(), kc.Spec.Cassandra.Meta.Annotations))
+
+		if err := r.setDatacenterOwnership(kc, desiredDc, dcConfig); err != nil {
+			dcLogger.Error(err, "Failed to set owner reference on CassandraDatacenter")
+			return result.Error(err), actualDcs
+		}
 
 		// Note: desiredDc should not be modified from now on
 		annotations.AddHashAnnotation(desiredDc)
@@ -316,6 +322,19 @@ func (r *K8ssandraClusterReconciler) reconcileDatacenters(ctx context.Context, k
 	}
 
 	return result.Continue(), actualDcs
+}
+
+// setDatacenterOwnership sets the K8ssandraCluster as an owner of the CassandraDatacenter,
+// but only when the DC is co-located (same namespace and same Kubernetes cluster). Owner
+// references cannot cross namespace or cluster boundaries, so cluster-scoped and multi-cluster
+// deployments keep relying on labels and finalizers for cleanup.
+func (r *K8ssandraClusterReconciler) setDatacenterOwnership(kc *api.K8ssandraCluster, dc *cassdcapi.CassandraDatacenter, dcConfig *cassandra.DatacenterConfig) error {
+	sameCluster := dcConfig.K8sContext == ""
+	sameNamespace := dc.Namespace == kc.Namespace
+	if sameCluster && sameNamespace {
+		return controllerutil.SetOwnerReference(kc, dc, r.Scheme)
+	}
+	return nil
 }
 
 func (r *K8ssandraClusterReconciler) setStatusForDatacenter(kc *api.K8ssandraCluster, dc *cassdcapi.CassandraDatacenter, targetContext string) {

--- a/controllers/k8ssandra/datacenters_test.go
+++ b/controllers/k8ssandra/datacenters_test.go
@@ -8,8 +8,10 @@ import (
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
@@ -71,6 +73,71 @@ func TestDatacenters(t *testing.T) {
 	t.Run("DcUpgradePriorityTest", dcUpgradePriorityTest)
 	t.Run("SortDatacentersForUpgradeTest", sortDatacentersForUpgradeTest)
 	t.Run("SortNoChangeTest", sortNoChangeTest)
+}
+
+func TestSetDatacenterOwnership(t *testing.T) {
+	require.NoError(t, api.AddToScheme(scheme.Scheme))
+	require.NoError(t, cassdcapi.AddToScheme(scheme.Scheme))
+
+	r := &K8ssandraClusterReconciler{Scheme: scheme.Scheme}
+	kc := &api.K8ssandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc",
+			Namespace: "ns1",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		dcNamespace string
+		k8sContext  string
+		expectOwner bool
+	}{
+		{
+			name:        "same namespace and local cluster",
+			dcNamespace: "ns1",
+			k8sContext:  "",
+			expectOwner: true,
+		},
+		{
+			name:        "different namespace",
+			dcNamespace: "ns2",
+			k8sContext:  "",
+			expectOwner: false,
+		},
+		{
+			name:        "remote cluster",
+			dcNamespace: "ns1",
+			k8sContext:  "remote",
+			expectOwner: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			dc := &cassdcapi.CassandraDatacenter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dc1",
+					Namespace: tt.dcNamespace,
+				},
+			}
+			dcConfig := &cassandra.DatacenterConfig{K8sContext: tt.k8sContext}
+
+			require.NoError(t, r.setDatacenterOwnership(kc, dc, dcConfig))
+
+			if tt.expectOwner {
+				require.Len(t, dc.OwnerReferences, 1)
+				owner := dc.OwnerReferences[0]
+				assert.Equal(kc.Name, owner.Name)
+				assert.Equal("K8ssandraCluster", owner.Kind)
+				// Non-controller owner reference: visibility only, no controller semantics.
+				assert.Nil(owner.Controller)
+			} else {
+				assert.Empty(dc.OwnerReferences)
+			}
+		})
+	}
 }
 
 func dcUpgradePriorityTest(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

When the operator creates a `CassandraDatacenter`, it now sets the owning `K8ssandraCluster` as an owner reference on the DC — but **only when the DC is co-located**: same namespace *and* same Kubernetes cluster as the `K8ssandraCluster`.

This lets GitOps tools such as ArgoCD render the `CassandraDatacenter` as a child of the `K8ssandraCluster` in their resource tree, instead of treating it as an orphaned, prunable resource (the out-of-sync / "trash-bin" behavior reported in the issue).

As discussed in #952, owner references cannot cross namespace or cluster boundaries — a cross-namespace owner reference is [treated as absent by the garbage collector](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications) and would make the dependent eligible for deletion. Since the operator supports cluster-scoped and multi-cluster deployments where the DC may live in a different namespace/cluster than its `K8ssandraCluster`, the reference is set only when both of these hold:
- **Same cluster** — the DC is created with the local client (`dcConfig.K8sContext == ""`).
- **Same namespace** — `dc.Namespace == kc.Namespace`.

For everything else, behavior is unchanged: cleanup keeps relying on the existing label- and finalizer-based mechanism.

**Implementation notes**:
- A non-controller owner reference (`controllerutil.SetOwnerReference`) is used rather than `SetControllerReference`. Both kinds of owner reference trigger GC cascade when the owner is deleted, so the choice is not about avoiding cascade; ArgoCD builds its tree from owner references regardless of the `controller` flag. The operator already owns the DC lifecycle (including graceful decommission) via the `K8ssandraClusterFinalizer`, so the non-controller reference avoids the extra `BlockOwnerDeletion` semantics and the single-controller constraint, which aren't needed here for a stateful resource.
- The owner reference is added before the DC's resource-hash annotation is computed, so existing co-located clusters pick it up automatically on the next reconcile (a metadata-only update — no pod restarts).

**Which issue(s) this PR fixes**:
Fixes #952

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
