### PR TITLE
Bound the informer cache with lean-cache scoping

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -15,5 +15,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ## unreleased
 
+* [ENHANCEMENT] [#1752](https://github.com/k8ssandra/k8ssandra-operator/issues/1752) Bound the informer cache (pkg/leancache): read Secrets/ConfigMaps/Pods/Services/Endpoints/EndpointSlices/Deployments/StatefulSets/CronJobs/ServiceMonitors/MedusaBackups through live API calls, project the corresponding watches to metadata only, and strip managedFields/last-applied from cached objects. Operator memory no longer scales with cluster size, and the operator no longer holds every cluster Secret in process memory.
 * [CHANGE] Update cass-operator to v1.31.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4

--- a/controllers/config/clientconfig_controller.go
+++ b/controllers/config/clientconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	configapi "github.com/k8ssandra/k8ssandra-operator/apis/config/v1beta1"
 	k8ssandraapi "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/leancache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/utils"
 )
 
@@ -105,7 +106,9 @@ func (r *ClientConfigReconciler) SetupWithManager(mgr ctrl.Manager, cancelFunc c
 
 	cb := ctrl.NewControllerManagedBy(mgr).
 		For(&configapi.ClientConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toMatchingClientConfig))
+		// OnlyMetadata: the map fn only needs name/namespace; kubeconfig secret
+		// contents are read through the non-cached client anyway.
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toMatchingClientConfig), builder.OnlyMetadata)
 
 	return cb.Complete(r)
 }
@@ -201,6 +204,10 @@ func (r *ClientConfigReconciler) initAdditionalClusterConfig(ctx context.Context
 	var c cluster.Cluster
 	c, err = cluster.New(cfg, func(o *cluster.Options) {
 		o.Scheme = r.Scheme
+		// Mirror the local manager's lean-cache settings (see main.go and
+		// pkg/leancache) so a remote cluster's cache is bounded the same way.
+		o.Cache.DefaultTransform = leancache.StripHeavyMetadata()
+		o.Client.Cache = &client.CacheOptions{DisableFor: leancache.DisableFor()}
 		if len(namespaces) > 0 {
 			nsConfig := make(map[string]cache.Config)
 			for _, i := range namespaces {

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -247,10 +247,12 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
 	cb = cb.Watches(&reaperapi.Reaper{},
 		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
+	// OnlyMetadata: both filters match on labels/name only; ConfigMap/EndpointSlice
+	// contents are read live (see leancache.DisableFor).
 	cb = cb.Watches(&corev1.ConfigMap{},
-		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
+		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter), builder.OnlyMetadata)
 	cb = cb.Watches(&discoveryv1.EndpointSlice{},
-		handler.EnqueueRequestsFromMapFunc(endpointsFilter))
+		handler.EnqueueRequestsFromMapFunc(endpointsFilter), builder.OnlyMetadata)
 
 	for _, c := range clusters {
 		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), &cassdcapi.CassandraDatacenter{},
@@ -265,12 +267,18 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj *reaperapi.Reaper) []reconcile.Request {
 				return clusterLabelFilter(ctx, obj)
 			})))
-		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), &corev1.ConfigMap{},
-			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj *corev1.ConfigMap) []reconcile.Request {
+		// Metadata-only projections of the remote ConfigMap/EndpointSlice watches,
+		// mirroring the OnlyMetadata local watches above.
+		configMapMeta := &metav1.PartialObjectMetadata{}
+		configMapMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), configMapMeta,
+			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj *metav1.PartialObjectMetadata) []reconcile.Request {
 				return clusterLabelFilter(ctx, obj)
 			})))
-		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), &discoveryv1.EndpointSlice{},
-			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj *discoveryv1.EndpointSlice) []reconcile.Request {
+		endpointSliceMeta := &metav1.PartialObjectMetadata{}
+		endpointSliceMeta.SetGroupVersionKind(discoveryv1.SchemeGroupVersion.WithKind("EndpointSlice"))
+		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), endpointSliceMeta,
+			handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj *metav1.PartialObjectMetadata) []reconcile.Request {
 				return clusterLabelFilter(ctx, obj)
 			})))
 	}

