### PR TITLE
Allow setting Medusa's chunk size

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -17,6 +17,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 * [CHANGE] Update cass-operator to v1.31.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
+* [ENHANCEMENT] [#1760](https://github.com/k8ssandra/k8ssandra-operator/issues/1760) Allow setting Medusa's chunk size
 * [BUGFIX] Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update
-

--- a/apis/medusa/v1alpha1/medusa_types.go
+++ b/apis/medusa/v1alpha1/medusa_types.go
@@ -86,6 +86,11 @@ type Storage struct {
 	// +optional
 	MultiPartUploadThreshold int `json:"multiPartUploadThreshold,omitempty"`
 
+	// Chunk size in bytes for multipart uploads.
+	// Defaults to 0 (medusa uses its own default).
+	// +optional
+	MultiPartChunkSize int `json:"multiPartChunkSize,omitempty"`
+
 	// Host to connect to for the storage backend.
 	// +optional
 	Host string `json:"host,omitempty"`

--- a/apis/medusa/v1alpha1/medusa_types.go
+++ b/apis/medusa/v1alpha1/medusa_types.go
@@ -87,7 +87,7 @@ type Storage struct {
 	MultiPartUploadThreshold int `json:"multiPartUploadThreshold,omitempty"`
 
 	// Chunk size in bytes for multipart uploads.
-	// Defaults to 0 (medusa uses its own default).
+	// Leaving this empty uses medusa's default value
 	// +optional
 	MultiPartChunkSize int `json:"multiPartChunkSize,omitempty"`
 

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -29272,7 +29272,7 @@ spec:
                       multiPartChunkSize:
                         description: |-
                           Chunk size in bytes for multipart uploads.
-                          Defaults to 0 (medusa uses its own default).
+                          Leaving this empty uses medusa's default value
                         type: integer
                       multiPartUploadThreshold:
                         default: 104857600
@@ -35516,7 +35516,7 @@ spec:
                   multiPartChunkSize:
                     description: |-
                       Chunk size in bytes for multipart uploads.
-                      Defaults to 0 (medusa uses its own default).
+                      Leaving this empty uses medusa's default value
                     type: integer
                   multiPartUploadThreshold:
                     default: 104857600

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -29269,6 +29269,11 @@ spec:
                           Maximum number of backups to keep (used by the purge process).
                           Default is unlimited.
                         type: integer
+                      multiPartChunkSize:
+                        description: |-
+                          Chunk size in bytes for multipart uploads.
+                          Defaults to 0 (medusa uses its own default).
+                        type: integer
                       multiPartUploadThreshold:
                         default: 104857600
                         description: |-
@@ -35507,6 +35512,11 @@ spec:
                     description: |-
                       Maximum number of backups to keep (used by the purge process).
                       Default is unlimited.
+                    type: integer
+                  multiPartChunkSize:
+                    description: |-
+                      Chunk size in bytes for multipart uploads.
+                      Defaults to 0 (medusa uses its own default).
                     type: integer
                   multiPartUploadThreshold:
                     default: 104857600

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -29204,6 +29204,11 @@ spec:
                           Maximum number of backups to keep (used by the purge process).
                           Default is unlimited.
                         type: integer
+                      multiPartChunkSize:
+                        description: |-
+                          Chunk size in bytes for multipart uploads.
+                          Defaults to 0 (medusa uses its own default).
+                        type: integer
                       multiPartUploadThreshold:
                         default: 104857600
                         description: |-

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -29207,7 +29207,7 @@ spec:
                       multiPartChunkSize:
                         description: |-
                           Chunk size in bytes for multipart uploads.
-                          Defaults to 0 (medusa uses its own default).
+                          Leaving this empty uses medusa's default value
                         type: integer
                       multiPartUploadThreshold:
                         default: 104857600

--- a/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
@@ -88,7 +88,7 @@ spec:
                   multiPartChunkSize:
                     description: |-
                       Chunk size in bytes for multipart uploads.
-                      Defaults to 0 (medusa uses its own default).
+                      Leaving this empty uses medusa's default value
                     type: integer
                   multiPartUploadThreshold:
                     default: 104857600

--- a/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
+++ b/config/crd/bases/medusa.k8ssandra.io_medusaconfigurations.yaml
@@ -85,6 +85,11 @@ spec:
                       Maximum number of backups to keep (used by the purge process).
                       Default is unlimited.
                     type: integer
+                  multiPartChunkSize:
+                    description: |-
+                      Chunk size in bytes for multipart uploads.
+                      Defaults to 0 (medusa uses its own default).
+                    type: integer
                   multiPartUploadThreshold:
                     default: 104857600
                     description: |-

--- a/pkg/medusa/reconcile.go
+++ b/pkg/medusa/reconcile.go
@@ -111,6 +111,9 @@ func CreateMedusaIni(kc *k8ss.K8ssandraCluster, dcConfig *cassandra.DatacenterCo
     {{- if .Spec.Medusa.StorageProperties.MultiPartUploadThreshold }}
     multi_part_upload_threshold = {{ .Spec.Medusa.StorageProperties.MultiPartUploadThreshold }}
     {{- end }}
+    {{- if .Spec.Medusa.StorageProperties.MultiPartChunkSize }}
+    multipart_chunksize = {{ .Spec.Medusa.StorageProperties.MultiPartChunkSize }}
+    {{- end }}
 
     [grpc]
     enabled = 1

--- a/pkg/medusa/reconcile_test.go
+++ b/pkg/medusa/reconcile_test.go
@@ -66,6 +66,7 @@ func testMedusaIniFull(t *testing.T) {
 					TransferMaxBandwidth:     "100MB/s",
 					ConcurrentTransfers:      2,
 					MultiPartUploadThreshold: 204857600,
+					MultiPartChunkSize:       10485760,
 					Host:                     "192.168.0.1",
 					Region:                   "us-east-1",
 					Port:                     9001,
@@ -98,6 +99,7 @@ func testMedusaIniFull(t *testing.T) {
 	assert.Contains(t, medusaIni, "transfer_max_bandwidth = 100MB/s")
 	assert.Contains(t, medusaIni, "concurrent_transfers = 2")
 	assert.Contains(t, medusaIni, "multi_part_upload_threshold = 204857600")
+	assert.Contains(t, medusaIni, "multipart_chunksize = 10485760")
 	assert.Contains(t, medusaIni, "host = 192.168.0.1")
 	assert.Contains(t, medusaIni, "region = us-east-1")
 	assert.Contains(t, medusaIni, "port = 9001")
@@ -216,6 +218,7 @@ func testMedusaIniZeroConcurrentTransfers(t *testing.T) {
 					TransferMaxBandwidth:     "100MB/s",
 					ConcurrentTransfers:      0,
 					MultiPartUploadThreshold: 204857600,
+					MultiPartChunkSize:       10485760,
 					Host:                     "192.168.0.1",
 					Region:                   "us-east-1",
 					Port:                     9001,
@@ -241,6 +244,7 @@ func testMedusaIniZeroConcurrentTransfers(t *testing.T) {
 	assert.Contains(t, medusaIni, "transfer_max_bandwidth = 100MB/s")
 	assert.Contains(t, medusaIni, "concurrent_transfers = 1")
 	assert.Contains(t, medusaIni, "multi_part_upload_threshold = 204857600")
+	assert.Contains(t, medusaIni, "multipart_chunksize = 10485760")
 	assert.Contains(t, medusaIni, "host = 192.168.0.1")
 	assert.Contains(t, medusaIni, "region = us-east-1")
 	assert.Contains(t, medusaIni, "port = 9001")
@@ -291,6 +295,7 @@ func testMedusaIniSecured(t *testing.T) {
 					TransferMaxBandwidth:     "100MB/s",
 					ConcurrentTransfers:      2,
 					MultiPartUploadThreshold: 204857600,
+					MultiPartChunkSize:       10485760,
 					Host:                     "192.168.0.1",
 					Region:                   "us-east-1",
 					Port:                     9001,
@@ -318,6 +323,7 @@ func testMedusaIniSecured(t *testing.T) {
 	assert.Contains(medusaIni, "transfer_max_bandwidth = 100MB/s")
 	assert.Contains(medusaIni, "concurrent_transfers = 2")
 	assert.Contains(medusaIni, "multi_part_upload_threshold = 204857600")
+	assert.Contains(medusaIni, "multipart_chunksize = 10485760")
 	assert.Contains(medusaIni, "host = 192.168.0.1")
 	assert.Contains(medusaIni, "region = us-east-1")
 	assert.Contains(medusaIni, "port = 9001")
@@ -435,6 +441,7 @@ func testMedusaIniUnsecured(t *testing.T) {
 					TransferMaxBandwidth:     "100MB/s",
 					ConcurrentTransfers:      2,
 					MultiPartUploadThreshold: 204857600,
+					MultiPartChunkSize:       10485760,
 					Host:                     "192.168.0.1",
 					Region:                   "us-east-1",
 					Port:                     9001,
@@ -460,6 +467,7 @@ func testMedusaIniUnsecured(t *testing.T) {
 	assert.Contains(t, medusaIni, "transfer_max_bandwidth = 100MB/s")
 	assert.Contains(t, medusaIni, "concurrent_transfers = 2")
 	assert.Contains(t, medusaIni, "multi_part_upload_threshold = 204857600")
+	assert.Contains(t, medusaIni, "multipart_chunksize = 10485760")
 	assert.Contains(t, medusaIni, "host = 192.168.0.1")
 	assert.Contains(t, medusaIni, "region = us-east-1")
 	assert.Contains(t, medusaIni, "port = 9001")
@@ -519,6 +527,7 @@ func testMedusaIniMissingOptionalSettings(t *testing.T) {
 	assert.NotContains(t, medusaIni, "transfer_max_bandwidth =")
 	assert.Contains(t, medusaIni, "concurrent_transfers = 1")
 	assert.NotContains(t, medusaIni, "multi_part_upload_threshold =")
+	assert.NotContains(t, medusaIni, "multipart_chunksize =")
 	assert.NotContains(t, medusaIni, "host =")
 	assert.NotContains(t, medusaIni, "region =")
 	assert.NotContains(t, medusaIni, "port =")

--- a/test/testdata/fixtures/single-dc-dse-medusa/k8ssandra.yaml
+++ b/test/testdata/fixtures/single-dc-dse-medusa/k8ssandra.yaml
@@ -12,7 +12,8 @@ spec:
         name: medusa-bucket-key
       host: minio-service.minio.svc.cluster.local
       port: 9000
-      secure: false 
+      secure: false
+      multiPartChunkSize: 1048576 # 10 MB
   cassandra:
     clusterName: "First Cluster"
     serverVersion: 6.8.43


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: Allows setting Medusa's chunk size via the `storage` CRD.

**Which issue(s) this PR fixes**:
Fixes #1760

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
