### PR TITLE
Add support for terminationGracePeriodSeconds (fixes #1781)

### DIFF
--- a/CHANGELOG/CHANGELOG-1.33.md
+++ b/CHANGELOG/CHANGELOG-1.33.md
@@ -18,6 +18,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 * [CHANGE] Update cass-operator to v1.32.0
 * [CHANGE] Bump k8ssandra-client to v0.8.13, medusa to v0.29.0 and reaper to v4.2.4
 * [CHANGE] Bump cassandra-medusa to v0.30.1
+* [FEATURE] [#1781](https://github.com/k8ssandra/k8ssandra-operator/issues/1781) Allow setting terminationGracePeriodSeconds on the Cassandra pods
 * [ENHANCEMENT] [#1760](https://github.com/k8ssandra/k8ssandra-operator/issues/1760) Allow setting Medusa's chunk size
 * [BUGFIX] [#1773](https://github.com/k8ssandra/k8ssandra-operator/issues/1773) Medusa Configurations aren't replicated to remote contexts
 * [BUGFIX] [#1415](https://github.com/k8ssandra/k8ssandra-operator/issues/1415) Trigger k8ssandrcluster reconcile on referenced MedusaConfiguration update

--- a/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
+++ b/apis/k8ssandra/v1alpha1/k8ssandracluster_types.go
@@ -447,6 +447,13 @@ type DatacenterOptions struct {
 	// +optional
 	PodPriorityClassName string `json:"podPriorityClassName,omitempty"`
 
+	// TerminationGracePeriodSeconds defines how long the Cassandra pods have to shut down gracefully, in seconds.
+	// The pre-stop hook drains the Cassandra node within this period, so a value that is too low results in the node
+	// being killed mid-drain. When unset, cass-operator applies its own default of 120 seconds.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
 	// ManagementApiAuth defines the authentication settings for the management API in the Cassandra pods.
 	// +optional
 	ManagementApiAuth *cassdcapi.ManagementApiAuthConfig `json:"managementApiAuth,omitempty"`

--- a/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/k8ssandra/v1alpha1/zz_generated.deepcopy.go
@@ -284,6 +284,11 @@ func (in *DatacenterOptions) DeepCopyInto(out *DatacenterOptions) {
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.ManagementApiAuth != nil {
 		in, out := &in.ManagementApiAuth, &out.ManagementApiAuth
 		*out = new(v1beta1.ManagementApiAuthConfig)

--- a/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
+++ b/charts/k8ssandra-operator/crds/k8ssandra-operator-crds.yaml
@@ -18363,6 +18363,14 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            TerminationGracePeriodSeconds defines how long the Cassandra pods have to shut down gracefully, in seconds.
+                            The pre-stop hook drains the Cassandra node within this period, so a value that is too low results in the node
+                            being killed mid-drain. When unset, cass-operator applies its own default of 120 seconds.
+                          format: int64
+                          minimum: 0
+                          type: integer
                         tolerations:
                           description: Tolerations applied to every Cassandra pod.
                           items:
@@ -28299,6 +28307,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      TerminationGracePeriodSeconds defines how long the Cassandra pods have to shut down gracefully, in seconds.
+                      The pre-stop hook drains the Cassandra node within this period, so a value that is too low results in the node
+                      being killed mid-drain. When unset, cass-operator applies its own default of 120 seconds.
+                    format: int64
+                    minimum: 0
+                    type: integer
                   tolerations:
                     description: Tolerations applied to every Cassandra pod.
                     items:

--- a/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
+++ b/config/crd/bases/k8ssandra.io_k8ssandraclusters.yaml
@@ -18298,6 +18298,14 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            TerminationGracePeriodSeconds defines how long the Cassandra pods have to shut down gracefully, in seconds.
+                            The pre-stop hook drains the Cassandra node within this period, so a value that is too low results in the node
+                            being killed mid-drain. When unset, cass-operator applies its own default of 120 seconds.
+                          format: int64
+                          minimum: 0
+                          type: integer
                         tolerations:
                           description: Tolerations applied to every Cassandra pod.
                           items:
@@ -28234,6 +28242,14 @@ spec:
                             type: string
                         type: object
                     type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      TerminationGracePeriodSeconds defines how long the Cassandra pods have to shut down gracefully, in seconds.
+                      The pre-stop hook drains the Cassandra node within this period, so a value that is too low results in the node
+                      being killed mid-drain. When unset, cass-operator applies its own default of 120 seconds.
+                    format: int64
+                    minimum: 0
+                    type: integer
                   tolerations:
                     description: Tolerations applied to every Cassandra pod.
                     items:

--- a/pkg/cassandra/datacenter.go
+++ b/pkg/cassandra/datacenter.go
@@ -379,6 +379,7 @@ func Coalesce(clusterName string, clusterTemplate *api.CassandraClusterTemplate,
 	dcConfig.ManagementApiAuth = mergedOptions.ManagementApiAuth
 	dcConfig.PodTemplateSpec.Spec.SecurityContext = mergedOptions.PodSecurityContext
 	dcConfig.PodTemplateSpec.Spec.PriorityClassName = mergedOptions.PodPriorityClassName
+	dcConfig.PodTemplateSpec.Spec.TerminationGracePeriodSeconds = mergedOptions.TerminationGracePeriodSeconds
 	dcConfig.PerNodeInitContainerImage = mergedOptions.PerNodeConfigInitContainerImage
 	dcConfig.ServiceAccount = mergedOptions.ServiceAccount
 	dcConfig.ReadOnlyRootFilesystem = mergedOptions.ReadOnlyRootFilesystem

--- a/pkg/cassandra/datacenter_test.go
+++ b/pkg/cassandra/datacenter_test.go
@@ -1326,6 +1326,46 @@ func TestCoalesce(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Set termination grace period at cluster level",
+			clusterTemplate: &api.CassandraClusterTemplate{
+				DatacenterOptions: api.DatacenterOptions{
+					TerminationGracePeriodSeconds: ptr.To(int64(300)),
+				},
+			},
+			dcTemplate: &api.CassandraDatacenterTemplate{},
+			want: &DatacenterConfig{
+				McacEnabled: false,
+				PodTemplateSpec: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers:                    []corev1.Container{{Name: "cassandra"}},
+						TerminationGracePeriodSeconds: ptr.To(int64(300)),
+					},
+				},
+			},
+		},
+		{
+			name: "Override termination grace period",
+			clusterTemplate: &api.CassandraClusterTemplate{
+				DatacenterOptions: api.DatacenterOptions{
+					TerminationGracePeriodSeconds: ptr.To(int64(300)),
+				},
+			},
+			dcTemplate: &api.CassandraDatacenterTemplate{
+				DatacenterOptions: api.DatacenterOptions{
+					TerminationGracePeriodSeconds: ptr.To(int64(600)),
+				},
+			},
+			want: &DatacenterConfig{
+				McacEnabled: false,
+				PodTemplateSpec: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers:                    []corev1.Container{{Name: "cassandra"}},
+						TerminationGracePeriodSeconds: ptr.To(int64(600)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1431,6 +1471,17 @@ func TestNewDatacenter_PodPriorityClassName(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "mock-priority", dc.Spec.PodTemplateSpec.Spec.PriorityClassName)
+}
+
+func TestNewDatacenter_TerminationGracePeriodSeconds(t *testing.T) {
+	template := GetDatacenterConfig()
+	template.PodTemplateSpec.Spec.TerminationGracePeriodSeconds = ptr.To(int64(300))
+	dc, err := NewDatacenter(
+		types.NamespacedName{Name: "testdc", Namespace: "test-namespace"},
+		&template,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, ptr.To(int64(300)), dc.Spec.PodTemplateSpec.Spec.TerminationGracePeriodSeconds)
 }
 
 // TestValidateCoalesced_Fail_NoStorageConfig tests that NewDatacenter fails when no storage config is provided.


### PR DESCRIPTION
**What this PR does**:

Adds an optional `terminationGracePeriodSeconds` to `DatacenterOptions`, so the grace period of the Cassandra pods can be set from a `K8ssandraCluster` instead of only by patching the generated `CassandraDatacenter`. cass-operator already honours `podTemplateSpec.spec.terminationGracePeriodSeconds` and only falls back to its own 120s default when the field is nil, so this passes the value through alongside the existing pod-level `podSecurityContext` and `podPriorityClassName` options. It is a pointer so an explicit `0` (kill immediately) stays distinguishable from unset, and `minimum: 0` keeps negative values out of the pod spec.

- `apis/k8ssandra/v1alpha1/k8ssandracluster_types.go` — the new optional field, settable per datacenter or as a cluster-level default (merged by `MergeCRs`, like its neighbours)
- `pkg/cassandra/datacenter.go` — one assignment onto the generated pod template spec
- CRDs and deepcopy regenerated with `make generate manifests` (controller-gen v0.21.0)
- Tests: two `TestCoalesce` cases (cluster level, datacenter override) plus `TestNewDatacenter_TerminationGracePeriodSeconds`

Verified locally with `make lint` and the full unit/integration suite (`go test ./apis/... ./pkg/... ./test/yq/... ./controllers/...`, envtest 1.34.0).

**Which issue(s) this PR fixes**:
Fixes #1781

**Checklist**
- [ ] Changes manually tested
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
