### PR TITLE
feat(chart): add affinity and topologySpreadConstraints support to the k8ssandra-operator chart

### DIFF
--- a/CHANGELOG/CHANGELOG-1.34.md
+++ b/CHANGELOG/CHANGELOG-1.34.md
@@ -14,3 +14,5 @@ Changelog for the K8ssandra Operator, new PRs should update the `unreleased` sec
 When cutting a new release, update the `unreleased` heading to the tag being generated and date, like `## vX.Y.Z - YYYY-MM-DD` and create a new placeholder section for  `unreleased` entries.
 
 ## unreleased
+
+* [ENHANCEMENT] Add `affinity` and `topologySpreadConstraints` support to the k8ssandra-operator chart, allowing the operator pods to be spread across nodes when `replicaCount` is greater than 1

--- a/charts/k8ssandra-operator/templates/deployment.yaml
+++ b/charts/k8ssandra-operator/templates/deployment.yaml
@@ -106,6 +106,12 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:

--- a/charts/k8ssandra-operator/values.yaml
+++ b/charts/k8ssandra-operator/values.yaml
@@ -85,6 +85,16 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 ##
 tolerations: []
+# -- Affinity rules for operator pod assignment. Useful with replicaCount > 1 to
+# keep the operator pods on separate nodes.
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+# -- Topology spread constraints for operator pod assignment. Useful with
+# replicaCount > 1 to spread the operator pods across nodes or zones.
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+##
+topologySpreadConstraints: []
 # -- This client configuration is used for the CRD upgrader job only. Otherwise, modify
 # the global.imageConfig values to change k8ssandra-client
 client:


### PR DESCRIPTION
**What this PR does**:

Adds `affinity` and `topologySpreadConstraints` values to the
`k8ssandra-operator` chart, rendered into the operator Deployment's pod spec.

The chart already exposes `nodeSelector` and `tolerations`, and already supports
`replicaCount > 1` (the operator uses leader election, so a standby replica is a
supported setup). But neither `nodeSelector` nor `tolerations` can express "keep
these replicas on different nodes", so nothing stops the scheduler from putting
every operator pod on the same node.

That is what happens in practice for us. We run `replicaCount: 2` in all four of
our environments, and in both production clusters both operator pods are
currently on the same node, so the second replica buys nothing against node
loss. It also means a single node drain can take out both replicas of the
chart's fail-closed webhooks at once, blocking K8ssandraCluster admission until
a pod is rescheduled elsewhere.

Both new values default to empty (`{}` / `[]`) and are wrapped in the same
`{{- if }}` conditional style as the existing `nodeSelector` and `tolerations`,
so existing installations render byte-identical output.

Example use:

```yaml
replicaCount: 2
affinity:
  podAntiAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 100
        podAffinityTerm:
          labelSelector:
            matchLabels:
              app.kubernetes.io/name: k8ssandra-operator
          topologyKey: kubernetes.io/hostname
```

Note this concerns the **operator Deployment's own** scheduling. It is unrelated
to #74 and #445, which are about replacing affinity rules with topology spread
constraints for Cassandra **rack** topology inside the CassandraDatacenter spec.

**Which issue(s) this PR fixes**:
Fixes #1790

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CHANGELOG.md updated (not required for documentation PRs)
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)

Notes on the unchecked boxes and on testing:

- **Manual testing**: verified with `helm template` that (a) with default values
  neither `affinity` nor `topologySpreadConstraints` appears in the rendered
  Deployment, (b) with both set they render correctly into the pod spec, and
  (c) the full chart still renders as valid YAML (31 manifests parsed). Rendered
  against chart deps `cass-operator` 0.67.1 and `k8ssandra-common` 0.29.2.
- **Automated tests**: left unchecked as I could not find an existing test layer
  that covers chart values plumbing — the e2e suites exercise the operator
  itself rather than rendered chart output. Happy to add coverage if you can
  point me at the right place.
- **Documentation**: the new values carry `# --` helm-docs annotations matching
  the surrounding entries. I deliberately did **not** regenerate
  `charts/k8ssandra-operator/README.md`: its values table is currently stale
  (it is missing `nodeSelector`, `tolerations`, `client.*` and
  `disableCrdUpgraderJob`, and its `image.tag` row says `v1.0.0` while
  `values.yaml` says `latest`), so a regeneration would produce a large diff
  unrelated to this change. Please tell me if you would rather I regenerate it
  here, or add just the two new rows by hand.
- **CLA**: not yet signed at the time of opening; I will get this done.

**Disclosure**: this change was written with AI assistance (Claude), reflected
in the commit's `Co-Authored-By` trailer. I have reviewed it and can speak to
the reasoning behind it.
