### PR TITLE
Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -17,3 +17,5 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [CHANGE] Update cass-operator to v1.31.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
+* [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update
+

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -27,6 +27,7 @@ import (
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	cassimages "github.com/k8ssandra/cass-operator/pkg/images"
 	api "github.com/k8ssandra/k8ssandra-operator/apis/k8ssandra/v1alpha1"
+	medusaapi "github.com/k8ssandra/k8ssandra-operator/apis/medusa/v1alpha1"
 	reaperapi "github.com/k8ssandra/k8ssandra-operator/apis/reaper/v1alpha1"
 	stargateapi "github.com/k8ssandra/k8ssandra-operator/apis/stargate/v1alpha1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
@@ -50,6 +51,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+// indexK8ssandraClusterByMedusaConfigRef registers a field index on K8ssandraCluster so that
+// the controller can efficiently query which clusters reference a given MedusaConfiguration.
+func indexK8ssandraClusterByMedusaConfigRef(mgr ctrl.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&api.K8ssandraCluster{},
+		MedusaConfigurationRefIndex,
+		func(obj client.Object) []string {
+			kc := obj.(*api.K8ssandraCluster)
+			if kc.Spec.Medusa == nil || kc.Spec.Medusa.MedusaConfigurationRef.Name == "" {
+				return nil
+			}
+			return []string{kc.Spec.Medusa.MedusaConfigurationRef.Name}
+		},
+	)
+}
 
 // K8ssandraClusterReconciler reconciles a K8ssandraCluster object
 type K8ssandraClusterReconciler struct {
@@ -213,6 +231,10 @@ func updateStatus(ctx context.Context, r client.Client, kc *api.K8ssandraCluster
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters []cluster.Cluster) error {
+	if err := indexK8ssandraClusterByMedusaConfigRef(mgr); err != nil {
+		return err
+	}
+
 	cb := ctrl.NewControllerManagedBy(mgr).
 		For(&api.K8ssandraCluster{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})))
 
@@ -241,6 +263,25 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 		return requests
 	}
 
