### PR TITLE
contact-point service creation did not use namespace filtering

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -21,3 +21,4 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [ENHANCEMENT] [#1760](https://github.com/k8ssandra/k8ssandra-operator/issues/1760) Allow setting Medusa's chunk size
 * [BUGFIX] Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update
+* [BUGFIX] [#1771](https://github.com/k8ssandra/k8ssandra-operator/issues/1771) ContactPoints services was created by polling the potential pods using dc name only, without namespace filtering

--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -19,6 +19,6 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
 * [CHANGE] Bump cassandra-medusa to v0.30.0
 * [ENHANCEMENT] [#1760](https://github.com/k8ssandra/k8ssandra-operator/issues/1760) Allow setting Medusa's chunk size
-* [BUGFIX] Medusa Configurations aren't replicated to remote contexts
+* [BUGFIX] [#1773](https://github.com/k8ssandra/k8ssandra-operator/issues/1773) Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update
 * [BUGFIX] [#1771](https://github.com/k8ssandra/k8ssandra-operator/issues/1771) ContactPoints services was created by polling the potential pods using dc name only, without namespace filtering

--- a/controllers/k8ssandra/contact_points_service.go
+++ b/controllers/k8ssandra/contact_points_service.go
@@ -71,7 +71,7 @@ func (r *K8ssandraClusterReconciler) loadAllPodsEndpoints(
 	endpoints := &discoveryv1.EndpointSliceList{}
 	searchLabels := dc.GetDatacenterLabels()
 	searchLabels["kubernetes.io/service-name"] = dc.GetAllPodsServiceName()
-	if err := remoteClient.List(ctx, endpoints, client.MatchingLabels(searchLabels)); err != nil {
+	if err := remoteClient.List(ctx, endpoints, client.InNamespace(dc.Namespace), client.MatchingLabels(searchLabels)); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/controllers/k8ssandra/contact_points_service_test.go
+++ b/controllers/k8ssandra/contact_points_service_test.go
@@ -1,0 +1,50 @@
+package k8ssandra
+
+import (
+	"testing"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLoadAllPodsEndpointsIsNamespaceScoped(t *testing.T) {
+	dc := &cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "target",
+		},
+		Spec: cassdcapi.CassandraDatacenterSpec{ClusterName: "cluster1"},
+	}
+
+	endpointSlice := func(namespace, address string) *discoveryv1.EndpointSlice {
+		labels := dc.GetDatacenterLabels()
+		labels[discoveryv1.LabelServiceName] = dc.GetAllPodsServiceName()
+		return &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dc.GetAllPodsServiceName(),
+				Namespace: namespace,
+				Labels:    labels,
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints:   []discoveryv1.Endpoint{{Addresses: []string{address}}},
+		}
+	}
+
+	remoteClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(
+			endpointSlice(dc.Namespace, "10.0.1.1"),
+			endpointSlice("other", "10.0.2.1"),
+		).
+		Build()
+
+	reconciler := &K8ssandraClusterReconciler{}
+	endpoints, err := reconciler.loadAllPodsEndpoints(t.Context(), dc, remoteClient)
+	require.NoError(t, err)
+	require.Len(t, endpoints, 1)
+	require.Equal(t, "10.0.1.1", endpoints[0].Endpoints[0].Addresses[0])
+}

--- a/pkg/cassandra/management.go
+++ b/pkg/cassandra/management.go
@@ -136,32 +136,22 @@ func (r *defaultManagementApiFacade) CreateKeyspaceIfNotExists(
 func (r *defaultManagementApiFacade) fetchDatacenterPods() ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	labels := client.MatchingLabels(r.dc.GetDatacenterLabels())
-	if err := r.k8sClient.List(r.ctx, podList, labels); err != nil {
+	if err := r.k8sClient.List(r.ctx, podList, client.InNamespace(r.dc.Namespace), labels); err != nil {
 		return nil, err
 	} else {
-		pods := r.filterPods(podList.Items, func(pod corev1.Pod) bool {
+		pods := make([]corev1.Pod, 0)
+		for _, pod := range podList.Items {
 			status := r.getCassandraContainerStatus(pod)
-			return status != nil && status.Ready
-		})
+			if status != nil && status.Ready {
+				pods = append(pods, pod)
+			}
+		}
 		if len(pods) == 0 {
 			err = fmt.Errorf("no pods in READY state found in datacenter %v", r.dc.Name)
 			return nil, err
 		}
 		return pods, nil
 	}
-}
-
-func (r *defaultManagementApiFacade) filterPods(pods []corev1.Pod, filter func(corev1.Pod) bool) []corev1.Pod {
-	if len(pods) == 0 {
-		return pods
-	}
-	filtered := make([]corev1.Pod, 0)
-	for _, pod := range pods {
-		if filter(pod) {
-			filtered = append(pods, pod)
-		}
-	}
-	return filtered
 }
 
 func (r *defaultManagementApiFacade) createReplicationConfig(replication map[string]int) []map[string]string {

--- a/pkg/cassandra/management_test.go
+++ b/pkg/cassandra/management_test.go
@@ -1,0 +1,81 @@
+package cassandra
+
+import (
+	"context"
+	"testing"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFetchDatacenterPodsIsNamespaceScoped(t *testing.T) {
+	dc := newManagementApiTestDatacenter()
+	remoteClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(
+			newManagementApiTestPod(dc, dc.Namespace, "target-pod", true),
+			newManagementApiTestPod(dc, "other", "other-pod", true),
+		).
+		Build()
+
+	facade := &defaultManagementApiFacade{
+		ctx:       context.Background(),
+		dc:        dc,
+		k8sClient: remoteClient,
+	}
+	pods, err := facade.fetchDatacenterPods()
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	require.Equal(t, "target-pod", pods[0].Name)
+}
+
+func TestFetchDatacenterPodsReturnsOnlyReadyPods(t *testing.T) {
+	dc := newManagementApiTestDatacenter()
+	remoteClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(
+			newManagementApiTestPod(dc, dc.Namespace, "ready-pod", true),
+			newManagementApiTestPod(dc, dc.Namespace, "unready-pod", false),
+		).
+		Build()
+
+	facade := &defaultManagementApiFacade{
+		ctx:       context.Background(),
+		dc:        dc,
+		k8sClient: remoteClient,
+	}
+	pods, err := facade.fetchDatacenterPods()
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	require.Equal(t, "ready-pod", pods[0].Name)
+}
+
+func newManagementApiTestDatacenter() *cassdcapi.CassandraDatacenter {
+	return &cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "target",
+		},
+		Spec: cassdcapi.CassandraDatacenterSpec{ClusterName: "mydb"},
+	}
+}
+
+func newManagementApiTestPod(dc *cassdcapi.CassandraDatacenter, namespace, name string, ready bool) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    dc.GetDatacenterLabels(),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "cassandra",
+				Ready: ready,
+			}},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Two remoteClient.List instances did not use namespace filtering, causing issues if a similar cluster was created with similar datacenter name in another namespace.

**Which issue(s) this PR fixes**:
Fixes #1771

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
