### PR TITLE
Use strconv.Itoa for the Medusa gRPC port (review follow-up to #1680)

### DIFF
--- a/controllers/medusa/common.go
+++ b/controllers/medusa/common.go
@@ -3,6 +3,7 @@ package medusa
 import (
 	"context"
 	"fmt"
+	"net"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
@@ -24,7 +25,7 @@ func newClient(ctx context.Context, c client.Client, cassdc *cassdcapi.Cassandra
 		grpcPort = explicitPort
 	}
 
-	address := fmt.Sprintf("%s:%d", pod.Status.PodIP, grpcPort)
+	address := net.JoinHostPort(pod.Status.PodIP, fmt.Sprint(grpcPort))
 
 	if clientSecretName != "" {
 		secretKey := types.NamespacedName{

--- a/controllers/medusa/common.go
+++ b/controllers/medusa/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
 	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
 	"github.com/k8ssandra/k8ssandra-operator/pkg/cassandra"
@@ -25,7 +26,7 @@ func newClient(ctx context.Context, c client.Client, cassdc *cassdcapi.Cassandra
 		grpcPort = explicitPort
 	}
 
-	address := net.JoinHostPort(pod.Status.PodIP, fmt.Sprint(grpcPort))
+	address := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(grpcPort))
 
 	if clientSecretName != "" {
 		secretKey := types.NamespacedName{

--- a/controllers/medusa/common_test.go
+++ b/controllers/medusa/common_test.go
@@ -1,0 +1,80 @@
+package medusa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cassdcapi "github.com/k8ssandra/cass-operator/apis/cassandra/v1beta1"
+	"github.com/k8ssandra/k8ssandra-operator/pkg/medusa"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// recordingClientFactory captures the address passed to NewClient for verification.
+type recordingClientFactory struct {
+	lastAddress string
+}
+
+func (f *recordingClientFactory) NewClient(address string) (medusa.Client, error) {
+	f.lastAddress = address
+	return nil, nil
+}
+
+func (f *recordingClientFactory) NewClientWithTLS(address string, secret *corev1.Secret) (medusa.Client, error) {
+	f.lastAddress = address
+	return nil, nil
+}
+
+func TestNewClientAddressFormatting(t *testing.T) {
+	tests := []struct {
+		name            string
+		podIP           string
+		expectedAddress string
+	}{
+		{
+			name:            "IPv4 address",
+			podIP:           "192.0.2.10", // RFC 5737 documentation range
+			expectedAddress: "192.0.2.10:50051",
+		},
+		{
+			name:            "IPv6 address",
+			podIP:           "2001:db8:ae4:ee06:1310::3", // RFC 3849 documentation range
+			expectedAddress: "[2001:db8:ae4:ee06:1310::3]:50051",
+		},
+		{
+			name:            "IPv6 loopback",
+			podIP:           "::1",
+			expectedAddress: "[::1]:50051",
+		},
+	}
+
+	cassdc := &cassdcapi.CassandraDatacenter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "test-ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &recordingClientFactory{}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-ns",
+				},
+				Status: corev1.PodStatus{
+					PodIP: tt.podIP,
+				},
+			}
+
+			_, _ = newClient(context.Background(), nil, cassdc, pod, factory)
+
+			require.NotEmpty(t, factory.lastAddress)
+			assert.Equal(t, tt.expectedAddress, factory.lastAddress)
+		})
+	}
+}


### PR DESCRIPTION
Continues #1680 by @rajish with @burmanm's review comment applied.

#1680 is open and mergeable but has been waiting on one review nit since January. This branch carries @rajish's three original commits unchanged (authorship preserved) plus a single commit addressing the review, so the fix can land as a whole. Happy to close this immediately if @rajish would rather push the change to their own branch — no wish to duplicate their work.

## The review comment

> Shouldn't this be `net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(grpcPort))` ? fmt looks like unnecessary round-trip.

Applied in `controllers/medusa/common.go`:

```diff
 import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
-	address := net.JoinHostPort(pod.Status.PodIP, fmt.Sprint(grpcPort))
+	address := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(grpcPort))
```

`strconv.Itoa` converts an `int` directly, where `fmt.Sprint` boxes the value into an `interface{}` and dispatches through the reflection-based formatter. Same output, less work, and it states the intent explicitly.

Notes on correctness:

- `grpcPort` is an `int` — `medusa.DefaultMedusaPort` is an untyped integer constant and `cassandra.FindContainerPort` returns `(int, bool)` — so `strconv.Itoa` applies with no cast.
- The `fmt` import stays; it is still used by `fmt.Errorf` in the same function.
- No behaviour change. For an `int`, `strconv.Itoa` and `fmt.Sprint` produce identical strings, so the three cases in `TestNewClientAddressFormatting` (`192.0.2.10`, `2001:db8:ae4:ee06:1310::3`, `::1`) are unaffected.

## Why this matters beyond the nit

The underlying bug in #1680 is real and reproducible. On an IPv6-primary cluster the operator builds `<ipv6>:<port>` instead of `[<ipv6>]:<port>`, and every Medusa gRPC call fails:

```
invalid target address 2a01:...:33:50051,
  error info: address 2a01:...:33:50051:443: too many colons in address
```

Confirmed on IPv6-primary Kubernetes with k8ssandra-operator v1.32.5 / Medusa 0.25.1. Medusa 0.22.3 was unaffected, which matches #1680's analysis that the regression came in when the gRPC client creation was refactored into the shared `newClient()`.

## Out of scope here, but related

There is a **second, separate** unbracketed-IPv6 URL construction that this PR does not touch, in the vendored `cass-operator` HTTP management-API client (`pkg/httphelper/client.go`):

```go
url := fmt.Sprintf("%s://%s:%d%s", client.Protocol, request.host, port, request.endpoint)
```

`request.host` comes from `BuildPodHostFromPod()`, which returns `pod.Status.PodIP` verbatim, so on IPv6 it produces:

```
parse "http://2a01:...:bf:8080/api/v0/ops/keyspace?keyspaceName=system_traces":
  invalid port ":598:7e0:16f::bf:8080" after host
```

That one aborts `updateReplicationOfSystemKeyspaces` inside `checkSchemas`, which returns early from `reconcileDatacenters` — before `afterCassandraReconciled`, where `reconcileReaper` runs. Net effect on an otherwise healthy cluster: no `Reaper` resource is ever created, and the `K8ssandraCluster` permanently reports `CALL list keyspaces system_traces failed on all datacenter dc1 pods`.

That line is identical in cass-operator v1.22.4, v1.30.3 and current `master`, so it has never had the #871 treatment. It needs the same `net.JoinHostPort` fix in the cass-operator repo — mentioning it here only so the two are not confused, since fixing this PR alone will not restore Reaper on IPv6.