+	// When a MedusaConfiguration changes, find all K8ssandraCluster objects that reference it by name via the field index and enqueue them for reconciliation.
+	medusaConfigFilter := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		kcList := &api.K8ssandraClusterList{}
+		if err := r.List(ctx, kcList,
+			client.InNamespace(obj.GetNamespace()),
+			client.MatchingFields{MedusaConfigurationRefIndex: obj.GetName()},
+		); err != nil {
+			return nil
+		}
+		requests := make([]reconcile.Request, len(kcList.Items))
+		for i, kc := range kcList.Items {
+			requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: kc.Namespace,
+				Name:      kc.Name,
+			}}
+		}
+		return requests
+	}
+
 	cb = cb.Watches(&cassdcapi.CassandraDatacenter{},
 		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
 	cb = cb.Watches(&stargateapi.Stargate{},
@@ -251,6 +292,8 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 		handler.EnqueueRequestsFromMapFunc(clusterLabelFilter))
 	cb = cb.Watches(&discoveryv1.EndpointSlice{},
 		handler.EnqueueRequestsFromMapFunc(endpointsFilter))
+	cb = cb.Watches(&medusaapi.MedusaConfiguration{},
+		handler.EnqueueRequestsFromMapFunc(medusaConfigFilter))
 
 	for _, c := range clusters {
 		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), &cassdcapi.CassandraDatacenter{},

--- a/controllers/k8ssandra/k8ssandracluster_controller.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller.go
@@ -54,9 +54,9 @@ import (
 
 // indexK8ssandraClusterByMedusaConfigRef registers a field index on K8ssandraCluster so that
 // the controller can efficiently query which clusters reference a given MedusaConfiguration.
-func indexK8ssandraClusterByMedusaConfigRef(mgr ctrl.Manager) error {
+func indexK8ssandraClusterByMedusaConfigRef(ctx context.Context, mgr ctrl.Manager) error {
 	return mgr.GetFieldIndexer().IndexField(
-		context.Background(),
+		ctx,
 		&api.K8ssandraCluster{},
 		MedusaConfigurationRefIndex,
 		func(obj client.Object) []string {
@@ -230,8 +230,8 @@ func updateStatus(ctx context.Context, r client.Client, kc *api.K8ssandraCluster
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters []cluster.Cluster) error {
-	if err := indexK8ssandraClusterByMedusaConfigRef(mgr); err != nil {
+func (r *K8ssandraClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, clusters []cluster.Cluster) error {
+	if err := indexK8ssandraClusterByMedusaConfigRef(ctx, mgr); err != nil {
 		return err
 	}
 
@@ -293,7 +293,7 @@ func (r *K8ssandraClusterReconciler) SetupWithManager(mgr ctrl.Manager, clusters
 	cb = cb.Watches(&discoveryv1.EndpointSlice{},
 		handler.EnqueueRequestsFromMapFunc(endpointsFilter))
 	cb = cb.Watches(&medusaapi.MedusaConfiguration{},
-		handler.EnqueueRequestsFromMapFunc(medusaConfigFilter))
+		handler.EnqueueRequestsFromMapFunc(medusaConfigFilter), builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
 	for _, c := range clusters {
 		cb = cb.WatchesRawSource(source.Kind(c.GetCache(), &cassdcapi.CassandraDatacenter{},

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -115,6 +115,7 @@ func TestK8ssandraCluster(t *testing.T) {
 	t.Run("CreateSingleDcClusterAuth", testEnv.ControllerTest(ctx, createSingleDcClusterAuth))
 	t.Run("CreateSingleDcClusterAuthExternalSecrets", testEnv.ControllerTest(ctx, createSingleDcClusterAuthExternalSecrets))
 	t.Run("CreateSingleDcClusterExternalInternode", testEnv.ControllerTest(ctx, createSingleDcClusterExternalInternode))
+	t.Run("MedusaConfigurationChangeTriggersReconcile", testEnv.ControllerTest(ctx, medusaConfigurationChangeTriggersReconcile))
 
 	// If webhooks are installed, this testcase is handled by the webhook test
 	t.Run("ApplyClusterWithEncryptionOptions", testEnv.ControllerTest(ctx, applyClusterWithEncryptionOptions))

--- a/controllers/k8ssandra/k8ssandracluster_controller_test.go
+++ b/controllers/k8ssandra/k8ssandracluster_controller_test.go
@@ -86,7 +86,7 @@ func TestK8ssandraCluster(t *testing.T) {
 			ManagementApi:    managementApiFactory,
 			Recorder:         mgr.GetEventRecorder("k8ssandracluster-controller"),
 			ImageRegistry:    getTestImageRegistry(),
-		}).SetupWithManager(mgr, clusters)
+		}).SetupWithManager(ctx, mgr, clusters)
 		return err
 	}, nil)
 	if err != nil {

--- a/controllers/k8ssandra/medusa_reconciler.go
+++ b/controllers/k8ssandra/medusa_reconciler.go
@@ -26,6 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// MedusaConfigurationRefIndex is the field index name used to look up K8ssandraCluster
+// objects by their spec.medusa.medusaConfigurationRef.name field.
+const MedusaConfigurationRefIndex = ".spec.medusa.medusaConfigurationRef.name"
+
 const (
 	operatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )

--- a/controllers/k8ssandra/medusa_reconciler_test.go
+++ b/controllers/k8ssandra/medusa_reconciler_test.go
@@ -743,3 +743,70 @@ func checkNoPurgeSchedule(ctx context.Context, namespace string, kc *api.K8ssand
 		return errors.IsNotFound(err)
 	}, timeout, interval, "Purge schedule should not exist")
 }
+
+// medusaConfigurationChangeTriggersReconcile verifies that a spec change to a MedusaConfiguration
+// object causes the K8ssandraCluster that references it to reconcile. This exercises the
+// field-index-based Watch registered in SetupWithManager.
+func medusaConfigurationChangeTriggersReconcile(t *testing.T, ctx context.Context, f *framework.Framework, namespace string) {
+	require := require.New(t)
+	fmt.Printf("namespace: %v \n", namespace)
+	t.Log("Creating Medusa bucket secret")
+	medusaSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      medusaBucketSecretName,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			"credentials": "some-credentials",
+		},
+	}
+	err := f.Create(ctx, controlPlaneContextKey(medusaSecret, f.ControlPlaneContext), medusaSecret)
+	require.NoError(err, "failed to create Medusa bucket secret")
+
+	t.Log("Creating initial MedusaConfiguration")
+	medusaConfig := MedusaConfig(medusaConfigName, namespace)
+	medusaConfig.Spec.StorageProperties.StorageSecretRef = corev1.LocalObjectReference{Name: medusaBucketSecretName}
+	medusaConfigKey := controlPlaneContextKey(medusaConfig, f.ControlPlaneContext)
+	err = f.Create(ctx, medusaConfigKey, medusaConfig)
+	require.NoError(err, "failed to create MedusaConfiguration")
+	require.Eventually(f.MedusaConfigExists(ctx, f.ControlPlaneContext, medusaConfigKey), timeout, interval)
+
+	kc := &api.K8ssandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      k8ssandraClusterName,
+		},
+		Spec: api.K8ssandraClusterSpec{
+			Cassandra: &api.CassandraClusterTemplate{
+				DatacenterOptions: api.DatacenterOptions{
+					ServerVersion: "3.11.14",
+				},
+				Datacenters: []api.CassandraDatacenterTemplate{
+					dcTemplate("dc1", f.DataPlaneContexts[0]),
+				},
+			},
+			Medusa: medusaTemplateWithConfigRefWithPrefix(medusaConfigName, prefixFromClusterSpec),
+		},
+	}
+
+	t.Log("Creating K8ssandraCluster referencing the MedusaConfiguration")
+	err = f.Client.Create(ctx, kc)
+	require.NoError(err, "failed to create K8ssandraCluster")
+	verifyReplicatedSecretReconciled(ctx, t, f, kc)
+
+	t.Log("Verifying configmap reflects the initial MedusaConfiguration values")
+	verifyConfigMap(require, ctx, f, namespace, prefixFromClusterSpec, concurrentTransfersFromMedusaConfig, keyFilePresent)
+
+	t.Log("Patching MedusaConfiguration with a new concurrentTransfers value")
+	updatedTransfers := concurrentTransfersFromMedusaConfig + 5
+	current := &medusaapi.MedusaConfiguration{}
+	err = f.Get(ctx, medusaConfigKey, current)
+	require.NoError(err, "failed to fetch MedusaConfiguration before patch")
+	patch := client.MergeFrom(current.DeepCopy())
+	current.Spec.StorageProperties.ConcurrentTransfers = updatedTransfers
+	err = f.Patch(ctx, current, patch, medusaConfigKey)
+	require.NoError(err, "failed to patch MedusaConfiguration")
+
+	t.Log("Verifying configmap is updated after MedusaConfiguration spec change")
+	verifyConfigMap(require, ctx, f, namespace, prefixFromClusterSpec, updatedTransfers, keyFilePresent)
+}

--- a/controllers/medusa/controllers_test.go
+++ b/controllers/medusa/controllers_test.go
@@ -80,7 +80,7 @@ func setupMedusaBackupTestEnv(t *testing.T, ctx context.Context) *testutils.Mult
 			ManagementApi:    managementApi,
 			Recorder:         controlPlaneMgr.GetEventRecorder("cassandrabackup-controller"),
 			ImageRegistry:    getTestImageRegistry(),
-		}).SetupWithManager(controlPlaneMgr, clusters)
+		}).SetupWithManager(ctx, controlPlaneMgr, clusters)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func main() {
 			ManagementApi:    cassandra.NewManagementApiFactory(),
 			Recorder:         mgr.GetEventRecorder("k8ssandracluster-controller"),
 			ImageRegistry:    registry,
-		}).SetupWithManager(mgr, additionalClusters); err != nil {
+		}).SetupWithManager(ctx, mgr, additionalClusters); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "K8ssandraCluster")
 			os.Exit(1)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Add watcher for medusaconfiguration in k8ssandracontroller , so that any change to referenced medusaconfiguration will trigger k8ssandracluster reconcile and it will update medua configurations configmap. Indexed k8ssandracluster againt medusaConfigurationReference for efficient filtering in watcher.

**Which issue(s) this PR fixes**:
Fixes #1415 

**Checklist**
- [x] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