--- a/controllers/reaper/reaper_controller.go
+++ b/controllers/reaper/reaper_controller.go
@@ -482,7 +482,9 @@ func (r *ReaperReconciler) getSecret(ctx context.Context, secretKey types.Namesp
 func (r *ReaperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&reaperapi.Reaper{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
+		// OnlyMetadata: owner-ref mapping needs only metadata; Deployment/Service
+		// contents are read live (see leancache.DisableFor).
+		Owns(&appsv1.Deployment{}, builder.OnlyMetadata).
+		Owns(&corev1.Service{}, builder.OnlyMetadata).
 		Complete(r)
 }

--- a/controllers/replication/secret_controller.go
+++ b/controllers/replication/secret_controller.go
@@ -407,17 +407,22 @@ func (s *SecretSyncController) SetupWithManager(mgr ctrl.Manager, clusters []clu
 		return requests
 	}
 
-	toMatchingReplicatesTyped := func(ctx context.Context, secret *corev1.Secret) []reconcile.Request {
+	toMatchingReplicatesTyped := func(ctx context.Context, secret *metav1.PartialObjectMetadata) []reconcile.Request {
 		return toMatchingReplicates(ctx, secret)
 	}
 
+	// Secret watches are metadata-only projections: the map fns above match on labels
+	// only, and secret contents are read live (see leancache.DisableFor), so no cache
+	// ever holds full Secret objects.
 	cb := ctrl.NewControllerManagedBy(mgr).
 		For(&api.ReplicatedSecret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toMatchingReplicates))
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(toMatchingReplicates), builder.OnlyMetadata)
 
 	for _, c := range clusters {
+		secretMeta := &metav1.PartialObjectMetadata{}
+		secretMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
 		cb = cb.WatchesRawSource(
-			source.Kind(c.GetCache(), &corev1.Secret{},
+			source.Kind(c.GetCache(), secretMeta,
 				handler.TypedEnqueueRequestsFromMapFunc(toMatchingReplicatesTyped)))
 	}
 

--- a/controllers/stargate/stargate_controller.go
+++ b/controllers/stargate/stargate_controller.go
@@ -479,7 +479,9 @@ func reconcileStargateConfigFile(
 func (r *StargateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.Stargate{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Service{}).
+		// OnlyMetadata: owner-ref mapping needs only metadata; Deployment/Service
+		// contents are read live (see leancache.DisableFor).
+		Owns(&appsv1.Deployment{}, builder.OnlyMetadata).
+		Owns(&corev1.Service{}, builder.OnlyMetadata).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/clientcache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/config"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/leancache"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/reaper"
 
@@ -143,8 +144,18 @@ func main() {
 		},
 	}
 
+	// Bound the operator's memory regardless of cluster size (see pkg/leancache):
+	// high-cardinality core-type reads go live to the API server (DisableFor) and the
+	// corresponding watches are metadata-only projections. Remote clusters get the
+	// same options in ClientConfigReconciler.InitClientConfigs.
 	options.Cache = cache.Options{
 		DefaultNamespaces: map[string]cache.Config{},
+		DefaultTransform:  leancache.StripHeavyMetadata(),
+	}
+	options.Client = client.Options{
+		Cache: &client.CacheOptions{
+			DisableFor: leancache.DisableFor(),
+		},
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)

--- a/pkg/leancache/leancache.go
+++ b/pkg/leancache/leancache.go
@@ -1,0 +1,76 @@
+// Package leancache centralizes the cache-scoping configuration that keeps the
+// operator's memory bounded regardless of cluster size. It is applied to the local
+// manager (main.go) and to every remote cluster.Cluster (clientconfig controller), so
+// both caches follow the same rules.
+//
+// The model:
+//   - High-cardinality / foreign types (see DisableFor) are never read through the
+//     cache: reads go live to the API server. All such reads in this operator are
+//     namespace+label scoped and happen only inside low-frequency reconciles.
+//   - Watches on those types use metadata-only projection (builder.OnlyMetadata /
+//     PartialObjectMetadata sources), so their informers hold object metadata, not
+//     payloads. Every relevant handler map fn only inspects metadata.
+package leancache
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	promapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	medusav1alpha1 "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
+)
+
+// DisableFor lists every type the operator reads but must not cache. Secrets and
+// ConfigMaps cannot be label-scoped instead: ReplicatedSecret matches secrets by
+// arbitrary user-supplied selectors, ClientConfig reads user kubeconfig secrets and
+// Stargate reads the user CassandraConfigMapRef — none of them carry operator labels.
+// The remaining entries are cold read paths whose informers would otherwise be
+// created lazily and cluster-wide (Pods via findSeeds/medusa/management facade,
+// CronJobs via medusa purge, ServiceMonitors via telemetry, MedusaBackup which has no
+// watch, and the objects behind the metadata-only Owns/Watches).
+func DisableFor() []client.Object {
+	return []client.Object{
+		&corev1.Secret{},
+		&corev1.ConfigMap{},
+		&corev1.Pod{},
+		&corev1.Service{},
+		&corev1.Endpoints{},
+		&discoveryv1.EndpointSlice{},
+		&appsv1.Deployment{},
+		&appsv1.StatefulSet{},
+		&batchv1.CronJob{},
+		&promapi.ServiceMonitor{},
+		&medusav1alpha1.MedusaBackup{},
+	}
+}
+
+// StripHeavyMetadata extends cache.TransformStripManagedFields by also dropping the
+// kubectl last-applied-configuration annotation from every cached object: for a
+// kubectl-applied object that annotation embeds the full object (including Secret
+// data), so it dominates cached-object size — and even survives metadata-only
+// projection, since annotations are part of PartialObjectMetadata. Nothing in the
+// operator reads it.
+func StripHeavyMetadata() toolscache.TransformFunc {
+	stripManagedFields := cache.TransformStripManagedFields()
+	return func(obj interface{}) (interface{}, error) {
+		obj, err := stripManagedFields(obj)
+		if err != nil {
+			return obj, err
+		}
+		if m, ok := obj.(metav1.Object); ok {
+			annotations := m.GetAnnotations()
+			if _, found := annotations[corev1.LastAppliedConfigAnnotation]; found {
+				delete(annotations, corev1.LastAppliedConfigAnnotation)
+				m.SetAnnotations(annotations)
+			}
+		}
+		return obj, nil
+	}
+}


### PR DESCRIPTION
**What this PR does**:
Bounds the operator's informer cache so memory no longer scales with cluster size, via a small `pkg/leancache` package applied to the local manager and mirrored to every remote `cluster.Cluster` (details and production numbers in #1752):

- `client.CacheOptions.DisableFor` for Secret, ConfigMap, Pod, Service, Endpoints, EndpointSlice, Deployment, StatefulSet, CronJob, ServiceMonitor and MedusaBackup: all reads of these types go live. Every such read is namespace+label-scoped inside low-frequency reconciles. This also removes the informers that cached reads used to create lazily (Pods via findSeeds/medusa/management facade; CronJobs via medusa purge; ServiceMonitors via telemetry; MedusaBackup which no controller watches), and means the operator no longer holds every cluster Secret in process memory.
- Secrets/ConfigMaps deliberately have **no label selector**: ReplicatedSecret matches arbitrary user-supplied selectors, ClientConfig reads user kubeconfig secrets, Stargate reads the user `CassandraConfigMapRef` — a selector would silently break replication/config injection. Metadata-only watches keep the event triggers intact.
- `builder.OnlyMetadata` on the Secret (replication + clientconfig), ConfigMap and EndpointSlice watches and on reaper/stargate `Owns(Deployment/Service)`; remote raw sources use `PartialObjectMetadata` projections. All map fns already inspect only metadata — no handler logic changes.
- A cache transform strips managedFields and the kubectl last-applied-configuration annotation (which embeds the full object incl. Secret data and survives metadata projection).

Production results (cluster-scoped): OOMKilled at startup with 512Mi → **103-112Mi** on clusters from 5.7k to 17.5k pods (pod count ×3 → +9Mi). Cross-cluster secret replication verified by the multi-cluster envtest suite and several days of production operation.

**Which issue(s) this PR fixes**:
Fixes #1752

**Checklist**
- [x] Changes manually tested — production on five clusters, cluster-scoped
- [x] Automated Tests added/updated — full controllers+pkg suite green incl. the 2-data-plane replication envtest
- [ ] Documentation added/updated
- [x] CHANGELOG updated
- [x] CLA Signed
